### PR TITLE
Implement Dispose for Connection and Transaction.

### DIFF
--- a/Snowflake.Data.Tests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/SFDbTransactionIT.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
+ */
+
+namespace Snowflake.Data.Tests
+{
+    using NUnit.Framework;
+    using Snowflake.Data.Client;
+    using System.Data;
+
+    [TestFixture]
+    class SFDbTransactionIT : SFBaseTest
+    {
+        [Test]
+        // Test that when a transaction is disposed, rollback would be sent out
+        public void TestTransactionDispose()
+        {
+            var conn = new SnowflakeDbConnection();
+            try
+            {
+                conn.ConnectionString = connectionString;
+                conn.Open();
+
+                IDbCommand command = conn.CreateCommand();
+                command.CommandText = "create or replace table testTransactionDispose(c int)";
+                command.ExecuteNonQuery();
+
+                using (IDbTransaction t1 = conn.BeginTransaction())
+                {
+                    IDbCommand t1c1 = conn.CreateCommand();
+                    t1c1.Transaction = t1;
+                    t1c1.CommandText = "insert into testTransactionDispose values (1)";
+                    t1c1.ExecuteNonQuery();
+                }
+
+                // Transaction t1 would be disposed and rollback at this point, tuple inserted is not visible
+                IDbCommand c2 = conn.CreateCommand();
+                c2.CommandText = "SELECT * FROM testTransactionDispose";
+                IDataReader reader2 = c2.ExecuteReader();
+                Assert.IsFalse(reader2.Read());
+            }
+            finally
+            {
+                IDbCommand command = conn.CreateCommand();
+                command.CommandText = "DROP TABLE IF EXISTS testTransactionDispose";
+                command.ExecuteNonQuery();
+                conn.Close();
+            }
+        }
+    }
+}

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -27,6 +27,8 @@ namespace Snowflake.Data.Client
 
         private int _connectionTimeout;
 
+        private bool disposed = false;
+
         public SnowflakeDbConnection()
         {
             _connectionState = ConnectionState.Closed;
@@ -139,6 +141,22 @@ namespace Snowflake.Data.Client
         protected override DbCommand CreateDbCommand()
         {
             return new SnowflakeDbCommand(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+
+            this.Close();
+            disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        ~SnowflakeDbConnection()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -45,6 +45,11 @@ namespace Snowflake.Data.Client
             get; set;
         }
 
+        public bool IsOpen()
+        {
+            return _connectionState == ConnectionState.Open;
+        }
+
         public override string Database => _connectionState == ConnectionState.Open ? SfSession.database : string.Empty;
 
         public override int ConnectionTimeout => this._connectionTimeout;
@@ -100,7 +105,16 @@ namespace Snowflake.Data.Client
         {
             logger.Debug("Open Connection.");
             SetSession();
-            SfSession.Open();
+            try
+            {
+                SfSession.Open();
+            }
+            catch (Exception e)
+            {
+                // Otherwise when Dispose() is called, the close request would timeout.
+                _connectionState = ConnectionState.Closed;
+                throw e;
+            }
             OnSessionEstablished();
         }
         

--- a/Snowflake.Data/Client/SnowflakeDbTransaction.cs
+++ b/Snowflake.Data/Client/SnowflakeDbTransaction.cs
@@ -18,6 +18,8 @@ namespace Snowflake.Data.Client
 
         private SnowflakeDbConnection connection;
 
+        private bool disposed = false;
+
         public SnowflakeDbTransaction(IsolationLevel isolationLevel, SnowflakeDbConnection connection)
         {
             logger.Debug("Begin transaction.");
@@ -70,6 +72,23 @@ namespace Snowflake.Data.Client
                 command.CommandText = "ROLLBACK";
                 command.ExecuteNonQuery();
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+
+            // Snowflake can handle a rollback for a rollback without any transaction
+            this.Rollback();
+            disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        ~SnowflakeDbTransaction()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbTransaction.cs
+++ b/Snowflake.Data/Client/SnowflakeDbTransaction.cs
@@ -79,8 +79,12 @@ namespace Snowflake.Data.Client
             if (disposed)
                 return;
 
-            // Snowflake can handle a rollback for a rollback without any transaction
-            this.Rollback();
+            // Rollback the uncommitted transaction when the connection is open
+            if (connection != null && connection.IsOpen())
+            {
+                // When there is no uncommitted transaction, Snowflake would just ignore the rollback request;
+                this.Rollback();
+            }
             disposed = true;
 
             base.Dispose(disposing);


### PR DESCRIPTION
This PR is to resolve #20 and #64 
There are four classed that implements IDisposable interface:
1. Connection
2. Transaction
3. Command
4. DataReader

I only implemented Dispose() function for connection and transaction. The dispose would call close() and rollback() respectably.

Our Command and DataReader does not hold any resources so there is not need to override the Dispose() on them.