### PR TITLE
Fix async support

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -7,6 +7,8 @@ using Snowflake.Data.Core;
 using System.Data.Common;
 using System.Data;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Snowflake.Data.Client
@@ -117,22 +119,44 @@ namespace Snowflake.Data.Client
 
         public override void Cancel()
         {
-            sfStatement.cancel();
+            sfStatement.Cancel();
         }
-
+        
         public override int ExecuteNonQuery()
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, 
-                convertToBindList(parameterCollection.parameterList), false);
-            resultSet.next();
-            return ResultSetUtil.calculateUpdateCount(resultSet);
+            SFBaseResultSet resultSet = ExecuteInternal();
+            resultSet.Next();
+            return resultSet.CalculateUpdateCount();
+        }
+
+        public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            //TODO: Respect these cancellation tokens.
+
+            var resultSet = await ExecuteInternalAsync();
+            await resultSet.NextAsync();
+            return resultSet.CalculateUpdateCount();
         }
 
         public override object ExecuteScalar()
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, null, false);
-            resultSet.next();
+            SFBaseResultSet resultSet = ExecuteInternal();
+            resultSet.Next();
             return resultSet.getValue(0);
+        }
+
+        public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            //TODO: Respect these cancellation tokens.
+            var result = await ExecuteInternalAsync();
+            await result.NextAsync();
+            return result.getValue(0);
         }
 
         public override void Prepare()
@@ -147,11 +171,17 @@ namespace Snowflake.Data.Client
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, null, false);
+            SFBaseResultSet resultSet = ExecuteInternal();
             return new SnowflakeDbDataReader(this, resultSet);
         }
 
-        private Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)
+        protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            var result = await ExecuteInternalAsync();
+            return new SnowflakeDbDataReader(this, result);
+        }
+
+        private static Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)
         {
             if (parameters == null || parameters.Count == 0)
             {
@@ -214,17 +244,14 @@ namespace Snowflake.Data.Client
             }
         }
 
