### PR TITLE
Pr 15

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -7,6 +7,7 @@ namespace Snowflake.Data.Tests
     using NUnit.Framework;
     using Snowflake.Data.Client;
     using System.Data;
+    using System;
 
     [TestFixture]
     class SFConnectionIT : SFBaseTest
@@ -36,7 +37,7 @@ namespace Snowflake.Data.Tests
         {
             using (IDbConnection conn = new SnowflakeDbConnection())
             {
-                string invalidConnectionString = "host=invalidaccount.snowflakecomputing.com;connection_timeout=30;"
+                string invalidConnectionString = "host=invalidaccount.snowflakecomputing.com;connection_timeout=5;"
                     + "account=invalidaccount;user=snowman;password=test;";
 
                 conn.ConnectionString = invalidConnectionString;
@@ -47,11 +48,11 @@ namespace Snowflake.Data.Tests
                     conn.Open();
                     Assert.Fail();
                 }
-                catch(SnowflakeDbException e)
+                catch(AggregateException e)
                 {
-                    Assert.AreEqual(270007, e.ErrorCode);
+                    Assert.AreEqual(270007, ((SnowflakeDbException)e.InnerException).ErrorCode);
                 }
-                Assert.AreEqual(30, conn.ConnectionTimeout);
+                Assert.AreEqual(5, conn.ConnectionTimeout);
             }
 
         }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -7,6 +7,8 @@ using Snowflake.Data.Core;
 using System.Data.Common;
 using System.Data;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Snowflake.Data.Client
@@ -117,22 +119,44 @@ namespace Snowflake.Data.Client
 
         public override void Cancel()
         {
-            sfStatement.cancel();
+            sfStatement.Cancel();
         }
-
+        
         public override int ExecuteNonQuery()
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, 
-                convertToBindList(parameterCollection.parameterList), false);
-            resultSet.next();
-            return ResultSetUtil.calculateUpdateCount(resultSet);
+            SFBaseResultSet resultSet = ExecuteInternal();
+            resultSet.Next();
+            return resultSet.CalculateUpdateCount();
+        }
+
+        public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            //TODO: Respect these cancellation tokens.
+
+            var resultSet = await ExecuteInternalAsync();
+            await resultSet.NextAsync();
+            return resultSet.CalculateUpdateCount();
         }
 
         public override object ExecuteScalar()
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, null, false);
-            resultSet.next();
+            SFBaseResultSet resultSet = ExecuteInternal();
+            resultSet.Next();
             return resultSet.GetValue(0);
+        }
+
+        public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            //TODO: Respect these cancellation tokens.
+            var result = await ExecuteInternalAsync();
+            await result.NextAsync();
+            return result.GetValue(0);
         }
 
         public override void Prepare()
@@ -147,11 +171,17 @@ namespace Snowflake.Data.Client
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            SFBaseResultSet resultSet = executeInternal(CommandText, null, false);
+            SFBaseResultSet resultSet = ExecuteInternal();
             return new SnowflakeDbDataReader(this, resultSet);
         }
 
-        private Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)
+        protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            var result = await ExecuteInternalAsync();
+            return new SnowflakeDbDataReader(this, result);
+        }
+
+        private static Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)
         {
             if (parameters == null || parameters.Count == 0)
             {
@@ -214,17 +244,14 @@ namespace Snowflake.Data.Client
             }
         }
 
