### PR TITLE
Improved memory usage and performance for SFBlockingChunkDownloaderV3 (fix for #159)

### DIFF
--- a/Snowflake.Data.Tests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/SFDbCommandIT.cs
@@ -229,6 +229,10 @@ namespace Snowflake.Data.Tests
             }
         }
 
+
+        /*
+         * Disabled to make sure that configuration changes does not cause problems with appveyor
+         * 
         [Test]
         public void TestUseV1ResultParser()
         {
@@ -251,6 +255,7 @@ namespace Snowflake.Data.Tests
                 }
                 conn.Close();
             }
+            SFConfiguration.Instance().UseV2JsonParser = true;
         }
 
         [Test]
@@ -275,7 +280,9 @@ namespace Snowflake.Data.Tests
                 }
                 conn.Close();
             }
+            SFConfiguration.Instance().UseV2ChunkDownloader = false;
         }
+        */
 
 
         [Test]

--- a/Snowflake.Data.Tests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/SFReusableChunkTest.cs
@@ -68,7 +68,7 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(null, chunk.ExtractCell(1, 1));
             Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
         }
-        
+
         [Test]
         public void TestChunkWithDate()
         {
@@ -95,6 +95,7 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual("2", chunk.ExtractCell(1, 0));
             Assert.AreEqual(null, chunk.ExtractCell(1, 1));
             Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+        }
 
         [Test]
         public void TestChunkWithEscape()

--- a/Snowflake.Data.Tests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/SFReusableChunkTest.cs
@@ -8,6 +8,7 @@ namespace Snowflake.Data.Tests
     using System.IO;
     using System.Text;
     using Snowflake.Data.Core;
+    using Snowflake.Data.Client;
 
     [TestFixture]
     class SFReusableChunkTest
@@ -98,7 +99,7 @@ namespace Snowflake.Data.Tests
         [Test]
         public void TestChunkWithEscape()
         {
-            string data = "[ [\"åäö\\nÅÄÖ\\r\", \"1.234\", null],  [\"2\", null, \"fghi\"] ]";
+            string data = "[ [\"\\\\åäö\\nÅÄÖ\\r\", \"1.234\", null],  [\"2\", null, \"fghi\"] ]";
             byte[] bytes = Encoding.UTF8.GetBytes(data);
             Stream stream = new MemoryStream(bytes);
             IChunkParser parser = new ReusableChunkParser(stream);
@@ -115,13 +116,14 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual("åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
+            Assert.AreEqual("\\åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
             Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
             Assert.AreEqual(null, chunk.ExtractCell(0, 2));
             Assert.AreEqual("2", chunk.ExtractCell(1, 0));
             Assert.AreEqual(null, chunk.ExtractCell(1, 1));
             Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
         }
+
         [Test]
         public void TestChunkWithLongString()
         {
@@ -149,6 +151,66 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual("2", chunk.ExtractCell(1, 0));
             Assert.AreEqual(null, chunk.ExtractCell(1, 1));
             Assert.AreEqual(longstring, chunk.ExtractCell(1, 2));
+        }
+
+        [Test]
+        public void TestParserError1()
+        {
+            // Unterminated escape sequence
+            string data = "[ [\"åäö\\";
+            byte[] bytes = Encoding.UTF8.GetBytes(data);
+            Stream stream = new MemoryStream(bytes);
+            IChunkParser parser = new ReusableChunkParser(stream);
+
+            ExecResponseChunk chunkInfo = new ExecResponseChunk()
+            {
+                url = "fake",
+                uncompressedSize = bytes.Length,
+                rowCount = 1
+            };
+
+            SFReusableChunk chunk = new SFReusableChunk(1);
+            chunk.Reset(chunkInfo, 0);
+
+            try
+            {
+                parser.ParseChunk(chunk);
+                Assert.Fail();
+            }
+            catch (SnowflakeDbException e)
+            {
+                Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode, e.ErrorCode);
+            }
+        }
+
+        [Test]
+        public void TestParserError2()
+        {
+            // Unterminated string
+            string data = "[ [\"åäö";
+            byte[] bytes = Encoding.UTF8.GetBytes(data);
+            Stream stream = new MemoryStream(bytes);
+            IChunkParser parser = new ReusableChunkParser(stream);
+
+            ExecResponseChunk chunkInfo = new ExecResponseChunk()
+            {
+                url = "fake",
+                uncompressedSize = bytes.Length,
+                rowCount = 1
+            };
+
+            SFReusableChunk chunk = new SFReusableChunk(1);
+            chunk.Reset(chunkInfo, 0);
+
+            try
+            {
+                parser.ParseChunk(chunk);
+                Assert.Fail();
+            }
+            catch (SnowflakeDbException e)
+            {
+                Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode, e.ErrorCode);
+            }
         }
     }
 }

