### PR TITLE
SNOW-81118 Not being strict on some properties for DBParameter 

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbParameter.cs
+++ b/Snowflake.Data/Client/SnowflakeDbParameter.cs
@@ -3,10 +3,6 @@
  */
 
 using System.Data.Common;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System;
 using System.Data;
 using Snowflake.Data.Core;
@@ -17,15 +13,19 @@ namespace Snowflake.Data.Client
     {
         public SFDataType SFDataType { get; set; }
 
+        private SFDataType OriginType;
+
         public SnowflakeDbParameter()
         {
             SFDataType = SFDataType.None;
+            OriginType = SFDataType.None;
         }
 
         public SnowflakeDbParameter(string ParameterName, SFDataType SFDataType)
         {
             this.ParameterName = ParameterName;
             this.SFDataType = SFDataType;
+            OriginType = SFDataType;
         }
 
         public SnowflakeDbParameter(int ParameterIndex, SFDataType SFDataType)
@@ -52,75 +52,21 @@ namespace Snowflake.Data.Client
             }
         }
 
-        public override bool IsNullable
-        {
-            get { return false; }
+        public override bool IsNullable { get; set; }
 
-            set
-            {
-                if (value != false)
-                {
-                    throw new SnowflakeDbException(SFError.UNSUPPORTED_FEATURE);
-                }
-            }
-        }
+        public override string ParameterName { get; set; }
 
-        public override string ParameterName
-        {
-            get;
-            set;
-        }
+        public override int Size { get; set; }
 
-        public override int Size
-        {
-            get { return 0; }
+        public override string SourceColumn { get; set; }
 
-            set
-            {
-                if (value != 0)
-                {
-                    throw new SnowflakeDbException(SFError.UNSUPPORTED_FEATURE);
-                }
-            }
-        }
+        public override bool SourceColumnNullMapping { get; set; }
 
-        public override string SourceColumn
-        {
-            get { return null; }
-
-            set
-            {
-                if (value != null)
-                {
-                    throw new SnowflakeDbException(SFError.UNSUPPORTED_FEATURE);
-                }
-            }
-        }
-
-        public override bool SourceColumnNullMapping
-        {
-            get { return false; }
-
-            set
-            {
-                // ReSharper disable once RedundantBoolCompare (compare to false for clarity)
-                if (value != false)
-                {
-                    throw  new SnowflakeDbException(SFError.UNSUPPORTED_FEATURE);
-                }
-            }
-        }
-
-        public override object Value
-        {
-            get;
-
-            set;
-        }
+        public override object Value { get; set; }
 
         public override void ResetDbType()
         {
-            throw new NotImplementedException();
+            SFDataType = OriginType;
         }
     }
 }


### PR DESCRIPTION
This could unblock potential use case from frameworks such as EntityFrameworkCore.
[SqlServer .NET driver](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlparameter.value?view=netframework-4.8)  just pass through these properties.
