### PR TITLE
Add SERVICE_NAME support to .NET

### DIFF
--- a/Snowflake.Data.Tests/Mock/MockRestSessionExpired.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestSessionExpired.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Data.Tests.Mock
 {
     using Snowflake.Data.Core;
 
-    class MockRestSessionExpired : IRestRequest
+    class MockRestSessionExpired : IRestRequester
     {
         static private readonly String EXPIRED_SESSION_TOKEN="session_expired_token";
 
@@ -23,9 +23,10 @@ namespace Snowflake.Data.Tests.Mock
 
         public MockRestSessionExpired() { }
 
-        public Task<T> PostAsync<T>(SFRestRequest postRequest, CancellationToken cancellationToken)
+        public Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            if (postRequest.jsonBody is AuthnRequest)
+            SFRestRequest sfRequest = (SFRestRequest)request;
+            if (sfRequest.jsonBody is AuthnRequest)
             {
                 AuthnResponse authnResponse = new AuthnResponse
                 {
@@ -42,9 +43,9 @@ namespace Snowflake.Data.Tests.Mock
                 // login request return success
                 return Task.FromResult<T>((T)(object)authnResponse);
             }
-            else if (postRequest.jsonBody is QueryRequest)
+            else if (sfRequest.jsonBody is QueryRequest)
             {
-                if (postRequest.authorizationToken.Equals(String.Format(TOKEN_FMT, EXPIRED_SESSION_TOKEN)))
+                if (sfRequest.authorizationToken.Equals(String.Format(TOKEN_FMT, EXPIRED_SESSION_TOKEN)))
                 {
                     QueryExecResponse queryExecResponse = new QueryExecResponse
                     {
@@ -53,7 +54,7 @@ namespace Snowflake.Data.Tests.Mock
                     };
                     return Task.FromResult<T>((T)(object)queryExecResponse);
                 }
-                else if (postRequest.authorizationToken.Equals(String.Format(TOKEN_FMT, "new_session_token")))
+                else if (sfRequest.authorizationToken.Equals(String.Format(TOKEN_FMT, "new_session_token")))
                 {
                     QueryExecResponse queryExecResponse = new QueryExecResponse
                     {
@@ -84,7 +85,7 @@ namespace Snowflake.Data.Tests.Mock
                     return Task.FromResult<T>((T)(object)queryExecResponse);
                 }
             }
-            else if (postRequest.jsonBody is RenewSessionRequest)
+            else if (sfRequest.jsonBody is RenewSessionRequest)
             {
                 return Task.FromResult<T>((T)(object)new RenewSessionResponse
                 {
@@ -102,22 +103,22 @@ namespace Snowflake.Data.Tests.Mock
             }
         }
 
-        public T Post<T>(SFRestRequest postRequest)
+        public T Post<T>(IRestRequest postRequest)
         {
             return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
         }
 
-        public T Get<T>(SFRestRequest request)
+        public T Get<T>(IRestRequest request)
         {
             return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
         }
 
-        public Task<T> GetAsync<T>(SFRestRequest request, CancellationToken cancellationToken)
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
             return Task.FromResult<T>((T)(object)null);
         }
 
-        public Task<HttpResponseMessage> GetAsync(S3DownloadRequest request, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
         {
             return Task.FromResult<HttpResponseMessage>(null);
         }

--- a/Snowflake.Data.Tests/Mock/MockRestSessionExpiredInQueryExec.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestSessionExpiredInQueryExec.cs
@@ -12,7 +12,7 @@ namespace Snowflake.Data.Tests.Mock
 {
     using Snowflake.Data.Core;
 
-    class MockRestSessionExpiredInQueryExec : IRestRequest
+    class MockRestSessionExpiredInQueryExec : IRestRequester
     {
         static private readonly int QUERY_IN_EXEC_CODE = 333333;
 
@@ -22,9 +22,10 @@ namespace Snowflake.Data.Tests.Mock
 
         public MockRestSessionExpiredInQueryExec() { }
 
-        public Task<T> PostAsync<T>(SFRestRequest postRequest, CancellationToken cancellationToken)
+        public Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            if (postRequest.jsonBody is AuthnRequest)
+            SFRestRequest sfRequest = (SFRestRequest)request;
+            if (sfRequest.jsonBody is AuthnRequest)
             {
                 AuthnResponse authnResponse = new AuthnResponse
                 {
@@ -41,7 +42,7 @@ namespace Snowflake.Data.Tests.Mock
                 // login request return success
                 return Task.FromResult<T>((T)(object)authnResponse);
             }
-            else if (postRequest.jsonBody is QueryRequest)
+            else if (sfRequest.jsonBody is QueryRequest)
             {
                 QueryExecResponse queryExecResponse = new QueryExecResponse
                 {
@@ -51,7 +52,7 @@ namespace Snowflake.Data.Tests.Mock
                 return Task.FromResult<T>((T)(object)queryExecResponse);
                 
             }
-            else if (postRequest.jsonBody is RenewSessionRequest)
+            else if (sfRequest.jsonBody is RenewSessionRequest)
             {
                 return Task.FromResult<T>((T)(object)new RenewSessionResponse
                 {
@@ -68,18 +69,19 @@ namespace Snowflake.Data.Tests.Mock
             }
         }
 
-        public T Post<T>(SFRestRequest postRequest)
+        public T Post<T>(IRestRequest postRequest)
         {
             return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
         }
 
-        public T Get<T>(SFRestRequest request)
+        public T Get<T>(IRestRequest request)
         {
             return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
         }
 
-        public Task<T> GetAsync<T>(SFRestRequest request, CancellationToken cancellationToken)
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
+            SFRestRequest sfRequest = (SFRestRequest)request;
             if (getResultCallCount == 0)
             {
                 getResultCallCount++;
@@ -100,8 +102,8 @@ namespace Snowflake.Data.Tests.Mock
                 };
                 return Task.FromResult<T>((T)(object)queryExecResponse);
             }
-            else if (getResultCallCount == 2 && 
-                request.authorizationToken.Equals("Snowflake Token=\"new_session_token\""))
+            else if (getResultCallCount == 2 &&
+                sfRequest.authorizationToken.Equals("Snowflake Token=\"new_session_token\""))
             {
                 getResultCallCount++;
                 QueryExecResponse queryExecResponse = new QueryExecResponse
@@ -134,7 +136,7 @@ namespace Snowflake.Data.Tests.Mock
             }
         }
 
-        public Task<HttpResponseMessage> GetAsync(S3DownloadRequest request, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
         {
             return Task.FromResult<HttpResponseMessage>(null);
         }

--- a/Snowflake.Data.Tests/Mock/MockServiceName.cs
+++ b/Snowflake.Data.Tests/Mock/MockServiceName.cs
@@ -16,31 +16,6 @@ namespace Snowflake.Data.Tests.Mock
         public const string INIT_SERVICE_NAME = "init";
         public Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            return PrepareResponse<T>(HttpMethod.Post, request, cancellationToken);
-        }
-
-        public T Post<T>(IRestRequest postRequest)
-        {
-            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
-        }
-
-        public T Get<T>(IRestRequest request)
-        {
-            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
-        }
-
-        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
-        {
-            return PrepareResponse<T>(HttpMethod.Get, request, cancellationToken);
-        }
-
-        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<HttpResponseMessage>(null);
-        }
-
-        private Task<T> PrepareResponse<T>(HttpMethod method, IRestRequest request, CancellationToken cancellationToken)
-        {
             var message = request.ToRequestMessage(HttpMethod.Post);
             var param = new NameValueParameter { name = "SERVICE_NAME" };
             if (!message.Headers.Contains("X-Snowflake-Service"))
@@ -101,7 +76,27 @@ namespace Snowflake.Data.Tests.Mock
                 return Task.FromResult<T>((T)(object)null);
             }
 
+       
         }
 
+        public T Post<T>(IRestRequest postRequest)
+        {
+            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
+        }
+
+        public T Get<T>(IRestRequest request)
+        {
+            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
+        }
+
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<T>((T)(object)null);
+        }
+
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<HttpResponseMessage>(null);
+        }
     }
 }

--- a/Snowflake.Data.Tests/Mock/MockServiceName.cs
+++ b/Snowflake.Data.Tests/Mock/MockServiceName.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ */
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+
+namespace Snowflake.Data.Tests.Mock
+{
+    using Snowflake.Data.Core;
+
+    class MockServiceName : IRestRequester
+    {
+        public const string INIT_SERVICE_NAME = "init";
+        public Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return PrepareResponse<T>(HttpMethod.Post, request, cancellationToken);
+        }
+
+        public T Post<T>(IRestRequest postRequest)
+        {
+            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
+        }
+
+        public T Get<T>(IRestRequest request)
+        {
+            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
+        }
+
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return PrepareResponse<T>(HttpMethod.Get, request, cancellationToken);
+        }
+
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<HttpResponseMessage>(null);
+        }
+
+        private Task<T> PrepareResponse<T>(HttpMethod method, IRestRequest request, CancellationToken cancellationToken)
+        {
+            var message = request.ToRequestMessage(HttpMethod.Post);
+            var param = new NameValueParameter { name = "SERVICE_NAME" };
+            if (!message.Headers.Contains("X-Snowflake-Service"))
+            {
+                param.value = INIT_SERVICE_NAME;
+            }
+            else
+            {
+                IEnumerable<string> headerValues = message.Headers.GetValues("X-Snowflake-Service");
+                foreach (string value in headerValues)
+                {
+                    param.value = value + 'a';
+                }
+            }
+
+            SFRestRequest sfRequest = (SFRestRequest)request;
+            if (sfRequest.jsonBody is AuthnRequest)
+            {
+                AuthnResponse authnResponse = new AuthnResponse
+                {
+                    data = new AuthnResponseData()
+                    {
+                        token = "session_token",
+                        masterToken = "master_token",
+                        authResponseSessionInfo = new SessionInfo(),
+                        nameValueParameter = new List<NameValueParameter>() { param }
+                    },
+                    success = true
+                };
+
+                // login request return success
+                return Task.FromResult<T>((T)(object)authnResponse);
+            }
+            else if (sfRequest.jsonBody is QueryRequest)
+            {
+
+                QueryExecResponse queryExecResponse = new QueryExecResponse
+                {
+                    success = true,
+                    data = new QueryExecResponseData
+                    {
+                        rowSet = new string[,] { { "1" } },
+                        rowType = new List<ExecResponseRowType>()
+                            {
+                                new ExecResponseRowType
+                                {
+                                    name = "colone",
+                                    type = "FIXED"
+                                }
+                            },
+                        parameters = new List<NameValueParameter> { param }
+                    }
+                };
+                return Task.FromResult<T>((T)(object)queryExecResponse);
+            }
+            else
+            {
+                return Task.FromResult<T>((T)(object)null);
+            }
+
+        }
+
+    }
+}

