### PR TITLE
Timers are not getting released under load, this code change seems to…

### DIFF
--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -48,7 +48,7 @@ namespace Snowflake.Data.Core
         public T Post<T>(IRestRequest request)
         {
             //Run synchronous in a new thread-pool task.
-            return Task.Run(async () => await PostAsync<T>(request, CancellationToken.None)).Result;
+            return PostAsync<T>(request, CancellationToken.None).Result;
         }
 
         public async Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
@@ -114,7 +114,12 @@ namespace Snowflake.Data.Core
             {
                 throw restRequestTimeout.IsCancellationRequested ? new SnowflakeDbException(SFError.REQUEST_TIMEOUT) : e;
             }
+            finally
+            {
+                restRequestTimeout.Dispose();
+                linkedCts.Dispose();
+            }
         }
-    }
     
+    }
 }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -207,6 +207,8 @@ namespace Snowflake.Data.Core
             finally
             {
                 ClearQueryRequestId();
+                _timeoutTokenSource.Dispose();
+                _linkedCancellationTokenSouce.Dispose();
             }
         }
         


### PR DESCRIPTION
Under heady load the timers do not seem to get released with the .net connector.  This code fix has minor changes to:

Snowflake.Data/Core/RestRequester.cs
Snowflake.Data/Core/SFStatement.cs

Per another user, this resolves.  I was able to compile and confirm that this doesn't seem to break anything, but was not able to test against the original issue.