--- a/Snowflake.Data.Tests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/SFReusableChunkTest.cs
@@ -94,6 +94,61 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual("2", chunk.ExtractCell(1, 0));
             Assert.AreEqual(null, chunk.ExtractCell(1, 1));
             Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+
+        [Test]
+        public void TestChunkWithEscape()
+        {
+            string data = "[ [\"åäö\\nÅÄÖ\\r\", \"1.234\", null],  [\"2\", null, \"fghi\"] ]";
+            byte[] bytes = Encoding.UTF8.GetBytes(data);
+            Stream stream = new MemoryStream(bytes);
+            IChunkParser parser = new ReusableChunkParser(stream);
+
+            ExecResponseChunk chunkInfo = new ExecResponseChunk()
+            {
+                url = "fake",
+                uncompressedSize = bytes.Length,
+                rowCount = 2
+            };
+
+            SFReusableChunk chunk = new SFReusableChunk(3);
+            chunk.Reset(chunkInfo, 0);
+
+            parser.ParseChunk(chunk);
+
+            Assert.AreEqual("åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
+            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+        }
+        [Test]
+        public void TestChunkWithLongString()
+        {
+            string longstring = new string('å', 10 * 1000 * 1000);
+            string data = "[ [\"åäö\\nÅÄÖ\\r\", \"1.234\", null],  [\"2\", null, \"" + longstring + "\"] ]";
+            byte[] bytes = Encoding.UTF8.GetBytes(data);
+            Stream stream = new MemoryStream(bytes);
+            IChunkParser parser = new ReusableChunkParser(stream);
+
+            ExecResponseChunk chunkInfo = new ExecResponseChunk()
+            {
+                url = "fake",
+                uncompressedSize = bytes.Length,
+                rowCount = 2
+            };
+
+            SFReusableChunk chunk = new SFReusableChunk(3);
+            chunk.Reset(chunkInfo, 0);
+
+            parser.ParseChunk(chunk);
+
+            Assert.AreEqual("åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
+            Assert.AreEqual(longstring, chunk.ExtractCell(1, 2));
         }
     }
 }

