### PR TITLE
Fix SFDbDataReaderIT.testGetDateTime on time zones ahead of UTC

### DIFF
--- a/Snowflake.Data.Tests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/SFDbDataReaderIT.cs
@@ -153,7 +153,7 @@ namespace Snowflake.Data.Tests
                 int count = cmd.ExecuteNonQuery();
                 Assert.AreEqual(0, count);
 
-                DateTime today = DateTime.Today;
+                DateTime today = DateTime.UtcNow.Date;
                 DateTime now = DateTime.Now;
 
                 string insertCommand = "insert into testgetdatetime values (?, ?)";


### PR DESCRIPTION
Fix for #79.