### PR TITLE
@SNOW-81851 add filter to ACCOUNT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ i.e "\<key1\>=\<value1\>;\<key2\>=\<value2\>...". The following table lists all 
 
 | Connection Property | Required | Comment                                                                       |
 |---------------------|----------|-------------------------------------------------------------------------------|
-| ACCOUNT             | Yes      | Account should not include region or clound provider information. i.e. account should be XXX instad of XXX.us-east-1.|
+| ACCOUNT             | Yes      | Account should not include region or clound provider information. i.e. account should be XXX instead of XXX.us-east-1.|
 | DB                  | No       |                                                                               |
-| HOST                | No       | If no value specified, driver will use \<ACCOUNT\>.snowflakecomputing.com. However, if you are not in us-west deployment, HOST is required, i.e. XXX.us-east-1.snowflakecomputing.com |
+| HOST                | No       | If no value specified, driver will use \<ACCOUNT\>.snowflakecomputing.com. However, if you are not in us-west deployment, or you want to use global url, HOST is required, i.e. XXX.us-east-1.snowflakecomputing.com, or XXX-jkabfvdjisoa778wqfgeruishafeuw89q.global.snowflakecomputing.com|
 | PASSWORD            | Depends  | Ignored for external browser, required for other authentication methods.      |
 | ROLE                | No       |                                                                               |
 | SCHEMA              | No       |                                                                               |
 | USER                | Yes      | For okta and externalbrowser, this should be the login name for your idp.     |
 | WAREHOUSE           | No       |                                                                               |
 | CONNECTION_TIMEOUT  | No       | Total timeout in seconds when connecting to Snowflake. Default to 120 seconds |
-| AUTHENTICATOR       | No       | The method of authentication. Currently support snowflake(default), [native SSO okta](https://docs.snowflake.net/manuals/user-guide/admin-security-fed-auth-use.html#native-sso-okta-only) and externalbrowser.  |
+| AUTHENTICATOR       | No       | The method of authentication. Currently support snowflake(default), [native SSO okta](https://docs.snowflake.net/manuals/user-guide/admin-security-fed-auth-use.html#native-sso-okta-only) and [externalbrowser](https://docs.snowflake.net/manuals/user-guide/admin-security-fed-auth-use.html#browser-based-sso).  |
 
 <br />
 

--- a/Snowflake.Data.Tests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/SFSessionPropertyTest.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * Copyright (c) 2019 Snowflake Computing Inc. All rights reserved.
+ */
+
+using Snowflake.Data.Core;
+using System.Security;
+using NUnit.Framework;
+
+namespace Snowflake.Data.Tests
+{
+    /// <summary>
+    /// The purpose of these testcases is to test if the connections string
+    /// can be parsed correctly into properties for a session.
+    /// </summary>
+    class SFSessionPropertyTest
+    {
+        private class Testcase
+        {
+            public string ConnectionString { get; set; }
+            public SecureString SecurePassword { get; set; }
+            public SFSessionProperties ExpectedProperties { get; set; }
+
+            public void TestValidCase()
+            {
+                SFSessionProperties actualProperties = SFSessionProperties.parseConnectionString(ConnectionString, SecurePassword);
+                Assert.AreEqual(actualProperties, ExpectedProperties);
+            }
+        }
+
+        [Test]
+        public void TestValidConnectionString()
+        {
+            Testcase[] testcases = new Testcase[]
+            {
+                new Testcase()
+                {
+                    ConnectionString = "ACCOUNT=testaccount;USER=testuser;PASSWORD=123;",
+                    ExpectedProperties = new SFSessionProperties()
+                    {
+                        { SFSessionProperty.ACCOUNT, "testaccount" },
+                        { SFSessionProperty.USER, "testuser" },
+                        { SFSessionProperty.HOST, "testaccount.snowflakecomputing.com" },
+                        { SFSessionProperty.AUTHENTICATOR, "snowflake" },
+                        { SFSessionProperty.SCHEME, "https" },
+                        { SFSessionProperty.CONNECTION_TIMEOUT, "0" },
+                        { SFSessionProperty.PASSWORD, "123" },
+                        { SFSessionProperty.PORT, "443" },
+                    },
+                },
+                new Testcase()
+                {
+                    ConnectionString = "ACCOUNT=testaccount-asdfopinwefinpoe.global;USER=testuser;PASSWORD=123;",
+                    ExpectedProperties = new SFSessionProperties()
+                    {
+                        { SFSessionProperty.ACCOUNT, "testaccount" },
+                        { SFSessionProperty.USER, "testuser" },
+                        { SFSessionProperty.HOST, "testaccount-asdfopinwefinpoe.global.snowflakecomputing.com" },
+                        { SFSessionProperty.AUTHENTICATOR, "snowflake" },
+                        { SFSessionProperty.SCHEME, "https" },
+                        { SFSessionProperty.CONNECTION_TIMEOUT, "0" },
+                        { SFSessionProperty.PASSWORD, "123" },
+                        { SFSessionProperty.PORT, "443" },
+                    },
+                }
+            };
+
+            foreach (Testcase testcase in testcases)
+            {
+                testcase.TestValidCase();
+            }
+        }
+    }
+}

--- a/Snowflake.Data.Tests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/SFSessionPropertyTest.cs
@@ -47,21 +47,6 @@ namespace Snowflake.Data.Tests
                         { SFSessionProperty.PORT, "443" },
                     },
                 },
