### PR TITLE
Added constructor overload for Command and Connection

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -27,19 +27,20 @@ namespace Snowflake.Data.Client
 
         public SnowflakeDbCommand()
         {
-            logger.Debug("Constucting SnowflakeDbCommand class");
+            logger.Debug("Constructing SnowflakeDbCommand class");
             // by default, no query timeout
             this.CommandTimeout = 0;
             parameterCollection = new SnowflakeDbParameterCollection();
         }
 
-        public SnowflakeDbCommand(SnowflakeDbConnection connection)
+        public SnowflakeDbCommand(SnowflakeDbConnection connection) : this()
         {
-            logger.Debug("Constucting SnowflakeDbCommand class");
             this.connection = connection;
-            // by default, no query timeout
-            this.CommandTimeout = 0;
-            parameterCollection = new SnowflakeDbParameterCollection();
+        }
+
+        public SnowflakeDbCommand(SnowflakeDbConnection connection, string cmdText) : this(connection)
+        {
+            this.CommandText = cmdText;
         }
 
         public override string CommandText

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -32,6 +32,11 @@ namespace Snowflake.Data.Client
             _connectionTimeout = 0;
         }
 
+        public SnowflakeDbConnection(string connectionString) : this()
+        {
+            ConnectionString = connectionString;
+        }
+
         public override string ConnectionString
         {
             get; set;


### PR DESCRIPTION
A couple of handy overloads for constructors of SnowflakeDbConnection and SnowflakeDbCommand. 
Changes: 
- added new (third) constructor for DbCommand that accepts connection and command text
- second constructor of DbCommand now calls default constructor, avoiding code duplication
- added new constructor for DbConnection that accepts connection string
- fixed typo in "Const**r**ucting" word

So instead of 

```cs
using (var connection = new SnowflakeDbConnection())
using (var cmd = new SnowflakeDbCommand(connection))
{
    connection.ConnectionString = connectionString;
    connection.Open();
    cmd.CommandText = query;

    // execute reader code...
}
```
you can write it like this: 
```cs
using (var connection = new SnowflakeDbConnection(connectionString))
using (var cmd = new SnowflakeDbCommand(connection, query))
{
    connection.Open();

    // execute reader code...
}
```
Cleaner and simpler.