### PR TITLE
Fixing renewal of sessions

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -13,27 +13,14 @@ namespace Snowflake.Data.Core
 {
     class HttpUtil
     {
-        static private HttpClient httpClient;
-
-        static public HttpClient getHttpClient()
-        {
-            if (httpClient == null)
-            {
-                initHttpClient();
-            }
-            return httpClient;
-        }
-
-        static private void initHttpClient()
+        static public HttpClient initHttpClient(TimeSpan timeout)
         {
             // enforce tls v1.2
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             ServicePointManager.UseNagleAlgorithm = false;
             ServicePointManager.CheckCertificateRevocationList = true;
 
-            httpClient = new HttpClient(new RetryHandler(new HttpClientHandler()));
-            // default timeout for each request is 16 seconds
-            //httpClient.Timeout = TimeSpan.FromSeconds(16);
+            return new HttpClient(new RetryHandler(new HttpClientHandler())) { Timeout  = timeout };
         }
 
         class RetryHandler : DelegatingHandler
@@ -50,19 +37,21 @@ namespace Snowflake.Data.Core
                 HttpResponseMessage response = null;
                 int backOffInSec = 1;
 
-                int httpTimeout = (int)requestMessage.Properties["TIMEOUT_PER_HTTP_REQUEST"];
+                TimeSpan httpTimeout = (TimeSpan)requestMessage.Properties["TIMEOUT_PER_HTTP_REQUEST"];
 
                 CancellationTokenSource childCts = null;
-                if (httpTimeout != -1)
-                {
-                    childCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    childCts.CancelAfter(httpTimeout);
-                }
 
                 while (true)
                 {
                     try
-                    {   
+                    {
+                        childCts = null;
+
+                        if (!httpTimeout.Equals(Timeout.InfiniteTimeSpan)) {
+                            childCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            childCts.CancelAfter(httpTimeout);
+                        }
+
                         response = await base.SendAsync(requestMessage, childCts == null ? 
                             cancellationToken : childCts.Token);
                     }
@@ -83,14 +72,19 @@ namespace Snowflake.Data.Core
                         }
                     }
 
-                    if (response.IsSuccessStatusCode)
+                    if (response != null)
                     {
-                        logger.Info("Retried request succeed.");
-                        logger.TraceFormat("Success Response {0}", response.ToString());
-                        return response;
+                        if (response.IsSuccessStatusCode) {
+                            logger.TraceFormat("Success Response {0}", response.ToString());
+                            return response;
+                        }
+                        logger.TraceFormat("Failed Response: {0}", response.ToString());
+                    }
+                    else 
+                    {
+                        logger.Info("Response returned was null.");
                     }
 
-                    logger.TraceFormat("Failed Response: {0}", response.ToString());
                     logger.DebugFormat("Sleep {0} seconds and then retry the request", backOffInSec);
                     Thread.Sleep(backOffInSec * 1000);
                     backOffInSec = backOffInSec >= 16 ? 16 : backOffInSec * 2;

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
+using System.Threading;
 
 namespace Snowflake.Data.Core
 {
@@ -26,10 +27,10 @@ namespace Snowflake.Data.Core
         internal string qrmk { get; set; }
 
         // request timeout in millis
-        internal int timeout { get; set; }
+        internal TimeSpan timeout { get; set; }
 
         // timeout for each http request 
-        internal int httpRequestTimeout { get; set; }
+        internal TimeSpan httpRequestTimeout { get; set; }
 
         internal Dictionary<string, string> chunkHeaders { get; set; }
     }
@@ -38,10 +39,10 @@ namespace Snowflake.Data.Core
     {
         public SFRestRequest()
         {
-            sfRestRequestTimeout = -1;
+            sfRestRequestTimeout = Timeout.InfiniteTimeSpan;
 
             // default each http request timeout to 16 seconds
-            httpRequestTimeout = 16000;
+            httpRequestTimeout = TimeSpan.FromSeconds(16); 
         }
 
         internal Uri uri { get; set; }
@@ -51,10 +52,10 @@ namespace Snowflake.Data.Core
         internal String authorizationToken { get; set; }
         
         // timeout for the whole rest request in millis (adding up all http retry)
-        internal int sfRestRequestTimeout { get; set; }
+        internal TimeSpan sfRestRequestTimeout { get; set; }
         
         // timeout for each http request 
-        internal int httpRequestTimeout { get; set; } 
+        internal TimeSpan httpRequestTimeout { get; set; } 
 
         public override string ToString()
         {

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -44,8 +44,6 @@ namespace Snowflake.Data.Core
         {
             var json = JsonConvert.SerializeObject(postRequest.jsonBody);
             HttpContent httpContent = new StringContent(json);
-            CancellationTokenSource cancellationTokenSource = 
-                new CancellationTokenSource(postRequest.sfRestRequestTimeout);
 
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, postRequest.uri);
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = postRequest.httpRequestTimeout;
@@ -55,7 +53,7 @@ namespace Snowflake.Data.Core
             message.Headers.Add(SF_AUTHORIZATION_HEADER, postRequest.authorizationToken);
             message.Headers.Accept.Add(applicationSnowflake);
 
-            var responseContent = sendRequest(message, cancellationTokenSource.Token).Content;
+            var responseContent = sendRequest(message, postRequest.sfRestRequestTimeout).Content;
 
             var jsonString = responseContent.ReadAsStringAsync();
             jsonString.Wait();
@@ -82,9 +80,9 @@ namespace Snowflake.Data.Core
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = getRequest.httpRequestTimeout;
 
             CancellationTokenSource cancellationTokenSource = 
-                new CancellationTokenSource(getRequest.timeout);
+                new CancellationTokenSource();
 
-            return sendRequest(message, cancellationTokenSource.Token);
+            return sendRequest(message, getRequest.timeout);
         }
 
         public JObject get(SFRestRequest getRequest)
@@ -94,10 +92,7 @@ namespace Snowflake.Data.Core
             message.Headers.Accept.Add(applicationSnowflake);
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = getRequest.httpRequestTimeout;
 
-            CancellationTokenSource cancellationTokenSource = 
-                new CancellationTokenSource(getRequest.sfRestRequestTimeout);
-
-            var responseContent = sendRequest(message, cancellationTokenSource.Token).Content;
+            var responseContent = sendRequest(message, getRequest.sfRestRequestTimeout).Content;
 
             var jsonString = responseContent.ReadAsStringAsync();
             jsonString.Wait();
@@ -105,25 +100,18 @@ namespace Snowflake.Data.Core
             return JObject.Parse(jsonString.Result);
         }
 
-        private HttpResponseMessage sendRequest(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
+        private HttpResponseMessage sendRequest(HttpRequestMessage requestMessage, TimeSpan timeout)
         {
             try
             {
-                var response = HttpUtil.getHttpClient().SendAsync(requestMessage, cancellationToken)
+                var response = HttpUtil.initHttpClient(timeout).SendAsync(requestMessage)
                     .Result.EnsureSuccessStatusCode();
 
                 return response;
             }
-            catch(AggregateException e)
+            catch (Exception e)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    throw new SnowflakeDbException(SFError.REQUEST_TIMEOUT);
-                }
-                else
-                {
-                    throw e;
-                }
+                throw e;
             }
         }
     }

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -79,9 +79,6 @@ namespace Snowflake.Data.Core
             }
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = getRequest.httpRequestTimeout;
 