-        private SFBaseResultSet executeInternal(string sql, 
-            Dictionary<string, BindingDTO> bindings, bool describeOnly)
+        private SFBaseResultSet ExecuteInternal(bool describeOnly = false)
         {
-            if (CommandTimeout != 0)
-            {
-                sfStatement.setQueryTimeoutBomb(CommandTimeout);
-            }
+            return sfStatement.Execute(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
+        }
 
-            SFBaseResultSet resultSet = sfStatement.execute(sql, bindings, describeOnly);
-
-            return resultSet;
+        private Task<SFBaseResultSet> ExecuteInternalAsync(bool describeOnly = false)
+        {
+            return sfStatement.ExecuteAsync(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Data.Client
         public SnowflakeDbCommand(SnowflakeDbConnection connection)
         {
             this.connection = connection;
-            this.sfStatement = new SFStatement(connection.sfSession);
+            this.sfStatement = new SFStatement(connection.SfSession);
             // by default, no query timeout
             this.CommandTimeout = 0;
             parameterCollection = new SnowflakeDbParameterCollection();

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -7,7 +7,8 @@ using System.Data.Common;
 using System.Collections;
 using Snowflake.Data.Core;
 using System.Data;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Common.Logging;
 
 namespace Snowflake.Data.Client
@@ -78,13 +79,7 @@ namespace Snowflake.Data.Client
             }
         }
 
-        public override int RecordsAffected
-        {
-            get
-            {
-                return ResultSetUtil.calculateUpdateCount(resultSet);
-            }
-        }
+        public override int RecordsAffected => resultSet.CalculateUpdateCount();
 
         public override bool GetBoolean(int ordinal)
         {
@@ -210,7 +205,15 @@ namespace Snowflake.Data.Client
 
         public override bool Read()
         {
-            return resultSet.next();
+            return resultSet.Next();
+        }
+
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            return resultSet.NextAsync();
         }
 
         public override void Close()

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -13,27 +13,14 @@ namespace Snowflake.Data.Core
 {
     class HttpUtil
     {
-        static private HttpClient httpClient;
-
-        static public HttpClient getHttpClient()
-        {
-            if (httpClient == null)
-            {
-                initHttpClient();
-            }
-            return httpClient;
-        }
-
-        static private void initHttpClient()
+        static public HttpClient initHttpClient(TimeSpan timeout)
         {
             // enforce tls v1.2
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             ServicePointManager.UseNagleAlgorithm = false;
             ServicePointManager.CheckCertificateRevocationList = true;
 
-            httpClient = new HttpClient(new RetryHandler(new HttpClientHandler()));
-            // default timeout for each request is 16 seconds
-            //httpClient.Timeout = TimeSpan.FromSeconds(16);
+            return new HttpClient(new RetryHandler(new HttpClientHandler())) { Timeout  = timeout };
         }
 
         class RetryHandler : DelegatingHandler
@@ -50,19 +37,21 @@ namespace Snowflake.Data.Core
                 HttpResponseMessage response = null;
                 int backOffInSec = 1;
 
-                int httpTimeout = (int)requestMessage.Properties["TIMEOUT_PER_HTTP_REQUEST"];
+                TimeSpan httpTimeout = (TimeSpan)requestMessage.Properties["TIMEOUT_PER_HTTP_REQUEST"];
 
                 CancellationTokenSource childCts = null;
-                if (httpTimeout != -1)
-                {
-                    childCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    childCts.CancelAfter(httpTimeout);
-                }
 
                 while (true)
                 {
                     try
-                    {   
+                    {
+                        childCts = null;
+
+                        if (!httpTimeout.Equals(Timeout.InfiniteTimeSpan)) {
+                            childCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            childCts.CancelAfter(httpTimeout);
+                        }
+
                         response = await base.SendAsync(requestMessage, childCts == null ? 
                             cancellationToken : childCts.Token);
                     }
@@ -83,14 +72,19 @@ namespace Snowflake.Data.Core
                         }
                     }
 
-                    if (response.IsSuccessStatusCode)
+                    if (response != null)
                     {
-                        logger.Info("Retried request succeed.");
-                        logger.TraceFormat("Success Response {0}", response.ToString());
-                        return response;
+                        if (response.IsSuccessStatusCode) {
+                            logger.TraceFormat("Success Response {0}", response.ToString());
+                            return response;
+                        }
+                        logger.TraceFormat("Failed Response: {0}", response.ToString());
+                    }
+                    else 
+                    {
+                        logger.Info("Response returned was null.");
                     }
 
-                    logger.TraceFormat("Failed Response: {0}", response.ToString());
                     logger.DebugFormat("Sleep {0} seconds and then retry the request", backOffInSec);
                     Thread.Sleep(backOffInSec * 1000);
                     backOffInSec = backOffInSec >= 16 ? 16 : backOffInSec * 2;

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Data.Core
 {
     class HttpUtil
     {
-        static public HttpClient initHttpClient(TimeSpan timeout)
+        public static HttpClient initHttpClient(TimeSpan timeout)
         {
             // enforce tls v1.2
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
@@ -30,7 +30,7 @@ namespace Snowflake.Data.Core
             internal RetryHandler(HttpMessageHandler innerHandler) : base(innerHandler)
             {
             }
-
+            
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage,
                 CancellationToken cancellationToken)
             {

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -20,7 +20,10 @@ namespace Snowflake.Data.Core
             ServicePointManager.UseNagleAlgorithm = false;
             ServicePointManager.CheckCertificateRevocationList = true;
 
-            return new HttpClient(new RetryHandler(new HttpClientHandler())) { Timeout  = timeout };
+            return new HttpClient(new RetryHandler(new HttpClientHandler()))
+            {
+                Timeout  = timeout
+            };
         }
 
         class RetryHandler : DelegatingHandler

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
+using System.Threading;
 
 namespace Snowflake.Data.Core
 {
@@ -26,10 +27,10 @@ namespace Snowflake.Data.Core
         internal string qrmk { get; set; }
 
         // request timeout in millis
-        internal int timeout { get; set; }
+        internal TimeSpan timeout { get; set; }
 
         // timeout for each http request 
-        internal int httpRequestTimeout { get; set; }
+        internal TimeSpan httpRequestTimeout { get; set; }
 
         internal Dictionary<string, string> chunkHeaders { get; set; }
     }
@@ -38,10 +39,10 @@ namespace Snowflake.Data.Core
     {
         public SFRestRequest()
         {
-            sfRestRequestTimeout = -1;
+            sfRestRequestTimeout = Timeout.InfiniteTimeSpan;
 
             // default each http request timeout to 16 seconds
-            httpRequestTimeout = 16000;
+            httpRequestTimeout = TimeSpan.FromSeconds(16); 
         }
 
         internal Uri uri { get; set; }
@@ -51,10 +52,10 @@ namespace Snowflake.Data.Core
         internal String authorizationToken { get; set; }
         
         // timeout for the whole rest request in millis (adding up all http retry)
-        internal int sfRestRequestTimeout { get; set; }
+        internal TimeSpan sfRestRequestTimeout { get; set; }
         
         // timeout for each http request 
-        internal int httpRequestTimeout { get; set; } 
+        internal TimeSpan httpRequestTimeout { get; set; } 
 
         public override string ToString()
         {

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -18,11 +18,12 @@ namespace Snowflake.Data.Core
 
         T Post<T>(SFRestRequest postRequest);
 
-        JObject post(SFRestRequest postRequest);
+        T Get<T>(SFRestRequest request);
 
-        JObject get(SFRestRequest getRequest);
+        Task<T> GetAsync<T>(SFRestRequest request);
 
-        HttpResponseMessage get(S3DownloadRequest getRequest);
+        Task<HttpResponseMessage> GetAsync(S3DownloadRequest request);
+        
     }
 
     public class S3DownloadRequest

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -8,11 +8,16 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {
     public interface IRestRequest
     {
+        Task<T> PostAsync<T>(SFRestRequest postRequest);
+
+        T Post<T>(SFRestRequest postRequest);
+
         JObject post(SFRestRequest postRequest);
 
         JObject get(SFRestRequest getRequest);

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Net.Http;
 using System;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Common.Logging;
@@ -43,7 +45,7 @@ namespace Snowflake.Data.Core
         public JObject post(SFRestRequest postRequest)
         {
             var json = JsonConvert.SerializeObject(postRequest.jsonBody);
-            HttpContent httpContent = new StringContent(json);
+            HttpContent httpContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, postRequest.uri);
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = postRequest.httpRequestTimeout;
@@ -61,6 +63,39 @@ namespace Snowflake.Data.Core
             return JObject.Parse(jsonString.Result);
         }
 
+        public T Post<T>(SFRestRequest postRequest)
+        {
+            //Run synchronous in a new thread-pool task.
+            return Task.Run(async () => await PostAsync<T>(postRequest)).Result;
+        }
+
+        public async Task<T> PostAsync<T>(SFRestRequest postRequest)
+        {
+            var req = ToRequestMessage(HttpMethod.Post, postRequest);
+
+            var response = await SendAsync(req, postRequest.sfRestRequestTimeout);
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        private HttpRequestMessage ToRequestMessage(HttpMethod method, SFRestRequest request)
+        {
+            var msg = new HttpRequestMessage(method, request.uri);
+            if (method != HttpMethod.Get && request.jsonBody != null)
+            {
+                var json = JsonConvert.SerializeObject(request.jsonBody);
+                //TODO: Check if we should use other encodings...
+                msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            msg.Headers.Add(SF_AUTHORIZATION_HEADER, request.authorizationToken);
+            msg.Headers.Accept.Add(applicationSnowflake);
+            
+            msg.Properties["TIMEOUT_PER_HTTP_REQUEST"] = request.httpRequestTimeout;
+
+            return msg;
+        }
+        
         public HttpResponseMessage get(S3DownloadRequest getRequest)
         {
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Get, getRequest.uri);
@@ -95,6 +130,14 @@ namespace Snowflake.Data.Core
             jsonString.Wait();
 
             return JObject.Parse(jsonString.Result);
+        }
+
+        private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, TimeSpan timeout)
+        {
+            var response = await HttpUtil.initHttpClient(timeout).SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            return response;
         }
 
         private HttpResponseMessage sendRequest(HttpRequestMessage requestMessage, TimeSpan timeout)

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -32,6 +32,11 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "data")]
         internal AuthnResponseData data { get; set; }
     }
+    
+    internal class RenewSessionResponse : BaseRestResponse {
+		[JsonProperty(PropertyName = "data")]
+		internal RenewSessionResponseData data { get; set; }
+	}
 
     internal class AuthnResponseData
     {
@@ -77,6 +82,25 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "ssoUrl", NullValueHandling = NullValueHandling.Ignore)]
         internal string ssoUrl { get; set; }
     }
+
+
+	internal class RenewSessionResponseData {
+
+		[JsonProperty(PropertyName = "sessionToken", NullValueHandling = NullValueHandling.Ignore)]
+		internal string sessionToken { get; set; }
+
+		[JsonProperty(PropertyName = "validityInSecondsST", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int16 masterTokenValidityInSeconds { get; set; }
+
+		[JsonProperty(PropertyName = "masterToken", NullValueHandling = NullValueHandling.Ignore)]
+		internal string masterToken { get; set; }
+
+		[JsonProperty(PropertyName = "validityInSecondsMT", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int16 validityInSeconds { get; set; }
+
+		[JsonProperty(PropertyName = "sessionId", NullValueHandling = NullValueHandling.Ignore)]
+		internal Int64 sessionId { get; set; }
+	}
 
     internal class SessionInfo
     {

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {
-    class ResultSetUtil
+    internal static class ResultSetUtil
     {
-        internal static int calculateUpdateCount(SFBaseResultSet resultSet)
+        internal static int CalculateUpdateCount(this SFBaseResultSet resultSet)
         {
             SFResultSetMetaData metaData = resultSet.sfResultSetMetaData;
             SFStatementType statementType = metaData.statementType;

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -20,7 +20,8 @@ namespace Snowflake.Data.Core
 
         internal bool isClosed;
 
-        internal abstract bool next();
+        internal abstract bool Next();
+        internal abstract Task<bool> NextAsync();
 
         protected abstract string getObjectInternal(int columnIndex);
 
@@ -158,5 +159,6 @@ namespace Snowflake.Data.Core
         {
             isClosed = true;
         }
+        
     }
 }

--- a/Snowflake.Data/Core/SFChunkDownloader.cs
+++ b/Snowflake.Data/Core/SFChunkDownloader.cs
@@ -122,8 +122,8 @@ namespace Snowflake.Data.Core
                 uri = new UriBuilder(chunk.url).Uri,
                 qrmk = downloadContext.qrmk,
                 // s3 download request timeout to one hour
-                timeout = 60 * 60,
-                httpRequestTimeout = 16000,
+                timeout = TimeSpan.FromHours(1),
+                httpRequestTimeout = TimeSpan.FromSeconds(16),
                 chunkHeaders = downloadContext.chunkHeaders
             };
 

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -26,6 +26,8 @@ namespace Snowflake.Data.Core
         static internal Object convertToCSharpVal(string srcVal, SFDataType srcType, Type destType)
         {
             logger.TraceFormat("src value: {0}, srcType: {1}, destType: {2}", srcVal, srcType, destType);
+            if (srcVal == null) return srcVal;
+            
             if (destType == typeof(Int16) 
                 || destType == typeof(Int32)
                 || destType == typeof(Int64)

--- a/Snowflake.Data/Core/SFResultChunk.cs
+++ b/Snowflake.Data/Core/SFResultChunk.cs
@@ -4,7 +4,7 @@
 
 namespace Snowflake.Data.Core
 {
-    class SFResultChunk
+    internal class SFResultChunk
     {
         public string[,] rowSet { get; set; }
 
@@ -15,21 +15,23 @@ namespace Snowflake.Data.Core
         public string url { get; set; }
 
         public DownloadState downloadState { get; set; }
+        public int ChunkIndex { get;  }
 
         public readonly object syncPrimitive; 
 
         public SFResultChunk(string[,] rowSet)
         {
             this.rowSet = rowSet;
-            this.rowCount = rowSet.Length;
+            this.rowCount = rowSet.GetLength(0);
             this.downloadState = DownloadState.NOT_STARTED;
         }
 
-        public SFResultChunk(string url, int rowCount, int colCount)
+        public SFResultChunk(string url, int rowCount, int colCount, int index)
         {
             this.rowCount = rowCount;
             this.colCount = colCount;
             this.url = url;
+            ChunkIndex = index;
             syncPrimitive = new object();
             this.downloadState = DownloadState.NOT_STARTED;
         }

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -68,7 +68,7 @@ namespace Snowflake.Data.Core
             }
 
             SFResultChunk nextChunk;
-            if ((nextChunk = _chunkDownloader.GetNextChunk()) != null)
+            if ((nextChunk = _chunkDownloader?.GetNextChunk()) != null)
             {
                 Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
                 _currentChunk.rowSet = null;

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
  */
 
+using System.Threading.Tasks;
 using Common.Logging;
 using Snowflake.Data.Client;
 
@@ -9,43 +10,38 @@ namespace Snowflake.Data.Core
 {
     class SFResultSet : SFBaseResultSet
     {
-        private static readonly ILog logger = LogManager.GetLogger<SFResultSet>();
+        private static readonly ILog Logger = LogManager.GetLogger<SFResultSet>();
+        
+        private int _currentChunkRowIdx;
 
-        private QueryExecResponseData execFirstChunkData;
+        private int _currentChunkRowCount;
 
-        private int currentChunkRowIdx;
+        private readonly int _totalChunkCount;
+        
+        private readonly SFChunkDownloader _chunkDownloader;
 
-        private int currentChunkRowCount;
-
-        private int totalChunkCount;
-
-        private int currentChunkIndex;
-
-        private SFChunkDownloader chunkDownloader;
-
-        private SFResultChunk currentChunk;
+        private SFResultChunk _currentChunk;
 
         public SFResultSet(QueryExecResponseData responseData, SFStatement sfStatement)
         {
-            execFirstChunkData = responseData;
             columnCount = responseData.rowType.Count;
-            currentChunkRowIdx = -1;
-            currentChunkRowCount = responseData.rowSet.GetLength(0);
-            currentChunkIndex = 0;
-
+            _currentChunkRowIdx = -1;
+            _currentChunkRowCount = responseData.rowSet.GetLength(0);
+           
             this.sfStatement = sfStatement;
 
             if (responseData.chunks != null)
             {
                 // counting the first chunk
-                totalChunkCount = responseData.chunks.Count + 1;
-                chunkDownloader = new SFChunkDownloader(responseData.rowType.Count,
+                _totalChunkCount = responseData.chunks.Count + 1;
+                _chunkDownloader = new SFChunkDownloader(columnCount,
                                                         responseData.chunks,
                                                         responseData.qrmk,
                                                         responseData.chunkHeaders);
             }
 
-            currentChunk = new SFResultChunk(responseData.rowSet);
+            _currentChunk = new SFResultChunk(responseData.rowSet);
+            responseData.rowSet = null;
 
             sfResultSetMetaData = new SFResultSetMetaData(responseData);
 
@@ -53,40 +49,36 @@ namespace Snowflake.Data.Core
             isClosed = false;
         }
 
-        internal override bool next()
+        internal override Task<bool> NextAsync()
+        {
+            return Task.FromResult(Next());
+        }
+
+        internal override bool Next()
         {
             if (isClosed)
             {
                 throw new SnowflakeDbException(SFError.DATA_READER_ALREADY_CLOSED);
             }
 
-            currentChunkRowIdx++;
-            
-            if (currentChunkRowIdx < currentChunkRowCount)
+            _currentChunkRowIdx++;
+            if (_currentChunkRowIdx < _currentChunkRowCount)
             {
                 return true;
             }
-            else if (++currentChunkIndex < totalChunkCount)
+
+            SFResultChunk nextChunk;
+            if ((nextChunk = _chunkDownloader.GetNextChunk()) != null)
             {
-                execFirstChunkData.rowSet = null;
-                logger.DebugFormat("Get chunk #{0} to consume", currentChunkIndex);
-
-                SFResultChunk chunk = chunkDownloader.getNextChunkToConsume();
-
-                if (chunk == null)
-                {
-                    throw new SnowflakeDbException(SFError.INTERNAL_ERROR, "Failed to get chunk to consume");
-                }
-                currentChunk = chunk;
-                currentChunkRowIdx = 0;
-                currentChunkRowCount = currentChunk.rowCount;
-
-                return true;                     
+                Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
+                _currentChunk.rowSet = null;
+                _currentChunk = nextChunk;
+                _currentChunkRowIdx = 0;
+                _currentChunkRowCount = _currentChunk.rowCount;
+                return true;
             }
-            else
-            {
-                return false;
-            }
+            
+           return false;
         }
 
         protected override string getObjectInternal(int columnIndex)
@@ -101,12 +93,12 @@ namespace Snowflake.Data.Core
                 throw new SnowflakeDbException(SFError.COLUMN_INDEX_OUT_OF_BOUND, columnIndex);
             }
 
-            return currentChunk.extractCell(currentChunkRowIdx, columnIndex);
+            return _currentChunk.extractCell(_currentChunkRowIdx, columnIndex);
         }
 
         private void updateSessionStatus(QueryExecResponseData responseData)
         {
-            SFSession session = this.sfStatement.sfSession;
+            SFSession session = this.sfStatement.SfSession;
             session.database = responseData.finalDatabaseName;
             session.schema = responseData.finalSchemaName;
 

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -10,6 +10,7 @@ using System.Web;
 using Newtonsoft.Json.Linq;
 using Common.Logging;
 using Snowflake.Data.Client;
+using System.Threading;
 
 namespace Snowflake.Data.Core
 {
@@ -122,7 +123,8 @@ namespace Snowflake.Data.Core
             loginRequest.uri = uriBuilder.Uri;
             loginRequest.authorizationToken = SF_AUTHORIZATION_BASIC;
             // total login timeout  
-            loginRequest.sfRestRequestTimeout = connectionTimeoutSec <= 0 ? -1 : connectionTimeoutSec * 1000;
+            if (connectionTimeoutSec <= 0) loginRequest.sfRestRequestTimeout = Timeout.InfiniteTimeSpan;
+            else loginRequest.sfRestRequestTimeout = TimeSpan.FromSeconds(connectionTimeoutSec);
 
             if (logger.IsTraceEnabled)
             {
@@ -155,7 +157,7 @@ namespace Snowflake.Data.Core
             NullDataResponse deleteSessionResponse = response.ToObject<NullDataResponse>();
             if (!deleteSessionResponse.success)
             {
-                logger.WarnFormat("Failed to delete session, error ignored. Code: {0} Message: {0}", 
+                logger.WarnFormat("Failed to delete session, error ignored. Code: {0} Message: {1}", 
                     deleteSessionResponse.code, deleteSessionResponse.message);
             }
         }
@@ -182,16 +184,20 @@ namespace Snowflake.Data.Core
             renewSessionRequest.jsonBody = postBody;
             renewSessionRequest.uri = uriBuilder.Uri;
             renewSessionRequest.authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, masterToken);
-            renewSessionRequest.sfRestRequestTimeout = -1;
+            renewSessionRequest.sfRestRequestTimeout = Timeout.InfiniteTimeSpan;
 
             JObject response = restRequest.post(renewSessionRequest);
-            NullDataResponse sessionRenewResponse = response.ToObject<NullDataResponse>();
+            RenewSessionResponse sessionRenewResponse = response.ToObject<RenewSessionResponse>();
             if (!sessionRenewResponse.success)
             {
                 SnowflakeDbException e = new SnowflakeDbException("", 
                     sessionRenewResponse.code, sessionRenewResponse.message, "");
                 logger.Error("Renew session failed", e);
                 throw e;
+            } 
+            else 
+            {
+                sessionToken = sessionRenewResponse.data.sessionToken;
             }
         }
 

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Snowflake.Data.Client;
 using Common.Logging;
+using System.Threading;
 
 namespace Snowflake.Data.Core
 {
@@ -72,7 +73,7 @@ namespace Snowflake.Data.Core
             queryRequest.uri = uriBuilder.Uri;
             queryRequest.authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sfSession.sessionToken);
             queryRequest.jsonBody = postBody;
-            queryRequest.httpRequestTimeout = -1;
+            queryRequest.httpRequestTimeout = Timeout.InfiniteTimeSpan;
 
             try
             {
@@ -82,7 +83,8 @@ namespace Snowflake.Data.Core
                 if (execResponse.code == SF_SESSION_EXPIRED_CODE)
                 {
                     sfSession.renewSession();
-                    this.execute(sql, bindings, describeOnly);
+                    this.requestId = null;
+                    return this.execute(sql, bindings, describeOnly);
                 }
                 else if (execResponse.code == SF_QUERY_IN_PROGRESS ||
                          execResponse.code == SF_QUERY_IN_PROGRESS_ASYNC)
@@ -109,7 +111,7 @@ namespace Snowflake.Data.Core
                             uri = getResultUriBuilder.Uri,
                             authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sfSession.sessionToken)
                         };
-                        getResultRequest.httpRequestTimeout = -1;
+                        getResultRequest.httpRequestTimeout = Timeout.InfiniteTimeSpan;
 
                         execResponse = null;
                         execResponse = restRequest.get(getResultRequest).ToObject<QueryExecResponse>();


### PR DESCRIPTION
This pull request implements OpenAsync and all ExecuteXXXAsync methods for DbCommand.

It builds upon the changes made by stefanorr in PR #10 .

Issues fixed:
#4 
#9 (this was actually fixed by stefanorr, it was an issue with the value provided for the timeout when downloading chunks).

Although it was not directly reported the base implementation of sending a request in RestRequestImpl.cs would have caused issues with ASP.NET applications due to deadlock caused by using .Result.

All Synchronous calls should now be safe for use in ASP.NET applications, although Asynchronous calls should be preferred when available.

``` 
var response = HttpUtil.getHttpClient().SendAsync(requestMessage, cancellationToken)
                    .Result.EnsureSuccessStatusCode();
```