### PR TITLE
PR - Fix for #69

### DIFF
--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -17,32 +17,57 @@ namespace Snowflake.Data.Core
             SFResultSetMetaData metaData = resultSet.sfResultSetMetaData;
             SFStatementType statementType = metaData.statementType;
 
-            int updateCount = 0;
-            switch (statementType)
+            try
             {
-                case SFStatementType.INSERT:
-                case SFStatementType.UPDATE:
-                case SFStatementType.DELETE:
-                case SFStatementType.MERGE:
-                case SFStatementType.MULTI_INSERT:
-                    for (int i = 0; i < resultSet.columnCount; i++)
-                    {
-                        updateCount += resultSet.GetValue<int>(i);
-                    }
-                    break;
-                case SFStatementType.COPY:
-                    var index = resultSet.sfResultSetMetaData.getColumnIndexByName("rows_loaded");
-                    if (index >= 0) updateCount = resultSet.GetValue<int>(index);
-                    break;
-                case SFStatementType.SELECT:
-                    updateCount = -1;
-                    break;
-                default:
-                    updateCount = 0;
-                    break;
-            }
+                int updateCount = 0;
+                switch (statementType)
+                {
+                    case SFStatementType.INSERT:
+                    case SFStatementType.UPDATE:
+                    case SFStatementType.DELETE:
+                    case SFStatementType.MERGE:
+                    case SFStatementType.MULTI_INSERT:
+                        for (int i = 0; i < resultSet.columnCount; i++)
+                        {
+                            updateCount += resultSet.GetValue<int>(i);
+                        }
 
-            return updateCount;
+                        break;
+                    case SFStatementType.COPY:
+                        var index = resultSet.sfResultSetMetaData.getColumnIndexByName("rows_loaded");
+                        if (index >= 0) updateCount = resultSet.GetValue<int>(index);
+                        break;
+                    case SFStatementType.SELECT:
+                        updateCount = -1;
+                        break;
+                    default:
+                        updateCount = 0;
+                        break;
+                }
+
+                return updateCount;
+            }
+            catch (Exception ex)
+            {
+                if (IsOverflowException(ex))
+                    return -1;
+
+                throw;
+            }
+        }
+
+        private static bool IsOverflowException(Exception ex)
+        {
+            if (ex is OverflowException)
+                return true;
+
+            if (ex.InnerException != null)
+                return IsOverflowException(ex.InnerException);
+
+            if (ex is AggregateException aggEx)
+                return aggEx.InnerExceptions.Any(IsOverflowException);
+
+            return false;
         }
     }
 }

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -17,57 +17,37 @@ namespace Snowflake.Data.Core
             SFResultSetMetaData metaData = resultSet.sfResultSetMetaData;
             SFStatementType statementType = metaData.statementType;
 
-            try
+            long updateCount = 0;
+            switch (statementType)
             {
-                int updateCount = 0;
-                switch (statementType)
-                {
-                    case SFStatementType.INSERT:
-                    case SFStatementType.UPDATE:
-                    case SFStatementType.DELETE:
-                    case SFStatementType.MERGE:
-                    case SFStatementType.MULTI_INSERT:
-                        for (int i = 0; i < resultSet.columnCount; i++)
-                        {
-                            updateCount += resultSet.GetValue<int>(i);
-                        }
+                case SFStatementType.INSERT:
+                case SFStatementType.UPDATE:
+                case SFStatementType.DELETE:
+                case SFStatementType.MERGE:
+                case SFStatementType.MULTI_INSERT:
+                    for (int i = 0; i < resultSet.columnCount; i++)
+                    {
+                        updateCount += resultSet.GetValue<long>(i);
+                    }
 
-                        break;
-                    case SFStatementType.COPY:
-                        var index = resultSet.sfResultSetMetaData.getColumnIndexByName("rows_loaded");
-                        if (index >= 0) updateCount = resultSet.GetValue<int>(index);
-                        break;
-                    case SFStatementType.SELECT:
-                        updateCount = -1;
-                        break;
-                    default:
-                        updateCount = 0;
-                        break;
-                }
-
-                return updateCount;
+                    break;
+                case SFStatementType.COPY:
+                    var index = resultSet.sfResultSetMetaData.getColumnIndexByName("rows_loaded");
+                    if (index >= 0) updateCount = resultSet.GetValue<long>(index);
+                    break;
+                case SFStatementType.SELECT:
+                    updateCount = -1;
+                    break;
+                default:
+                    updateCount = 0;
+                    break;
             }
-            catch (Exception ex)
-            {
-                if (IsOverflowException(ex))
-                    return -1;
 
-                throw;
-            }
-        }
+            if (updateCount > int.MaxValue)
+                return -1;
 
-        private static bool IsOverflowException(Exception ex)
-        {
-            if (ex is OverflowException)
-                return true;
+            return (int)updateCount;
 
-            if (ex.InnerException != null)
-                return IsOverflowException(ex.InnerException);
-
-            if (ex is AggregateException aggEx)
-                return aggEx.InnerExceptions.Any(IsOverflowException);
-
-            return false;
         }
     }
 }


### PR DESCRIPTION
I searched but I was not able to figure out the recommended driver behavior for this case.

I opted to return -1 if more than int.MaxValue rows were mutated and an OverflowException was generated. This may be non-standard behavior and you should probably confirm what the expected behavior for a .NET driver is in this case.