-        private SFBaseResultSet executeInternal(string sql, 
-            Dictionary<string, BindingDTO> bindings, bool describeOnly)
+        private SFBaseResultSet ExecuteInternal(bool describeOnly = false)
         {
-            if (CommandTimeout != 0)
-            {
-                sfStatement.setQueryTimeoutBomb(CommandTimeout);
-            }
+            return sfStatement.Execute(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
+        }
 
-            SFBaseResultSet resultSet = sfStatement.execute(sql, bindings, describeOnly);
-
-            return resultSet;
+        private Task<SFBaseResultSet> ExecuteInternalAsync(bool describeOnly = false)
+        {
+            return sfStatement.ExecuteAsync(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -134,9 +134,7 @@ namespace Snowflake.Data.Client
             if (cancellationToken.IsCancellationRequested)
                 throw new TaskCanceledException();
 
-            //TODO: Respect these cancellation tokens.
-
-            var resultSet = await ExecuteInternalAsync();
+            var resultSet = await ExecuteInternalAsync(cancellationToken);
             await resultSet.NextAsync();
             return resultSet.CalculateUpdateCount();
         }
@@ -153,8 +151,7 @@ namespace Snowflake.Data.Client
             if (cancellationToken.IsCancellationRequested)
                 throw new TaskCanceledException();
 
-            //TODO: Respect these cancellation tokens.
-            var result = await ExecuteInternalAsync();
+            var result = await ExecuteInternalAsync(cancellationToken);
             await result.NextAsync();
             return result.GetValue(0);
         }
@@ -177,7 +174,7 @@ namespace Snowflake.Data.Client
 
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            var result = await ExecuteInternalAsync();
+            var result = await ExecuteInternalAsync(cancellationToken);
             return new SnowflakeDbDataReader(this, result);
         }
 
@@ -249,9 +246,9 @@ namespace Snowflake.Data.Client
             return sfStatement.Execute(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
         }
 
