### PR TITLE
Fix sequential okta auth failure

### DIFF
--- a/Snowflake.Data/Core/Authenticator/OktaAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/OktaAuthenticator.cs
@@ -45,6 +45,7 @@ namespace Snowflake.Data.Core.Authenticator
         async Task IAuthenticator.AuthenticateAsync(CancellationToken cancellationToken)
         {
             logger.Info("Okta Authentication");
+            HttpUtil.ClearCookies(oktaUrl);
 
             logger.Debug("step 1: get sso and token url");
             var authenticatorRestRequest = BuildAuthenticatorRestRequest();
@@ -81,6 +82,7 @@ namespace Snowflake.Data.Core.Authenticator
         void IAuthenticator.Authenticate()
         {
             logger.Info("Okta Authentication");
+            HttpUtil.ClearCookies(oktaUrl);
 
             logger.Debug("step 1: get sso and token url");
             var authenticatorRestRequest = BuildAuthenticatorRestRequest();

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -18,8 +18,24 @@ namespace Snowflake.Data.Core
     {
         static private HttpClient httpClient = null;
 
+        static private CookieContainer cookieContainer = null;
+
         static private object httpClientInitLock = new object();
-        
+
+        static public void ClearCookies(Uri uri)
+        {
+            if (cookieContainer == null)
+            {
+                return;
+            }
+
+            var cookies = cookieContainer.GetCookies(uri);
+            foreach (Cookie cookie in cookies)
+            {
+                cookie.Expired = true;
+            }
+        }
+
         static public HttpClient getHttpClient()
         {
             lock (httpClientInitLock)
@@ -43,7 +59,8 @@ namespace Snowflake.Data.Core
             ServicePointManager.DefaultConnectionLimit = 20;
 
             HttpUtil.httpClient = new HttpClient(new RetryHandler(new HttpClientHandler(){
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                CookieContainer = cookieContainer = new CookieContainer()
             }));
         }
 

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -141,7 +141,7 @@ namespace Snowflake.Data.Core
 
             if (authenticator == null)
             {
-                authenticator = new BasicAuthenticator(this);
+                authenticator = AuthenticatorFactory.GetAuthenticator(this);
             }
 
             await authenticator.AuthenticateAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
There is an issue when using OktaAuthentificator.
Request for idp (step 3)  leads to 403 Forbidden if HttpClient has cookie sid, which applies in step 4.
So that second connection to sf through okta fails.