### PR TITLE
Support AnsiString, AnsiStringFixedLength when converting DbType to SFDataType

### DIFF
--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -192,6 +192,8 @@ namespace Snowflake.Data.Core
                 case DbType.Guid:
                 case DbType.String:
                 case DbType.StringFixedLength:
+                case DbType.AnsiString:
+                case DbType.AnsiStringFixedLength:
                     destType = SFDataType.TEXT.ToString();
                     destVal = srcValAsCultureInvariantString;
                     break;


### PR DESCRIPTION
Hello,
I am proposing support for AnsiString and AnsiStringFixedLength when converting from DbType to SFDataType.

Context: 

I am building out an NHibernate+Spring data provider using this connector. 

One issue I am having is many of my mappings have the specific type of AnsiString. This is done for query optimization with SQL Server, that need to continue to support.