### PR TITLE
Transient Errors during Http requests are not retried

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -84,7 +84,8 @@ namespace Snowflake.Data.Core
                         }
                         else
                         {
-                            throw e;
+                            //TODO: Should probably check to see if the error is recoverable or transient.
+                            logger.Warn("Error occurred during request, retrying...", e);
                         }
                     }
 


### PR DESCRIPTION
This came from our fork of the connector. I cannot actually remember now what the specific error was that was transient and retry-able. 

Some exploration would probably be good as to what errors could be transient. A max retries in this section also might be beneficial.