### PR TITLE
SNOW-76790 .Net dbDataReader RowsAffected issue

### DIFF
--- a/Snowflake.Data.Tests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/SFDbDataReaderIT.cs
@@ -21,6 +21,38 @@ namespace Snowflake.Data.Tests
         static private readonly Random rand = new Random();
 
         [Test]
+        public void testRecordsAffected()
+        {
+            using (IDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = connectionString;
+                conn.Open();
+
+                IDbCommand cmd = conn.CreateCommand();
+                cmd.CommandText = "create or replace table testRecordsAffected(cola number)";
+                int count = cmd.ExecuteNonQuery();
+                Assert.AreEqual(0, count);
+
+                string insertCommand = "insert into testRecordsAffected values (1),(1),(1)";
+                cmd.CommandText = insertCommand;
+                IDataReader reader = cmd.ExecuteReader();
+                Assert.AreEqual(3, reader.RecordsAffected);
+
+                // Reader's RecordsAffected should be available even if the reader is closed
+                reader.Close();
+                Assert.AreEqual(3, reader.RecordsAffected);
+
+                cmd.CommandText = "drop table if exists testRecordsAffected";
+                count = cmd.ExecuteNonQuery();
+                Assert.AreEqual(0, count);
+
+                // Reader's RecordsAffected should be available even if the connection is closed
+                conn.Close();
+                Assert.AreEqual(3, reader.RecordsAffected);
+            }
+        }
+
+        [Test]
         public void testGetNumber()
         {
             using (IDbConnection conn = new SnowflakeDbConnection())

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -157,7 +157,6 @@ namespace Snowflake.Data.Client
         {
             logger.Debug($"ExecuteNonQuery, command: {CommandText}");
             SFBaseResultSet resultSet = ExecuteInternal();
-            resultSet.Next();
             return resultSet.CalculateUpdateCount();
         }
 
@@ -168,7 +167,6 @@ namespace Snowflake.Data.Client
                 throw new TaskCanceledException();
 
             var resultSet = await ExecuteInternalAsync(cancellationToken);
-            await resultSet.NextAsync();
             return resultSet.CalculateUpdateCount();
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -31,7 +31,9 @@ namespace Snowflake.Data.Client
             this.resultSet = resultSet;
             this.isClosed = false;
             this.SchemaTable = PopulateSchemaTable(resultSet);
+            RecordsAffected = resultSet.CalculateUpdateCount();
         }
+
         public override object this[string name]
         {
             get
@@ -82,7 +84,7 @@ namespace Snowflake.Data.Client
             }
         }
 
-        public override int RecordsAffected => resultSet.CalculateUpdateCount();
+        public override int RecordsAffected { get; }
 
         public override DataTable GetSchemaTable()
         {

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -25,6 +25,7 @@ namespace Snowflake.Data.Core
                 case SFStatementType.DELETE:
                 case SFStatementType.MERGE:
                 case SFStatementType.MULTI_INSERT:
+                    resultSet.Next();
                     for (int i = 0; i < resultSet.columnCount; i++)
                     {
                         updateCount += resultSet.GetValue<long>(i);
@@ -32,6 +33,7 @@ namespace Snowflake.Data.Core
 
                     break;
                 case SFStatementType.COPY:
+                    resultSet.Next();
                     var index = resultSet.sfResultSetMetaData.getColumnIndexByName("rows_loaded");
                     if (index >= 0) updateCount = resultSet.GetValue<long>(index);
                     break;

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -128,8 +128,6 @@ namespace Snowflake.Data.Core
                 throw new SnowflakeDbException(SFError.COLUMN_INDEX_OUT_OF_BOUND, columnIndex);
             }
 
-            //Logger.DebugFmt("RowIndex: {0}, ColumnIndex:{1}, CurrentChunkIndex: {2}, CurrentChunkRowCount: {3}", 
-            //    _currentChunkRowIdx, columnIndex, _currentChunk.GetChunkIndex(), _currentChunk.GetRowCount());
             return _currentChunk.ExtractCell(_currentChunkRowIdx, columnIndex);
         }
 


### PR DESCRIPTION
Customers using ASP.NET EntityFramework would have exception because in the framework's codebase, the RecordsAffected property would be called even if the the reader is closed. See https://github.com/aspnet/EntityFrameworkCore/blob/master/src/EFCore.Relational/Storage/RelationalDataReader.cs#L115

This PR is to fetch RowsAffected earlier for dataReader.