### PR TITLE
#111 Fix handling large DateTime values

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -34,18 +34,10 @@ namespace Snowflake.Data.Tests
             testThread.Join();
         }
 
-        private static readonly DateTime[] _testConvertDatetimeInputData =
-        {
-            new DateTime(2019, 2, 4, 15, 30, 1, 123),
-            new DateTime(1982, 1, 18, 16, 20, 00, 666),
-            /* This test and conversion will fail if not-even-seconds before unix epoch are used.
-            new DateTime(1900, 9, 3).AddTicks(1), */
-            new DateTime(2100, 1, 1, 1, 1, 1, 1).AddTicks(1)
-        };
-
         [Test]
         [TestCase("2100-12-31 23:59:59.9999999")]
-        //[TestCase("9999-12-31 23:59:59.9999999")] fails
+        [TestCase("2200-01-01 11:22:33.4455667")]
+        [TestCase("9999-12-31 23:59:59.9999999")]
         [TestCase("1982-01-18 16:20:00.6666666")]
         [TestCase(null)]
         public void TestConvertDatetime(string inputTimeStr)

--- a/Snowflake.Data.Tests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/SFDbDataReaderIT.cs
@@ -3,7 +3,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Data.Common;
 using System.Data;
@@ -144,58 +143,15 @@ namespace Snowflake.Data.Tests
 
         [Test]
         [TestCase(null)]
-        //[TestCase("9999-12-31 23:59:59.9999999")] fails
+        [TestCase("9999-12-31 23:59:59.9999999")]
         [TestCase("1982-01-18 16:20:00.6666666")]
-        // [TestCase("1969-07-21 02:56:15.1234567")] fails
+        //[TestCase("1969-07-21 02:56:15.1234567")] fails, dates with time before unix epoch are parsed wrong
         [TestCase("1900-09-03 12:12:12.1212121")]
         public void TestGetDate(string inputTimeStr)
         {
             testGetDateAndOrTime(inputTimeStr, null, SFDataType.DATE);
         }
 
-        /*
-        [Test]
-        public void testGetDate()
-        {
-            using (IDbConnection conn = new SnowflakeDbConnection())
-            {
-                conn.ConnectionString = connectionString;
-                conn.Open();
-
-                IDbCommand cmd = conn.CreateCommand();
-                cmd.CommandText = "create or replace table testGetDate(cola date);";
-                int count = cmd.ExecuteNonQuery();
-                Assert.AreEqual(0, count);
-
-                DateTime today = DateTime.UtcNow.Date;
-
-                string insertCommand = "insert into testGetDate values (?)";
-                cmd.CommandText = insertCommand;
-
-                var p1 = cmd.CreateParameter();
-                p1.ParameterName = "1";
-                p1.Value = today;
-                p1.DbType = DbType.Date;
-                cmd.Parameters.Add(p1);
-
-                count = cmd.ExecuteNonQuery();
-                Assert.AreEqual(1, count);
-
-                cmd.CommandText = "select * from testGetDate";
-                IDataReader reader = cmd.ExecuteReader();
-
-                Assert.IsTrue(reader.Read());
-                Assert.AreEqual(0, DateTime.Compare(today, reader.GetDateTime(0)));
-                Assert.AreEqual(today.ToString("yyyy-MM-dd"), reader.GetString(0));
-                reader.Close();
-
-                cmd.CommandText = "drop table if exists testGetDate";
-                count = cmd.ExecuteNonQuery();
-                Assert.AreEqual(0, count);
-
-                conn.Close();
-            }
-        } */
 
         [Test]
         [TestCase(null, null)]
@@ -309,14 +265,14 @@ namespace Snowflake.Data.Tests
         [TestCase(null, 3)]
         [TestCase("2100-12-31 23:59:59.9999999", null)]
         [TestCase("2100-12-31 23:59:59.9999999", 5)]
-        //[TestCase("9999-12-31 23:59:59.9999999", null)] fails
-        //[TestCase("9999-12-31 23:59:59.9999999", 5)] fails
+        [TestCase("9999-12-30 23:59:59.9999999", null)]
+        [TestCase("9999-12-30 23:59:59.9999999", 5)]
         [TestCase("1982-01-18 16:20:00.6666666", null)]
         [TestCase("1982-01-18 16:20:00.6666666", 3)]
-        //[TestCase("1969-07-21 02:56:15.1234567", null)] fails
-        //[TestCase("1969-07-21 02:56:15.1234567", 1)] fails
-        //[TestCase("1900-09-03 12:12:12.1212121", null)] fails
-        //[TestCase("1900-09-03 12:12:12.1212121", 1)] fails
+        //[TestCase("1969-07-21 02:56:15.1234567", null)] //parsing fails with dates with second fractions before the unix epoch
+        [TestCase("1969-07-21 02:56:15.0000000", 1)] //dates w/o second fractions before the unix epoch are fine
+        //[TestCase("1900-09-03 12:12:12.1212121", null)] // fails
+        [TestCase("1900-09-03 12:12:12.0000000", 1)]
         public void testGetTimestampNTZ(string inputTimeStr, int? precision)
         {
             testGetDateAndOrTime(inputTimeStr, precision, SFDataType.TIMESTAMP_NTZ);

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -94,7 +94,8 @@ namespace Snowflake.Data.Core
                 case SFDataType.TIMESTAMP_NTZ:
 
                     Tuple<long, long> secAndNsec = ExtractTimestamp(srcVal);
-                    return UnixEpoch.AddTicks((long)(secAndNsec.Item1 * 1000 * 1000 * 1000 + secAndNsec.Item2) / 100);
+                    var tickDiff = secAndNsec.Item1 * 10000000L + secAndNsec.Item2 / 100L;
+                    return UnixEpoch.AddTicks(tickDiff);
 
                 default:
                     throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcType, typeof(DateTime));
@@ -235,8 +236,10 @@ namespace Snowflake.Data.Core
                     }
                     else
                     {
-                        DateTime srcDt = ((DateTime)srcVal);
-                        destVal = ((long)(srcDt.Subtract(UnixEpoch).Ticks * 100)).ToString();
+                        DateTime srcDt = (DateTime)srcVal;
+                        var diff = srcDt.Subtract(UnixEpoch);
+                        var tickDiff = diff.Ticks;
+                        destVal = $"{tickDiff}00"; // Cannot multiple tickDiff by 100 because long might overflow.
                     }
                     break;
                 


### PR DESCRIPTION
When providing fix for #103 in PR #104 (also #110 related because of merge conflicts) I found that there are also other problems related to handling DateTime values. I was kind of hoping that you'd dig in to them and fix them but you didn't so far so here it goes.

I just filed in a separate issue #111 of problems related to large DateTime values and I am providing fix for the issue in this PR. Without these fixes both in inserting to database and reading from it will result in overflowing long value. These changes help avoiding them.

Also removed a test I earlier commented out after replacing it with another one.