### PR TITLE
Fix typo in `INVALID_DATA_CONVERSION` value

### DIFF
--- a/Snowflake.Data/Core/ErrorMessages.resx
+++ b/Snowflake.Data/Core/ErrorMessages.resx
@@ -145,7 +145,7 @@
     <value>Connection string is invalid: {0}</value>
   </data>
   <data name="INVALID_DATA_CONVERSION" xml:space="preserve">
-    <value>Failed to convert data {0} from type {0} to type {1}.</value>
+    <value>Failed to convert data {0} from type {1} to type {2}.</value>
   </data>
   <data name="MISSING_CONNECTION_PROPERTY" xml:space="preserve">
     <value>Required property {0} is not provided.</value>


### PR DESCRIPTION
Existing message is confusing & omits the target type.