-        private Task<SFBaseResultSet> ExecuteInternalAsync(bool describeOnly = false)
+        private Task<SFBaseResultSet> ExecuteInternalAsync(CancellationToken cancellationToken, bool describeOnly = false)
         {
-            return sfStatement.ExecuteAsync(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
+            return sfStatement.ExecuteAsync(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly, cancellationToken);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Data.Client
         public SnowflakeDbCommand(SnowflakeDbConnection connection)
         {
             this.connection = connection;
-            this.sfStatement = new SFStatement(connection.sfSession);
+            this.sfStatement = new SFStatement(connection.SfSession);
             // by default, no query timeout
             this.CommandTimeout = 0;
             parameterCollection = new SnowflakeDbParameterCollection();

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -97,8 +97,7 @@ namespace Snowflake.Data.Client
                 return Task.FromCanceled(cancellationToken);
 
             SetSession();
-            //TODO: Respect the cancellation tokens...
-            return SfSession.OpenAsync().ContinueWith(t => OnSessionEstablished(), cancellationToken);
+            return SfSession.OpenAsync(cancellationToken).ContinueWith(t => OnSessionEstablished(), cancellationToken);
         }
 
         private void SetSession()
@@ -112,9 +111,6 @@ namespace Snowflake.Data.Client
         {
             _connectionState = ConnectionState.Open;
         }
-
-
-
 
         protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         {

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -7,7 +7,8 @@ using System.Data.Common;
 using System.Collections;
 using Snowflake.Data.Core;
 using System.Data;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Common.Logging;
 
 namespace Snowflake.Data.Client
@@ -78,13 +79,7 @@ namespace Snowflake.Data.Client
             }
         }
 
-        public override int RecordsAffected
-        {
-            get
-            {
-                return ResultSetUtil.calculateUpdateCount(resultSet);
-            }
-        }
+        public override int RecordsAffected => resultSet.CalculateUpdateCount();
 
         public override bool GetBoolean(int ordinal)
         {
@@ -210,7 +205,15 @@ namespace Snowflake.Data.Client
 
         public override bool Read()
         {
-            return resultSet.next();
+            return resultSet.Next();
+        }
+
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                throw new TaskCanceledException();
+
+            return resultSet.NextAsync();
         }
 
         public override void Close()

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Core
             internal RetryHandler(HttpMessageHandler innerHandler) : base(innerHandler)
             {
             }
-
+            
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage,
                 CancellationToken cancellationToken)
             {

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -14,14 +14,19 @@ namespace Snowflake.Data.Core
     class HttpUtil
     {
         static private HttpClient httpClient = null;
+
+        static private object httpClientInitLock = new object();
         
         static public HttpClient getHttpClient()
         {
-            if (httpClient == null)
+            lock (httpClientInitLock)
             {
-                initHttpClient();
+                if (httpClient == null)
+                {
+                    initHttpClient();
+                }
+                return httpClient;
             }
-            return httpClient;
         }        
 
         static private void initHttpClient()

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -18,11 +18,12 @@ namespace Snowflake.Data.Core
 
         T Post<T>(SFRestRequest postRequest);
 
-        JObject post(SFRestRequest postRequest);
+        T Get<T>(SFRestRequest request);
 
-        JObject get(SFRestRequest getRequest);
+        Task<T> GetAsync<T>(SFRestRequest request);
 
-        HttpResponseMessage get(S3DownloadRequest getRequest);
+        Task<HttpResponseMessage> GetAsync(S3DownloadRequest request);
+        
     }
 
     public class S3DownloadRequest

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -8,11 +8,16 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {
     public interface IRestRequest
     {
+        Task<T> PostAsync<T>(SFRestRequest postRequest);
+
+        T Post<T>(SFRestRequest postRequest);
+
         JObject post(SFRestRequest postRequest);
 
         JObject get(SFRestRequest getRequest);

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -14,16 +14,15 @@ namespace Snowflake.Data.Core
 {
     public interface IRestRequest
     {
-        Task<T> PostAsync<T>(SFRestRequest postRequest);
+        Task<T> PostAsync<T>(SFRestRequest postRequest, CancellationToken cancellationToken);
 
         T Post<T>(SFRestRequest postRequest);
 
         T Get<T>(SFRestRequest request);
 
-        Task<T> GetAsync<T>(SFRestRequest request);
+        Task<T> GetAsync<T>(SFRestRequest request, CancellationToken cancellationToken);
 
-        Task<HttpResponseMessage> GetAsync(S3DownloadRequest request);
-        
+        Task<HttpResponseMessage> GetAsync(S3DownloadRequest request, CancellationToken cancellationToken);
     }
 
     public class S3DownloadRequest

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -78,6 +78,21 @@ namespace Snowflake.Data.Core
             return JsonConvert.DeserializeObject<T>(json);
         }
 
+        public T Get<T>(SFRestRequest request)
+        {
+            //Run synchronous in a new thread-pool task.
+            return Task.Run(async () => await GetAsync<T>(request)).Result;
+        }
+
+        public async Task<T> GetAsync<T>(SFRestRequest request)
+        {
+            var req = ToRequestMessage(HttpMethod.Get, request);
+
+            var response = await SendAsync(req, request.sfRestRequestTimeout);
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
         private HttpRequestMessage ToRequestMessage(HttpMethod method, SFRestRequest request)
         {
             var msg = new HttpRequestMessage(method, request.uri);
@@ -96,7 +111,7 @@ namespace Snowflake.Data.Core
             return msg;
         }
         
-        public HttpResponseMessage get(S3DownloadRequest getRequest)
+        public Task<HttpResponseMessage> GetAsync(S3DownloadRequest getRequest)
         {
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Get, getRequest.uri);
 
@@ -114,30 +129,26 @@ namespace Snowflake.Data.Core
             }
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = getRequest.httpRequestTimeout;
 
-            return sendRequest(message, getRequest.timeout);
+            return SendAsync(message, getRequest.timeout);
         }
-
-        public JObject get(SFRestRequest getRequest)
+        
+        private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, TimeSpan timeoutPerRestRequest)
         {
-            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Get, getRequest.uri);
-            message.Headers.Add(SF_AUTHORIZATION_HEADER, getRequest.authorizationToken);
-            message.Headers.Accept.Add(applicationSnowflake);
-            message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = getRequest.httpRequestTimeout;
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(timeoutPerRestRequest);
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+            try
+            {
+                var response = await HttpUtil.getHttpClient().SendAsync(request, cancellationToken);
+                response.EnsureSuccessStatusCode();
 
-            var responseContent = sendRequest(message, getRequest.sfRestRequestTimeout).Content;
+                return response;
+            }
+            catch (Exception e)
+            {
+                throw cancellationToken.IsCancellationRequested ? new SnowflakeDbException(SFError.REQUEST_TIMEOUT) 
+                    : e;
+            }
 
-            var jsonString = responseContent.ReadAsStringAsync();
-            jsonString.Wait();
-
-            return JObject.Parse(jsonString.Result);
-        }
-
-        private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, TimeSpan timeout)
-        {
-            var response = await HttpUtil.initHttpClient(timeout).SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            return response;
         }
 
         private HttpResponseMessage sendRequest(HttpRequestMessage requestMessage, TimeSpan timeoutPerRestRequest)

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -120,10 +120,17 @@ namespace Snowflake.Data.Core
             CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellationToken,
                 restRequestTimeout.Token);
 