--- a/Snowflake.Data.Tests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/SFStatementTest.cs
@@ -17,10 +17,10 @@ namespace Snowflake.Data.Tests
         [Test]
          public void TestSessionRenew()
         {
-            Mock.MockRestSessionExpired rest = new Mock.MockRestSessionExpired();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, rest);
+            Mock.MockRestSessionExpired restRequester = new Mock.MockRestSessionExpired();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
             sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession, rest);
+            SFStatement statement = new SFStatement(sfSession, restRequester);
             SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false);
             Assert.AreEqual(true, resultSet.Next());
             Assert.AreEqual("1", resultSet.GetString(0));
@@ -31,10 +31,10 @@ namespace Snowflake.Data.Tests
         [Test]
         public void TestSessionRenewDuringQueyrExec()
         {
-            Mock.MockRestSessionExpiredInQueryExec rest = new Mock.MockRestSessionExpiredInQueryExec();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, rest);
+            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
             sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession, rest);
+            SFStatement statement = new SFStatement(sfSession, restRequester);
             SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false);
             Assert.AreEqual(true, resultSet.Next());
             Assert.AreEqual("1", resultSet.GetString(0));

--- a/Snowflake.Data.Tests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/SFStatementTest.cs
@@ -9,13 +9,14 @@ namespace Snowflake.Data.Tests
     using System;
 
     /**
-     * Mock rest request to test session renew
+     * Mock rest request test
      */
     [TestFixture]
     class SFStatementTest
     {
+        // Mock test for session token renew
         [Test]
-         public void TestSessionRenew()
+        public void TestSessionRenew()
         {
             Mock.MockRestSessionExpired restRequester = new Mock.MockRestSessionExpired();
             SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
@@ -28,8 +29,9 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual("new_master_token", sfSession.masterToken);
         }
 
+        // Mock test for session renew during query execution
         [Test]
-        public void TestSessionRenewDuringQueyrExec()
+        public void TestSessionRenewDuringQueryExec()
         {
             Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
             SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
@@ -38,6 +40,27 @@ namespace Snowflake.Data.Tests
             SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false);
             Assert.AreEqual(true, resultSet.Next());
             Assert.AreEqual("1", resultSet.GetString(0));
+        }
+
+        // Mock test for Service Name
+        // The Mock requester would take in the X-Snowflake-Service header in the request
+        // and append a character 'a' at the end, send back as SERVICE_NAME parameter
+        // This test is to assure that SETVICE_NAME parameter would be upgraded to the session
+        [Test]
+        public void TestServiceName()
+        {
+            var restRequester = new Mock.MockServiceName();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            string expectServiceName = Mock.MockServiceName.INIT_SERVICE_NAME;
+            Assert.AreEqual(expectServiceName, sfSession.ParameterMap[SFSessionParameter.SERVICE_NAME]);
+            for (int i = 0; i < 5; i++)
+            {
+                SFStatement statement = new SFStatement(sfSession, restRequester);
+                SFBaseResultSet resultSet = statement.Execute(0, "SELECT 1", null, false);
+                expectServiceName += "a";
+                Assert.AreEqual(expectServiceName, sfSession.ParameterMap[SFSessionParameter.SERVICE_NAME]);
+            }
         }
     }
 }

