### PR TITLE
Update the masterToken on refresh.

### DIFF
--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -242,6 +242,7 @@ namespace Snowflake.Data.Core
             else 
             {
                 sessionToken = response.data.sessionToken;
+                masterToken = response.data.masterToken;
             }
         }
 


### PR DESCRIPTION
The refreshSession method was not updating the masterToken of the session from the response.

This resulted in a new 1 hour validity sessionToken being used, but after 4 hours being unable to renew the session again.

By updating the masterToken from the response a new 4 hour sliding window is obtained each time resfreshSession is called.

Tested w/ single a connection that was able to continue to be used for over 24 hours. Fixes #74 