-            var response = await HttpUtil.getHttpClient().SendAsync(request, linkedCts.Token);
-            response.EnsureSuccessStatusCode();
+            try
+            {
+                var response = await HttpUtil.getHttpClient().SendAsync(request, linkedCts.Token);
+                response.EnsureSuccessStatusCode();
 
-            return response;
+                return response;
+            }
+            catch(Exception e)
+            {
+                throw restRequestTimeout.IsCancellationRequested ? new SnowflakeDbException(SFError.REQUEST_TIMEOUT) : e;
+            }
         }
     }
 }

--- a/Snowflake.Data/Core/RestRequestImpl.cs
+++ b/Snowflake.Data/Core/RestRequestImpl.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Net.Http;
 using System;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Common.Logging;
@@ -43,7 +45,7 @@ namespace Snowflake.Data.Core
         public JObject post(SFRestRequest postRequest)
         {
             var json = JsonConvert.SerializeObject(postRequest.jsonBody);
-            HttpContent httpContent = new StringContent(json);
+            HttpContent httpContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, postRequest.uri);
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = postRequest.httpRequestTimeout;
@@ -61,6 +63,39 @@ namespace Snowflake.Data.Core
             return JObject.Parse(jsonString.Result);
         }
 
+        public T Post<T>(SFRestRequest postRequest)
+        {
+            //Run synchronous in a new thread-pool task.
+            return Task.Run(async () => await PostAsync<T>(postRequest)).Result;
+        }
+
+        public async Task<T> PostAsync<T>(SFRestRequest postRequest)
+        {
+            var req = ToRequestMessage(HttpMethod.Post, postRequest);
+
+            var response = await SendAsync(req, postRequest.sfRestRequestTimeout);
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        private HttpRequestMessage ToRequestMessage(HttpMethod method, SFRestRequest request)
+        {
+            var msg = new HttpRequestMessage(method, request.uri);
+            if (method != HttpMethod.Get && request.jsonBody != null)
+            {
+                var json = JsonConvert.SerializeObject(request.jsonBody);
+                //TODO: Check if we should use other encodings...
+                msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            msg.Headers.Add(SF_AUTHORIZATION_HEADER, request.authorizationToken);
+            msg.Headers.Accept.Add(applicationSnowflake);
+            
+            msg.Properties["TIMEOUT_PER_HTTP_REQUEST"] = request.httpRequestTimeout;
+
+            return msg;
+        }
+        
         public HttpResponseMessage get(S3DownloadRequest getRequest)
         {
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Get, getRequest.uri);
@@ -97,6 +132,14 @@ namespace Snowflake.Data.Core
             return JObject.Parse(jsonString.Result);
         }
 
+        private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, TimeSpan timeout)
+        {
+            var response = await HttpUtil.initHttpClient(timeout).SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            return response;
+        }
+
         private HttpResponseMessage sendRequest(HttpRequestMessage requestMessage, TimeSpan timeoutPerRestRequest)
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(timeoutPerRestRequest);
@@ -115,5 +158,4 @@ namespace Snowflake.Data.Core
             }
         }
     }