-                new Testcase()
-                {
-                    ConnectionString = "ACCOUNT=testaccount-asdfopinwefinpoe.global;USER=testuser;PASSWORD=123;",
-                    ExpectedProperties = new SFSessionProperties()
-                    {
-                        { SFSessionProperty.ACCOUNT, "testaccount" },
-                        { SFSessionProperty.USER, "testuser" },
-                        { SFSessionProperty.HOST, "testaccount-asdfopinwefinpoe.global.snowflakecomputing.com" },
-                        { SFSessionProperty.AUTHENTICATOR, "snowflake" },
-                        { SFSessionProperty.SCHEME, "https" },
-                        { SFSessionProperty.CONNECTION_TIMEOUT, "0" },
-                        { SFSessionProperty.PASSWORD, "123" },
-                        { SFSessionProperty.PORT, "443" },
-                    },
-                }
             };
 
             foreach (Testcase testcase in testcases)

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -72,7 +72,8 @@ namespace Snowflake.Data.Core
                     }
                 }
                 return true;
-            } catch (InvalidCastException)
+            }
+            catch (InvalidCastException)
             {
                 logger.Warn("Invalid casting to SFSessionProperties");
                 return false;
@@ -108,7 +109,7 @@ namespace Snowflake.Data.Core
                     else
                     {
                         string invalidStringDetail = String.Format("Invalid key value pair {0}", keyVal);
-                        SnowflakeDbException e = new SnowflakeDbException(SFError.INVALID_CONNECTION_STRING, 
+                        SnowflakeDbException e = new SnowflakeDbException(SFError.INVALID_CONNECTION_STRING,
                             new object[] { invalidStringDetail });
                         logger.Error("Invalid string.", e);
                         throw e;
@@ -130,9 +131,7 @@ namespace Snowflake.Data.Core
                 logger.Info($"Compose host name: {hostName}");
             }
 
-            properties[SFSessionProperty.ACCOUNT] = ParseAccount(properties[SFSessionProperty.ACCOUNT]);
-
-            return properties; 
+            return properties;
         }
 
         private static void checkSessionProperties(SFSessionProperties properties)
@@ -143,12 +142,12 @@ namespace Snowflake.Data.Core
                 if (IsRequired(sessionProperty, properties) &&
                     !properties.ContainsKey(sessionProperty))
                 {
-                    SnowflakeDbException e = new SnowflakeDbException(SFError.MISSING_CONNECTION_PROPERTY, 
+                    SnowflakeDbException e = new SnowflakeDbException(SFError.MISSING_CONNECTION_PROPERTY,
                         sessionProperty);
                     logger.Error("Missing connetion property", e);
                     throw e;
                 }
-                
+
                 // add default value to the map
                 string defaultVal = sessionProperty.GetAttribute<SFSessionPropertyAttr>().defaultValue;
                 if (defaultVal != null && !properties.ContainsKey(sessionProperty))
@@ -170,26 +169,6 @@ namespace Snowflake.Data.Core
             {
                 return sessionProperty.GetAttribute<SFSessionPropertyAttr>().required;
             }
-        }
-
-        private static string ParseAccount(string rawAccount)
-        {
-            // filter the .<region> or .global
-            string parsedAccount = rawAccount;
-            int firstDot = parsedAccount.IndexOf('.');
-            if (firstDot != -1)
-            {
-                parsedAccount = parsedAccount.Substring(0, firstDot);
-            }
-
-            // filter the connection group
-            int firstDash = parsedAccount.IndexOf('-');
-            if (firstDash != -1)
-            {
-                parsedAccount = parsedAccount.Substring(0, firstDash);
-            }
-
-            return parsedAccount;
         }
     }
 


### PR DESCRIPTION
It would remove the connection group and the region name.
I did not change any document because the scope for the statement "hostname field is going to be deprecated" in [JIRA](https://snowflakecomputing.atlassian.net/browse/SNOW-76706). In that JIRA SnowSQL is going to be deprecate hostname, but not mentioning other drivers.

@smtakeda @notkriswagner Do we want every driver to follow that SnowSQL and deprecate hostname, using only account to specify the account, region and connection group?

If yes then I will change the document accordingly, otherwise I would not modify the document since we already encourage the customers to use hostname rather than account to form URL in our docs.