--- a/Snowflake.Data/Core/ChunkDownloaderFactory.cs
+++ b/Snowflake.Data/Core/ChunkDownloaderFactory.cs
@@ -13,10 +13,11 @@ namespace Snowflake.Data.Core
                                                      SFBaseResultSet resultSet,
                                                      CancellationToken cancellationToken)
         {
+            int ChunkDownloaderVersion = SFConfiguration.Instance().ChunkDownloaderVersion;
             if (SFConfiguration.Instance().UseV2ChunkDownloader)
-                SFConfiguration.Instance().ChunkDownloaderVersion = 2;
+                ChunkDownloaderVersion = 2;
 
-            switch (SFConfiguration.Instance().ChunkDownloaderVersion)
+            switch (ChunkDownloaderVersion)
             {
                 case 1:
                     return new SFBlockingChunkDownloader(responseData.rowType.Count,

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -36,6 +36,9 @@ namespace Snowflake.Data.Core
             ServicePointManager.UseNagleAlgorithm = false;
             ServicePointManager.CheckCertificateRevocationList = true;
 
+            // Control how many simultaneous connections to each host are allowed from this client
+            ServicePointManager.DefaultConnectionLimit = 20;
+
             HttpUtil.httpClient = new HttpClient(new RetryHandler(new HttpClientHandler(){
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             }));

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -103,7 +103,7 @@ namespace Snowflake.Data.Core
 
             try
             {
-                var response = await HttpUtil.getHttpClient().SendAsync(request, linkedCts.Token).ConfigureAwait(false);
+                var response = await HttpUtil.getHttpClient().SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
                 return response;

--- a/Snowflake.Data/Core/ReusableChunkParser.cs
+++ b/Snowflake.Data/Core/ReusableChunkParser.cs
@@ -9,11 +9,130 @@ namespace Snowflake.Data.Core
 {
     using Snowflake.Data.Client;
 
-    class ReusableChunkParser : IChunkParser
+    public class FastStreamWrapper
     {
+        Stream wrappedStream;
+        byte[] buffer = new byte[8192];
+        int count = 0;
+        int next = 0;
+
+        public FastStreamWrapper(Stream s)
+        {
+            wrappedStream = s;
+        }
+
+        // Small method to encourage inlining
+        public int ReadByte()
+        {
+            // fast path first
+            if (next < count)
+                return buffer[next++];
+            else
+                return ReadByteSlow();
+
+        }
+
+        private int ReadByteSlow()
+        {
+            // fast path first
+            if (next < count)
+                return buffer[next++];
+
+            if (count >= 0)
+            {
+                next = 0;
+                count = wrappedStream.ReadAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult();
+            }
+
+            if (count <= 0)
+            {
+                count = -1;
+                return -1;
+            }
+
+            return buffer[next++];
+        }
+    }
+
+    public class ReusableChunkParser : IChunkParser
+    {
+        // Very fast parser, only supports strings and nulls
+        // Never generates parsing errors
+
         private readonly Stream stream;
 
         internal ReusableChunkParser(Stream stream)
+        {
+            this.stream = stream;
+        }
+
+        public void ParseChunk(IResultChunk chunk)
+        {
+            SFReusableChunk rc = (SFReusableChunk)chunk;
+
+            bool inString = false;
+            int c;
+            var input = new FastStreamWrapper(stream);
+            MemoryStream ms = new MemoryStream();
+            while ((c = input.ReadByte()) >= 0)
+            {
+                if (!inString)
+                {
+                    // n means null
+                    // " quote means begin string
+                    // all else are ignored
+                    if (c == '"')
+                    {
+                        inString = true;
+                    }
+                    else if (c == 'n')
+                    {
+                        rc.AddCell(null, 0);
+                    }
+                    // ignore anything else
+                }
+                else
+                {
+                    // Inside a string, look for end string
+                    // Anything else is saved in the buffer
+                    if (c == '"')
+                    {
+                        rc.AddCell(ms.GetBuffer(), (int)ms.Length);
+                        ms.SetLength(0);
+                        inString = false;
+                    }
+                    else if (c == '\\')
+                    {
+                        // Process next character
+                        c = input.ReadByte();
+                        switch (c)
+                        {
+                            case 'n':
+                                c = 10;
+                                break;
+                            case 'r':
+                                c = 13;
+                                break;
+                            case 'b':
+                                c = 8;
+                                break;
+                        }
+                        ms.WriteByte((byte)c);
+                    }
+                    else
+                    {
+                        ms.WriteByte((byte)c);
+                    }
+                }
+            }
+        }
+    }
+
+    class ReusableChunkParserOld : IChunkParser
+    {
+        private readonly Stream stream;
+
+        internal ReusableChunkParserOld(Stream stream)
         {
             this.stream = stream;
         }

--- a/Snowflake.Data/Core/ReusableChunkParser.cs
+++ b/Snowflake.Data/Core/ReusableChunkParser.cs
@@ -12,7 +12,7 @@ namespace Snowflake.Data.Core
     public class FastStreamWrapper
     {
         Stream wrappedStream;
-        byte[] buffer = new byte[8192];
+        byte[] buffer = new byte[32768];
         int count = 0;
         int next = 0;
 
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Core
             if (count >= 0)
             {
                 next = 0;
-                count = wrappedStream.ReadAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult();
+                count = wrappedStream.Read(buffer, 0, buffer.Length);
             }
 
             if (count <= 0)

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -57,10 +57,9 @@ namespace Snowflake.Data.Core
             this.chunkHeaders = chunkHeaders;
             this.nextChunkToDownloadIndex = 0;
             this.ResultSet = ResultSet;
-            // To reduce memory consumption we never use more than two prefetch threads
-            // Each slot can use over 300MB of memory
-            //this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
-            this.prefetchSlot = Math.Min(chunkInfos.Count, 2);
+            this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
+            // This code does not work properly with prefetchSlot<2, silently adjust if necessary
+            this.prefetchSlot = Math.Max(this.prefetchSlot, 2);
             this.chunkInfos = chunkInfos;
             this.nextChunkToConsumeIndex = 0;
             this.taskQueues = new List<Task<IResultChunk>>();

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -57,8 +57,10 @@ namespace Snowflake.Data.Core
             this.chunkHeaders = chunkHeaders;
             this.nextChunkToDownloadIndex = 0;
             this.ResultSet = ResultSet;
-            this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
-            this.prefetchSlot = 2;
+            // To reduce memory consumption we never use more than two prefetch threads
+            // Each slot can use over 300MB of memory
+            //this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
+            this.prefetchSlot = Math.Min(chunkInfos.Count, 2);
             this.chunkInfos = chunkInfos;
             this.nextChunkToConsumeIndex = 0;
             this.taskQueues = new List<Task<IResultChunk>>();

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -58,8 +58,6 @@ namespace Snowflake.Data.Core
             this.nextChunkToDownloadIndex = 0;
             this.ResultSet = ResultSet;
             this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
-            // This code does not work properly with prefetchSlot<2, silently adjust if necessary
-            this.prefetchSlot = Math.Max(this.prefetchSlot, 2);
             this.chunkInfos = chunkInfos;
             this.nextChunkToConsumeIndex = 0;
             this.taskQueues = new List<Task<IResultChunk>>();

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -136,7 +136,7 @@ namespace Snowflake.Data.Core
                 qrmk = downloadContext.qrmk,
                 // s3 download request timeout to one hour
                 RestTimeout = TimeSpan.FromHours(1),
-                HttpTimeout = TimeSpan.FromSeconds(16),
+                HttpTimeout = Timeout.InfiniteTimeSpan, // Disable timeout for each request
                 chunkHeaders = downloadContext.chunkHeaders
             };
 

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -58,6 +58,7 @@ namespace Snowflake.Data.Core
             this.nextChunkToDownloadIndex = 0;
             this.ResultSet = ResultSet;
             this.prefetchSlot = Math.Min(chunkInfos.Count, GetPrefetchThreads(ResultSet));
+            this.prefetchSlot = 2;
             this.chunkInfos = chunkInfos;
             this.nextChunkToConsumeIndex = 0;
             this.taskQueues = new List<Task<IResultChunk>>();
@@ -163,12 +164,7 @@ namespace Snowflake.Data.Core
         /// <param name="resultChunk"></param>
         private void ParseStreamIntoChunk(Stream content, IResultChunk resultChunk)
         {
-            Stream openBracket = new MemoryStream(Encoding.UTF8.GetBytes("["));
-            Stream closeBracket = new MemoryStream(Encoding.UTF8.GetBytes("]"));
-
-            Stream concatStream = new ConcatenatedStream(new Stream[3] { openBracket, content, closeBracket });
-
-            IChunkParser parser = new ReusableChunkParser(concatStream);
+            IChunkParser parser = new ReusableChunkParser(content);
             parser.ParseChunk(resultChunk);
         }
     }

--- a/Snowflake.Data/Core/SFReusableChunk.cs
+++ b/Snowflake.Data/Core/SFReusableChunk.cs
@@ -66,7 +66,7 @@ namespace Snowflake.Data.Core
             private static int metaBlockLengthBits = 15;
             private static int metaBlockLength = 1 << metaBlockLengthBits;
 
-            private readonly List<char[]> data = new List<char[]>();
+            private readonly List<byte[]> data = new List<byte[]>();
             private readonly List<int[]> offsets = new List<int[]>();
             private readonly List<int[]> lengths = new List<int[]>();
             private int nextIndex = 0;
@@ -102,7 +102,7 @@ namespace Snowflake.Data.Core
                     if (spaceLeftOnBlock(offset) < length)
                     {
                         int copied = 0;
-                        char[] cell = new char[length];
+                        byte[] cell = new byte[length];
                         while (copied < length)
                         {
                             int copySize
@@ -114,11 +114,11 @@ namespace Snowflake.Data.Core
 
                             copied += copySize;
                         }
-                        return new String(cell);
+                        return Encoding.UTF8.GetString(cell);
                     }
                     else
                     {
-                        return new String(data[getBlock(offset)], getBlockOffset(offset), length);
+                        return Encoding.UTF8.GetString(data[getBlock(offset)], getBlockOffset(offset), length);
                     }
                 }
             }
@@ -137,8 +137,10 @@ namespace Snowflake.Data.Core
                 }
                 else
                 {
+                    byte[] bytes = Encoding.UTF8.GetBytes(val);
+
                     int offset = currentDatOffset;
-                    int length = val.Length;
+                    int length = bytes.Length;
 
                     // store offset and length
                     offsets[getMetaBlock(nextIndex)]
@@ -150,12 +152,11 @@ namespace Snowflake.Data.Core
                     int copied = 0;
                     if (spaceLeftOnBlock(offset) < length)
                     {
-                        char[] source = val.ToCharArray();
                         while (copied < length)
                         {
                             int copySize
                                 = Math.Min(length - copied, spaceLeftOnBlock(offset + copied));
-                            Array.Copy(source, copied,
+                            Array.Copy(bytes, copied,
                                              data[getBlock(offset + copied)],
                                              getBlockOffset(offset + copied),
                                              copySize);
@@ -164,7 +165,7 @@ namespace Snowflake.Data.Core
                     }
                     else
                     {
-                        Array.Copy(val.ToCharArray(), 0,
+                        Array.Copy(bytes, 0,
                                          data[getBlock(offset)],
                                          getBlockOffset(offset), length);
                     }
@@ -202,7 +203,7 @@ namespace Snowflake.Data.Core
             {
                 while (data.Count < blockCount)
                 {
-                    data.Add(new char[1 << blockLengthBits]);
+                    data.Add(new byte[1 << blockLengthBits]);
                 }
                 while (offsets.Count < metaBlockCount)
                 {


### PR DESCRIPTION
The previous implementation downloaded each chunk into an uncompressed MemoryStream before parsing. This consumed over 270MB for the memory stream per chunk.
I have also changed the data type for BlockResultData.data from char[] to byte[] to half the memory requirement for this object

I have also implemented a very simple limited json-parser that is twice as fast as Newtonsoft for this particular application.
With the new parser, it is also possible to reduce the number of prefetch slots to 2 with maintained performance.

In my test case that just downloads a 10 million row table, the old implementation takes 21 seconds and uses over 4G memory.
![image](https://user-images.githubusercontent.com/51655419/63090686-52e2c300-bf5c-11e9-90bb-7e7c7c441c48.png)

The new implementation takes 13 seconds and uses 530MB of memory.

![image](https://user-images.githubusercontent.com/51655419/63090693-57a77700-bf5c-11e9-920c-dcb73aa31cbb.png)