--- a/Snowflake.Data.Tests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/SFStatementTest.cs
@@ -6,7 +6,6 @@ namespace Snowflake.Data.Tests
 {
     using Snowflake.Data.Core;
     using NUnit.Framework;
-    using System;
 
     /**
      * Mock rest request test

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -5,28 +5,44 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace Snowflake.Data.Core
 {
-    public interface IRestRequest
+    /**
+     * The RestRequester is responsible to send out a rest request and receive response
+     */
+    public interface IRestRequester
     {
-        Task<T> PostAsync<T>(SFRestRequest postRequest, CancellationToken cancellationToken);
+        Task<T> PostAsync<T>(IRestRequest postRequest, CancellationToken cancellationToken);
 
-        T Post<T>(SFRestRequest postRequest);
+        T Post<T>(IRestRequest postRequest);
 
-        T Get<T>(SFRestRequest request);
+        T Get<T>(IRestRequest request);
 
-        Task<T> GetAsync<T>(SFRestRequest request, CancellationToken cancellationToken);
+        Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken);
 
-        Task<HttpResponseMessage> GetAsync(S3DownloadRequest request, CancellationToken cancellationToken);
+        Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken);
     }
 
-    public class S3DownloadRequest
+    public interface IRestRequest
     {
+        HttpRequestMessage ToRequestMessage(HttpMethod method);
+        TimeSpan RestTimeout();
+    }
+
+    public class S3DownloadRequest : IRestRequest
+    {
+        private const string SSE_C_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm";
+
+        private const string SSE_C_KEY = "x-amz-server-side-encryption-customer-key";
+
+        private const string SSE_C_AES = "AES256";
+
         internal Uri uri{ get; set; }
 
         internal string qrmk { get; set; }
@@ -38,10 +54,39 @@ namespace Snowflake.Data.Core
         internal TimeSpan httpRequestTimeout { get; set; }
 
         internal Dictionary<string, string> chunkHeaders { get; set; }
+
+        public HttpRequestMessage ToRequestMessage(HttpMethod method)
+        {
+            HttpRequestMessage message = new HttpRequestMessage(method, uri);
+            if (chunkHeaders != null)
+            {
+                foreach (var item in chunkHeaders)
+                {
+                    message.Headers.Add(item.Key, item.Value);
+                }
+            } else
+            {
+                message.Headers.Add(SSE_C_ALGORITHM, SSE_C_AES);
+                message.Headers.Add(SSE_C_KEY, qrmk);
+            }
+
+            message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = httpRequestTimeout;
+
+            return message;
+        }
+
+        public TimeSpan RestTimeout()
+        {
+            return timeout;
+        }
     }
 