-            CancellationTokenSource cancellationTokenSource = 
-                new CancellationTokenSource();
-
             return sendRequest(message, getRequest.timeout);
         }
 

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -32,6 +32,11 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "data")]
         internal AuthnResponseData data { get; set; }
     }
+    
+    internal class RenewSessionResponse : BaseRestResponse {
+		[JsonProperty(PropertyName = "data")]
+		internal RenewSessionResponseData data { get; set; }
+	}
 
     internal class AuthnResponseData
     {
@@ -77,6 +82,25 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "ssoUrl", NullValueHandling = NullValueHandling.Ignore)]
         internal string ssoUrl { get; set; }
     }
+
+
+	internal class RenewSessionResponseData {
+
+		[JsonProperty(PropertyName = "sessionToken", NullValueHandling = NullValueHandling.Ignore)]
+		internal string sessionToken { get; set; }
+
+		[JsonProperty(PropertyName = "validityInSecondsST", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int16 masterTokenValidityInSeconds { get; set; }
+
+		[JsonProperty(PropertyName = "masterToken", NullValueHandling = NullValueHandling.Ignore)]
+		internal string masterToken { get; set; }
+
+		[JsonProperty(PropertyName = "validityInSecondsMT", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int16 validityInSeconds { get; set; }
+
+		[JsonProperty(PropertyName = "sessionId", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int64 sessionId { get; set; }
+	}
 
     internal class SessionInfo
     {

--- a/Snowflake.Data/Core/SFChunkDownloader.cs
+++ b/Snowflake.Data/Core/SFChunkDownloader.cs
@@ -122,8 +122,8 @@ namespace Snowflake.Data.Core
                 uri = new UriBuilder(chunk.url).Uri,
                 qrmk = downloadContext.qrmk,
                 // s3 download request timeout to one hour
-                timeout = 60 * 60,
-                httpRequestTimeout = 16000,
+                timeout = TimeSpan.FromHours(1),
+                httpRequestTimeout = TimeSpan.FromSeconds(16),
                 chunkHeaders = downloadContext.chunkHeaders
             };
 

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -26,6 +26,8 @@ namespace Snowflake.Data.Core
         static internal Object convertToCSharpVal(string srcVal, SFDataType srcType, Type destType)
         {
             logger.TraceFormat("src value: {0}, srcType: {1}, destType: {2}", srcVal, srcType, destType);
+            if (srcVal == null) return srcVal;
+            
             if (destType == typeof(Int16) 
                 || destType == typeof(Int32)
                 || destType == typeof(Int64)

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -155,7 +155,7 @@ namespace Snowflake.Data.Core
             NullDataResponse deleteSessionResponse = response.ToObject<NullDataResponse>();
             if (!deleteSessionResponse.success)
             {
-                logger.WarnFormat("Failed to delete session, error ignored. Code: {0} Message: {0}", 
+                logger.WarnFormat("Failed to delete session, error ignored. Code: {0} Message: {1}", 
                     deleteSessionResponse.code, deleteSessionResponse.message);
             }
         }
@@ -185,14 +185,18 @@ namespace Snowflake.Data.Core
             renewSessionRequest.sfRestRequestTimeout = -1;
 
             JObject response = restRequest.post(renewSessionRequest);
-            NullDataResponse sessionRenewResponse = response.ToObject<NullDataResponse>();
+			RenewSessionResponse sessionRenewResponse = response.ToObject<RenewSessionResponse>();
             if (!sessionRenewResponse.success)
             {
                 SnowflakeDbException e = new SnowflakeDbException("", 
                     sessionRenewResponse.code, sessionRenewResponse.message, "");
                 logger.Error("Renew session failed", e);
                 throw e;
-            }
+            } 
+            else 
+            {
+				sessionToken = sessionRenewResponse.data.sessionToken;
+			}
         }
 
         private void parseLoginResponse(JObject response)

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Snowflake.Data.Client;
 using Common.Logging;
+using System.Threading;
 
 namespace Snowflake.Data.Core
 {
@@ -72,7 +73,7 @@ namespace Snowflake.Data.Core
             queryRequest.uri = uriBuilder.Uri;
             queryRequest.authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sfSession.sessionToken);
             queryRequest.jsonBody = postBody;
-            queryRequest.httpRequestTimeout = -1;
+            queryRequest.httpRequestTimeout = Timeout.InfiniteTimeSpan;
 
             try
             {
@@ -82,7 +83,7 @@ namespace Snowflake.Data.Core
                 if (execResponse.code == SF_SESSION_EXPIRED_CODE)
                 {
                     sfSession.renewSession();
-		    this.requestId = null;
+                    this.requestId = null;
                     return this.execute(sql, bindings, describeOnly);
                 }
                 else if (execResponse.code == SF_QUERY_IN_PROGRESS ||
@@ -110,7 +111,7 @@ namespace Snowflake.Data.Core
                             uri = getResultUriBuilder.Uri,
                             authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sfSession.sessionToken)
                         };
-                        getResultRequest.httpRequestTimeout = -1;
+                        getResultRequest.httpRequestTimeout = Timeout.InfiniteTimeSpan;
 
                         execResponse = null;
                         execResponse = restRequest.get(getResultRequest).ToObject<QueryExecResponse>();

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -82,8 +82,8 @@ namespace Snowflake.Data.Core
                 if (execResponse.code == SF_SESSION_EXPIRED_CODE)
                 {
                     sfSession.renewSession();
-					this.requestId = null;
-                    this.execute(sql, bindings, describeOnly);
+		    this.requestId = null;
+                    return this.execute(sql, bindings, describeOnly);
                 }
                 else if (execResponse.code == SF_QUERY_IN_PROGRESS ||
                          execResponse.code == SF_QUERY_IN_PROGRESS_ASYNC)

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -82,6 +82,7 @@ namespace Snowflake.Data.Core
                 if (execResponse.code == SF_SESSION_EXPIRED_CODE)
                 {
                     sfSession.renewSession();
+					this.requestId = null;
                     this.execute(sql, bindings, describeOnly);
                 }
                 else if (execResponse.code == SF_QUERY_IN_PROGRESS ||


### PR DESCRIPTION
Currently, sessions can not be renewed as the response for these is not handled correctly. The response is currently cast to a NullDataResponse, which fails and throws an exception due to the data field being an object not a string. I created a new response class and applied it to the response. I also made the session object reflect the change in token generated by snowflake.

There is also a minor change to fix logging index error.

Fixes issue #16 