-
 }

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {
-    class ResultSetUtil
+    internal static class ResultSetUtil
     {
-        internal static int calculateUpdateCount(SFBaseResultSet resultSet)
+        internal static int CalculateUpdateCount(this SFBaseResultSet resultSet)
         {
             SFResultSetMetaData metaData = resultSet.sfResultSetMetaData;
             SFStatementType statementType = metaData.statementType;

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -3,6 +3,7 @@
  */
 
 using System;
+using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -16,7 +16,8 @@ namespace Snowflake.Data.Core
 
         internal bool isClosed;
 
-        internal abstract bool next();
+        internal abstract bool Next();
+        internal abstract Task<bool> NextAsync();
 
         protected abstract string getObjectInternal(int columnIndex);
 
@@ -55,5 +56,6 @@ namespace Snowflake.Data.Core
         {
             isClosed = true;
         }
+        
     }
 }

--- a/Snowflake.Data/Core/SFResultChunk.cs
+++ b/Snowflake.Data/Core/SFResultChunk.cs
@@ -4,7 +4,7 @@
 
 namespace Snowflake.Data.Core
 {
-    class SFResultChunk
+    internal class SFResultChunk
     {
         public string[,] rowSet { get; set; }
 
@@ -15,21 +15,23 @@ namespace Snowflake.Data.Core
         public string url { get; set; }
 
         public DownloadState downloadState { get; set; }
+        public int ChunkIndex { get;  }
 
         public readonly object syncPrimitive; 
 
         public SFResultChunk(string[,] rowSet)
         {
             this.rowSet = rowSet;
-            this.rowCount = rowSet.Length;
+            this.rowCount = rowSet.GetLength(0);
             this.downloadState = DownloadState.NOT_STARTED;
         }
 
-        public SFResultChunk(string url, int rowCount, int colCount)
+        public SFResultChunk(string url, int rowCount, int colCount, int index)
         {
             this.rowCount = rowCount;
             this.colCount = colCount;
             this.url = url;
+            ChunkIndex = index;
             syncPrimitive = new object();
             this.downloadState = DownloadState.NOT_STARTED;
         }

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -68,7 +68,7 @@ namespace Snowflake.Data.Core
             }
 
             SFResultChunk nextChunk;
-            if ((nextChunk = _chunkDownloader.GetNextChunk()) != null)
+            if ((nextChunk = _chunkDownloader?.GetNextChunk()) != null)
             {
                 Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
                 _currentChunk.rowSet = null;

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
  */
 
+using System.Threading.Tasks;
 using Common.Logging;
 using Snowflake.Data.Client;
 
@@ -9,43 +10,38 @@ namespace Snowflake.Data.Core
 {
     class SFResultSet : SFBaseResultSet
     {
-        private static readonly ILog logger = LogManager.GetLogger<SFResultSet>();
+        private static readonly ILog Logger = LogManager.GetLogger<SFResultSet>();
+        
+        private int _currentChunkRowIdx;
 
-        private QueryExecResponseData execFirstChunkData;
+        private int _currentChunkRowCount;
 
-        private int currentChunkRowIdx;
+        private readonly int _totalChunkCount;
+        
+        private readonly SFChunkDownloader _chunkDownloader;
 
-        private int currentChunkRowCount;
-
-        private int totalChunkCount;
-
-        private int currentChunkIndex;
-
-        private SFChunkDownloader chunkDownloader;
-
-        private SFResultChunk currentChunk;
+        private SFResultChunk _currentChunk;
 
         public SFResultSet(QueryExecResponseData responseData, SFStatement sfStatement)
         {
-            execFirstChunkData = responseData;
             columnCount = responseData.rowType.Count;
-            currentChunkRowIdx = -1;
-            currentChunkRowCount = responseData.rowSet.GetLength(0);
-            currentChunkIndex = 0;
-
+            _currentChunkRowIdx = -1;
+            _currentChunkRowCount = responseData.rowSet.GetLength(0);
+           
             this.sfStatement = sfStatement;
 
             if (responseData.chunks != null)
             {
                 // counting the first chunk
-                totalChunkCount = responseData.chunks.Count + 1;
-                chunkDownloader = new SFChunkDownloader(responseData.rowType.Count,
+                _totalChunkCount = responseData.chunks.Count + 1;
+                _chunkDownloader = new SFChunkDownloader(columnCount,
                                                         responseData.chunks,
                                                         responseData.qrmk,
                                                         responseData.chunkHeaders);
             }
 
-            currentChunk = new SFResultChunk(responseData.rowSet);
+            _currentChunk = new SFResultChunk(responseData.rowSet);
+            responseData.rowSet = null;
 
             sfResultSetMetaData = new SFResultSetMetaData(responseData);
 
@@ -53,40 +49,36 @@ namespace Snowflake.Data.Core
             isClosed = false;
         }
 
-        internal override bool next()
+        internal override Task<bool> NextAsync()
+        {
+            return Task.FromResult(Next());
+        }
+
+        internal override bool Next()
         {
             if (isClosed)
             {
                 throw new SnowflakeDbException(SFError.DATA_READER_ALREADY_CLOSED);
             }
 
-            currentChunkRowIdx++;
-            
-            if (currentChunkRowIdx < currentChunkRowCount)
+            _currentChunkRowIdx++;
+            if (_currentChunkRowIdx < _currentChunkRowCount)
             {
                 return true;
             }
-            else if (++currentChunkIndex < totalChunkCount)
+
+            SFResultChunk nextChunk;
+            if ((nextChunk = _chunkDownloader.GetNextChunk()) != null)
             {
-                execFirstChunkData.rowSet = null;
-                logger.DebugFormat("Get chunk #{0} to consume", currentChunkIndex);
-
-                SFResultChunk chunk = chunkDownloader.getNextChunkToConsume();
-
-                if (chunk == null)
-                {
-                    throw new SnowflakeDbException(SFError.INTERNAL_ERROR, "Failed to get chunk to consume");
-                }
-                currentChunk = chunk;
-                currentChunkRowIdx = 0;
-                currentChunkRowCount = currentChunk.rowCount;
-
-                return true;                     
+                Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
+                _currentChunk.rowSet = null;
+                _currentChunk = nextChunk;
+                _currentChunkRowIdx = 0;
+                _currentChunkRowCount = _currentChunk.rowCount;
+                return true;
             }
-            else
-            {
-                return false;
-            }
+            
+           return false;
         }
 
         protected override string getObjectInternal(int columnIndex)
@@ -101,12 +93,12 @@ namespace Snowflake.Data.Core
                 throw new SnowflakeDbException(SFError.COLUMN_INDEX_OUT_OF_BOUND, columnIndex);
             }
 
-            return currentChunk.extractCell(currentChunkRowIdx, columnIndex);
+            return _currentChunk.extractCell(_currentChunkRowIdx, columnIndex);
         }
 
         private void updateSessionStatus(QueryExecResponseData responseData)
         {
-            SFSession session = this.sfStatement.sfSession;
+            SFSession session = this.sfStatement.SfSession;
             session.database = responseData.finalDatabaseName;
             session.schema = responseData.finalSchemaName;
 

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
  */
 
+using System.Threading;
 using System.Threading.Tasks;
 using Common.Logging;
 using Snowflake.Data.Client;
@@ -22,7 +23,7 @@ namespace Snowflake.Data.Core
 
         private SFResultChunk _currentChunk;
 
-        public SFResultSet(QueryExecResponseData responseData, SFStatement sfStatement)
+        public SFResultSet(QueryExecResponseData responseData, SFStatement sfStatement, CancellationToken cancellationToken)
         {
             columnCount = responseData.rowType.Count;
             _currentChunkRowIdx = -1;
@@ -37,7 +38,8 @@ namespace Snowflake.Data.Core
                 _chunkDownloader = new SFChunkDownloader(columnCount,
                                                         responseData.chunks,
                                                         responseData.qrmk,
-                                                        responseData.chunkHeaders);
+                                                        responseData.chunkHeaders,
+                                                        cancellationToken);
             }
 
             _currentChunk = new SFResultChunk(responseData.rowSet);
@@ -49,9 +51,48 @@ namespace Snowflake.Data.Core
             isClosed = false;
         }
 
+        internal void resetChunkInfo(SFResultChunk nextChunk)
+        {
+            Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
+            _currentChunk.rowSet = null;
+            _currentChunk = nextChunk;
+            _currentChunkRowIdx = 0;
+            _currentChunkRowCount = _currentChunk.rowCount;
+        }
+
         internal override Task<bool> NextAsync()
         {
-            return Task.FromResult(Next());
+            if (isClosed)
+            {
+                throw new SnowflakeDbException(SFError.DATA_READER_ALREADY_CLOSED);
+            }
+
+            _currentChunkRowIdx++;
+            if (_currentChunkRowIdx < _currentChunkRowCount)
+            {
+                return Task.FromResult(true);
+            }
+
+            if (_chunkDownloader != null)
+            {
+                // GetNextChunk could be blocked if download result is not done yet. 
+                // So put this piece of code in a seperate task
+                return Task.Run(() =>
+                {
+                    SFResultChunk nextChunk;
+                    if ((nextChunk = _chunkDownloader.GetNextChunk()) != null)
+                    {
+                        resetChunkInfo(nextChunk);
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                });
+            }
+            
+           return Task.FromResult(false);
         }
 
         internal override bool Next()
@@ -70,11 +111,7 @@ namespace Snowflake.Data.Core
             SFResultChunk nextChunk;
             if ((nextChunk = _chunkDownloader?.GetNextChunk()) != null)
             {
-                Logger.DebugFormat("Recieved chunk #{0} of {1}", nextChunk.ChunkIndex+1, _totalChunkCount);
-                _currentChunk.rowSet = null;
-                _currentChunk = nextChunk;
-                _currentChunkRowIdx = 0;
-                _currentChunkRowCount = _currentChunk.rowCount;
+                resetChunkInfo(nextChunk);
                 return true;
             }
             

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -100,9 +100,12 @@ namespace Snowflake.Data.Core
         {
             // build uri
             var queryParams = new Dictionary<string,string>();
-            queryParams[SF_QUERY_WAREHOUSE] = properties.TryGetValue(SFSessionProperty.WAREHOUSE, out var warehouseValue) ? warehouseValue : "";
-            queryParams[SF_QUERY_DB] = properties.TryGetValue(SFSessionProperty.DB, out var dbValue) ? dbValue : "";
-            queryParams[SF_QUERY_SCHEMA] = properties.TryGetValue(SFSessionProperty.SCHEMA, out var schemaValue) ? schemaValue : "";
+            string warehouseValue;
+            string dbValue;
+            string schemaValue; 
+            queryParams[SF_QUERY_WAREHOUSE] = properties.TryGetValue(SFSessionProperty.WAREHOUSE, out warehouseValue) ? warehouseValue : "";
+            queryParams[SF_QUERY_DB] = properties.TryGetValue(SFSessionProperty.DB, out dbValue) ? dbValue : "";
+            queryParams[SF_QUERY_SCHEMA] = properties.TryGetValue(SFSessionProperty.SCHEMA, out schemaValue) ? schemaValue : "";
             queryParams[SF_QUERY_REQUEST_ID] = Guid.NewGuid().ToString();
             
             var loginUri = BuildUri(SF_LOGIN_PATH, queryParams);
@@ -165,7 +168,7 @@ namespace Snowflake.Data.Core
             ProcessLoginResponse(response);
         }
 
-        internal async Task OpenAsync()
+        internal async Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Session");
 
@@ -176,7 +179,7 @@ namespace Snowflake.Data.Core
                 logger.TraceFormat("Login Request Data: {0}", loginRequest.ToString());
             }
 
-            var response = await restRequest.PostAsync<AuthnResponse>(loginRequest);
+            var response = await restRequest.PostAsync<AuthnResponse>(loginRequest, cancellationToken);
             ProcessLoginResponse(response);
         }
 


### PR DESCRIPTION
This pr is used to run #15, which tried to fix #4.

I improved following from #15.

- Improved SnowflakeDbDataReader.NextAsync() method. Basically, in most cases synchronized execution of Next is okay. However, if current chunk consumption is done and new chunk has not been downloaded, main thread will blocked on waiting for download. Wrap this waiting download logic in a separate thread so that main is not blocked.

- Honor cancellation token. If a cancellation token is passed from upper layer. Honor those cancel signal. 

@smtakeda @jianshenghuang @akrock Can you review the change? 