### PR TITLE
Create SfStatement when executing DbCommand #180

### DIFF
--- a/Snowflake.Data.Tests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/SFDbCommandIT.cs
@@ -483,5 +483,21 @@ namespace Snowflake.Data.Tests
                 conn.Close();
             }
         }
+
+        [Test]
+        public void TestCreateCommandBeforeOpeningConnection()
+        {
+            using(var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                
+                using(var command = conn.CreateCommand())
+                {
+                    conn.Open();
+                    command.CommandText = "select 1";
+                    Assert.DoesNotThrow(() => command.ExecuteNonQuery());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I delayed the creation of SfStatement until it's needed: when executing a command. Behavior does not change with this implementation. All tests pass and I added a new test to test for the issue this fix addresses.