-    public class SFRestRequest
+    public class SFRestRequest : IRestRequest
     {
+        private static MediaTypeWithQualityHeaderValue applicationSnowflake = new MediaTypeWithQualityHeaderValue("application/snowflake");
+
+        private const string SF_AUTHORIZATION_HEADER = "Authorization";
+
         public SFRestRequest()
         {
             sfRestRequestTimeout = Timeout.InfiniteTimeSpan;
@@ -55,17 +100,42 @@ namespace Snowflake.Data.Core
         internal Object jsonBody { get; set;  }
 
         internal String authorizationToken { get; set; }
+
+        internal String serviceName { get; set; }
         
         // timeout for the whole rest request in millis (adding up all http retry)
         internal TimeSpan sfRestRequestTimeout { get; set; }
         
         // timeout for each http request 
-        internal TimeSpan httpRequestTimeout { get; set; } 
+        internal TimeSpan httpRequestTimeout { get; set; }
 
         public override string ToString()
         {
             return String.Format("SFRestRequest {{url: {0}, request body: {1} }}", uri.ToString(), 
                 jsonBody.ToString());
+        }
+
+        public HttpRequestMessage ToRequestMessage(HttpMethod method)
+        {
+            var message = new HttpRequestMessage(method, uri);
+            if (method != HttpMethod.Get && jsonBody != null)
+            {
+                var json = JsonConvert.SerializeObject(jsonBody);
+                //TODO: Check if we should use other encodings...
+                message.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            message.Headers.Add(SF_AUTHORIZATION_HEADER, authorizationToken);
+            message.Headers.Accept.Add(applicationSnowflake);
+
+            message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = httpRequestTimeout;
+            
+            return message;
+        }
+
+        public TimeSpan RestTimeout()
+        {
+            return sfRestRequestTimeout;
         }
     }
 

--- a/Snowflake.Data/Core/IRestRequest.cs
+++ b/Snowflake.Data/Core/IRestRequest.cs
@@ -86,6 +86,7 @@ namespace Snowflake.Data.Core
         private static MediaTypeWithQualityHeaderValue applicationSnowflake = new MediaTypeWithQualityHeaderValue("application/snowflake");
 
         private const string SF_AUTHORIZATION_HEADER = "Authorization";
+        private const string SF_SERVICE_NAME_HEADER = "X-Snowflake-Service";
 
         public SFRestRequest()
         {
@@ -126,6 +127,10 @@ namespace Snowflake.Data.Core
             }
 
             message.Headers.Add(SF_AUTHORIZATION_HEADER, authorizationToken);
+            if (serviceName != null)
+            {
+                message.Headers.Add(SF_SERVICE_NAME_HEADER, serviceName);
+            }
             message.Headers.Accept.Add(applicationSnowflake);
 
             message.Properties["TIMEOUT_PER_HTTP_REQUEST"] = httpRequestTimeout;

--- a/Snowflake.Data/Core/SFBlockingChunkDownloader.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloader.cs
@@ -38,7 +38,7 @@ namespace Snowflake.Data.Core
 
         private readonly int prefetchThreads;
 
-        private static IRestRequest restRequest = RestRequestImpl.Instance;
+        private static IRestRequester restRequester = RestRequesterImpl.Instance;
 
         private Dictionary<string, string> chunkHeaders;
 
@@ -127,7 +127,7 @@ namespace Snowflake.Data.Core
                 chunkHeaders = downloadContext.chunkHeaders
             };
 
-            var httpResponse = await restRequest.GetAsync(downloadRequest, downloadContext.cancellationToken);
+            var httpResponse = await restRequester.GetAsync(downloadRequest, downloadContext.cancellationToken);
             Stream stream = httpResponse.Content.ReadAsStreamAsync().Result;
             IEnumerable<string> encoding;
             //TODO this shouldn't be required.

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -37,7 +37,7 @@ namespace Snowflake.Data.Core
 
         private readonly int prefetchSlot;
 
-        private static IRestRequest restRequest = RestRequestImpl.Instance;
+        private static IRestRequester restRequester = RestRequesterImpl.Instance;
 
         private Dictionary<string, string> chunkHeaders;
 
@@ -140,7 +140,7 @@ namespace Snowflake.Data.Core
                 chunkHeaders = downloadContext.chunkHeaders
             };
 
