### PR TITLE
Fir fox #106

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -2,6 +2,9 @@
  * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
  */
 
+using System;
+using System.Data;
+
 namespace Snowflake.Data.Tests
 {
     using Snowflake.Data.Core;
@@ -29,6 +32,39 @@ namespace Snowflake.Data.Tests
             });
             testThread.Start();
             testThread.Join();
+        }
+
+        private static readonly DateTime[] _testConvertDatetimeInputData =
+        {
+            new DateTime(2019, 2, 4, 15, 30, 1, 123),
+            new DateTime(1982, 1, 18, 16, 20, 00, 666),
+            /* This test and conversion will fail if not-even-seconds before unix epoch are used.
+            new DateTime(1900, 9, 3).AddTicks(1), */
+            new DateTime(2100, 1, 1, 1, 1, 1, 1).AddTicks(1)
+        };
+
+        [Test]
+        [TestCase("2100-12-31 23:59:59.9999999")]
+        //[TestCase("9999-12-31 23:59:59.9999999")] fails
+        [TestCase("1982-01-18 16:20:00.6666666")]
+        [TestCase(null)]
+        public void TestConvertDatetime(string inputTimeStr)
+        {
+            DateTime inputTime;
+            if (inputTimeStr == null)
+            {
+                inputTime = DateTime.Now;
+            }
+            else
+            {
+                inputTime = DateTime.ParseExact(inputTimeStr, "yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
+            }
+
+            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var tickDiff = inputTime.Ticks - unixEpoch.Ticks;
+            var inputStringAsItWasFromDatabase = (tickDiff / 10000000.0m).ToString(CultureInfo.InvariantCulture);
+            var result = SFDataConverter.ConvertToCSharpVal(inputStringAsItWasFromDatabase, SFDataType.TIMESTAMP_NTZ, typeof(DateTime));
+            Assert.AreEqual(inputTime, result);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -30,7 +30,7 @@ namespace Snowflake.Data.Client
             this.dbCommand = command;
             this.resultSet = resultSet;
             this.isClosed = false;
-            this.SchemaTable = PopuldateSchemaTable(resultSet);
+            this.SchemaTable = PopulateSchemaTable(resultSet);
         }
         public override object this[string name]
         {
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Client
             return this.SchemaTable;
         }
 
-        private DataTable PopuldateSchemaTable(SFBaseResultSet resultSet)
+        private DataTable PopulateSchemaTable(SFBaseResultSet resultSet)
         {
             var table = new DataTable("SchemaTable");
 

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -133,8 +133,18 @@ namespace Snowflake.Data.Core
             }
             else
             {
-                return Tuple.Create(Int64.Parse(srcVal.Substring(0, dotIndex)), 
-                    Int64.Parse(srcVal.Substring(dotIndex+1, srcVal.Length-dotIndex-1)));
+                var intPart = Int64.Parse(srcVal.Substring(0, dotIndex));
+                var decimalPartLength = srcVal.Length - dotIndex - 1;
+                var decimalPartStr = srcVal.Substring(dotIndex + 1, decimalPartLength);
+                var decimalPart = Int64.Parse(decimalPartStr);
+                // If the decimal part contained less than nine characters, we must convert the value to nanoseconds by
+                // multiplying by 10^[precision difference].
+                if (decimalPartLength < 9)
+                {
+                    decimalPart *= (int) Math.Pow(10, 9 - decimalPartLength);
+                }
+
+                return Tuple.Create(intPart, decimalPart);                
             }
         }
 


### PR DESCRIPTION
There was a rather severe bug in SFDataConverter method ExtractTimestamp. It takes a string as input which is actually a decimal number where integer part is seconds since Unix epoch and decimal part is the fraction part as-is. However, the method assumes that the fraction part is always nine decimals long, but in our setup it depends on the precision of the underlying column. If the decimal part is e.g. 123 with precision 3 (milliseconds) it gets converted into 123 nanoseconds, i.e. 0 milliseconds. It should get converted into 123000000 nanoseconds instead.

This pull requests provides a fix for the method.

While improving tests related to the fix I found that the connector, Snowflake server (3.12.0) and/or snowsql Windows client (v1.1.73) has trouble handling date(time)s that represent time before the unix epoch. Or dates closing the "magic" year 9999. I added test cases for them as well but commented them out as I was not able to provide solutions for them. I tried to find out how to file a snowsql bug could not find a better way than this:
https://snowflakecommunity.force.com/s/question/0D50Z00008qFUXwSAO/

Although my fix does not solve all problems related to date and time parsing I hope at least parsing the post unix epoch -> present dates with lesser accuracy are parsed right, pretty please fix it asap.