-            using (var httpResponse = await restRequest.GetAsync(downloadRequest, downloadContext.cancellationToken)
+            using (var httpResponse = await restRequester.GetAsync(downloadRequest, downloadContext.cancellationToken)
                            .ConfigureAwait(continueOnCapturedContext: false))
             using (Stream stream = await httpResponse.Content.ReadAsStreamAsync()
                 .ConfigureAwait(continueOnCapturedContext: false))

--- a/Snowflake.Data/Core/SFChunkDownloaderV2.cs
+++ b/Snowflake.Data/Core/SFChunkDownloaderV2.cs
@@ -30,7 +30,7 @@ namespace Snowflake.Data.Core
         //TODO: parameterize prefetch slot
         private const int prefetchSlot = 5;
         
-        private static IRestRequest restRequest = RestRequestImpl.Instance;
+        private static IRestRequester restRequester = RestRequesterImpl.Instance;
         
         private Dictionary<string, string> chunkHeaders;
 
@@ -130,7 +130,7 @@ namespace Snowflake.Data.Core
                 chunkHeaders = downloadContext.chunkHeaders
             };
 
-            var httpResponse = await restRequest.GetAsync(downloadRequest, downloadContext.cancellationToken).ConfigureAwait(false);
+            var httpResponse = await restRequester.GetAsync(downloadRequest, downloadContext.cancellationToken).ConfigureAwait(false);
             Stream stream = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
             if (httpResponse.Content.Headers.TryGetValues("Content-Encoding", out var encoding))

--- a/Snowflake.Data/Core/SFSessionParameter.cs
+++ b/Snowflake.Data/Core/SFSessionParameter.cs
@@ -10,6 +10,7 @@ namespace Snowflake.Data.Core
 {
     internal enum SFSessionParameter
     {
-        CLIENT_PREFETCH_THREADS
+        CLIENT_PREFETCH_THREADS,
+        SERVICE_NAME
     }
 }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -93,6 +93,8 @@ namespace Snowflake.Data.Core
             {
                 uri = queryUri,
                 authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, SfSession.sessionToken),
+                serviceName = SfSession.ParameterMap.ContainsKey(SFSessionParameter.SERVICE_NAME)
+                                ? SfSession.ParameterMap[SFSessionParameter.SERVICE_NAME] : null,
                 jsonBody = postBody,
                 httpRequestTimeout = Timeout.InfiniteTimeSpan
             };


### PR DESCRIPTION
This PR contains two commits:

1. Refactor RestRequest with: 1) changing its name to RestRequester; 2) Remove all logics of RestRequest from the requester to request (inversion of control), since RestRequester should know nothing about RestRequest.

2. Add SERVICE_NAME support so that it can read SERVICE_NAME parameter from the payload and send out the next request with a service name in the header.