### PR TITLE
SNOW-344502 - Improved performance when downloading large amounts of data.

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -51,11 +51,10 @@ namespace Snowflake.Data.Tests
                 inputTime = DateTime.ParseExact(inputTimeStr, "yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
             }
 
-            var dataConverter = new SFDataConverter();
             var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             var tickDiff = inputTime.Ticks - unixEpoch.Ticks;
             var inputStringAsItWasFromDatabase = (tickDiff / 10000000.0m).ToString(CultureInfo.InvariantCulture);
-            var result = dataConverter.ConvertToCSharpVal(inputStringAsItWasFromDatabase, SFDataType.TIMESTAMP_NTZ, typeof(DateTime));
+            var result = SFDataConverter.ConvertToCSharpVal(inputStringAsItWasFromDatabase, SFDataType.TIMESTAMP_NTZ, typeof(DateTime));
             Assert.AreEqual(inputTime, result);
         }
 
@@ -97,5 +96,29 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(dtExpected, dtResult);
         }
 
+        [Test]
+        [TestCase("9223372036854775807")]
+        [TestCase("-9223372036854775808")]
+        [TestCase("-1")]
+        [TestCase("999999999999999999")]
+        public void TestConvertToInt64(string s)
+        {
+            Int64 actual = (Int64)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int64));
+            Int64 expected = Convert.ToInt64(s);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase("9223372036854775807.9223372036854775807")]
+        [TestCase("-9223372036854775807.1234567890")]
+        [TestCase("-1.300")]
+        [TestCase("999999999999999999.000000000000100000000000")]
+        [TestCase("4294967295.4294967296")]
+        public void TestConvertToDecimal(string s)
+        {
+            decimal actual = (decimal)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal));
+            decimal expected = Convert.ToDecimal(s, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -117,7 +117,8 @@ namespace Snowflake.Data.Tests
         public void TestConvertToDecimal(string s)
         {
             decimal actual = (decimal)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal));
-            decimal expected = Convert.ToDecimal(s, System.Globalization.CultureInfo.InvariantCulture);
+            decimal expected = Convert.ToDecimal(s, CultureInfo.InvariantCulture);
+
             Assert.AreEqual(expected, actual);
         }
     }

--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -109,6 +109,72 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        [TestCase("2147483647")]
+        [TestCase("-2147483648")]
+        [TestCase("-1")]
+        [TestCase("0")]
+        public void TestConvertToInt32(string s)
+        {
+            Int32 actual = (Int32)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int32));
+            Int32 expected = Convert.ToInt32(s);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase("32767")]
+        [TestCase("-32768")]
+        [TestCase("-1")]
+        [TestCase("0")]
+        public void TestConvertToInt16(string s)
+        {
+            Int16 actual = (Int16)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int16));
+            Int16 expected = Convert.ToInt16(s);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase("255")]
+        [TestCase("0")]
+        public void TestConvertToByte(string s)
+        {
+            byte actual = (byte)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(byte));
+            byte expected = Convert.ToByte(s);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase("256")]
+        [TestCase("-1")]
+        public void TestOverflowByte(string s)
+        {
+            Assert.Throws<OverflowException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(byte)));
+        }
+
+        [Test]
+        [TestCase("32768")]
+        [TestCase("-32769")]
+        public void TestOverflowInt16(string s)
+        {
+            Assert.Throws<OverflowException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int16)));
+        }
+
+        [Test]
+        [TestCase("2147483648")]
+        [TestCase("-2147483649")]
+        public void TestOverflowInt32(string s)
+        {
+            Assert.Throws<OverflowException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int32)));
+        }
+
+        [Test]
+        [TestCase("9223372036854775808")]
+        [TestCase("-9223372036854775809")]
+        public void TestOverflowInt64(string s)
+        {
+            Assert.Throws<OverflowException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int64)));
+        }
+
+        [Test]
         [TestCase("9223372036854775807.9223372036854775807")]
         [TestCase("-9223372036854775807.1234567890")]
         [TestCase("-1.300")]

--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -187,5 +187,67 @@ namespace Snowflake.Data.Tests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        [TestCase("9223372036854775807.9223372036854775807")]
+        [TestCase("-9223372036854775807.1234567890")]
+        [TestCase("-1.300")]
+        [TestCase("999999999999999999.000000000000100000000000")]
+        [TestCase("4294967295.4294967296")]
+        [TestCase("1.5e-36")]
+        [TestCase("1.5e+38")]
+        //[TestCase("inf")] -- TODO - Not supported yet
+        //[TestCase("-inf")] -- TODO - Not supported yet
+        [TestCase("NaN")]
+        public void TestConvertToFloat(string s)
+        {
+            double actualDouble = (double)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(double));
+            double expectedDoulbe = Convert.ToDouble(s, CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(actualDouble, expectedDoulbe);
+
+            float actualFloat = (float)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(float));
+            float expectedFloat = Convert.ToSingle(s, CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(expectedFloat, actualFloat);
+        }
+
+        [Test]
+        [TestCase("thisIsNotAValidValue")]
+        [TestCase("-1.300")]
+        [TestCase("425.426")]
+        [TestCase("1.5e-36")]
+        [TestCase("1.5e+38")]
+        [TestCase("inf")]
+        [TestCase("-inf")]
+        [TestCase("NaN")]
+        public void TestInvalidConversionInvalidInt(string s)
+        {
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int32)));
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int64)));
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(Int16)));
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(byte)));
+        }
+
+        [Test]
+        [TestCase("thisIsNotAValidValue")]
+        public void TestInvalidConversionInvalidFloat(string s)
+        {
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(float)));
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(double)));
+        }
+
+        [Test]
+        [TestCase("thisIsNotAValidValue")]
+        [TestCase("1.5e-36")]
+        [TestCase("1.5e+38")]
+        [TestCase("inf")]
+        [TestCase("-inf")]
+        [TestCase("NaN")]
+        public void TestInvalidConversionInvalidDecimal(string s)
+        {
+            Assert.Throws<FormatException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal)));
+        }
+
     }
 }

--- a/Snowflake.Data.Tests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/SFReusableChunkTest.cs
@@ -33,12 +33,12 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual("1", chunk.ExtractCell(0, 0));
-            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
-            Assert.AreEqual("abcde", chunk.ExtractCell(0, 2));
-            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
-            Assert.AreEqual("5.678", chunk.ExtractCell(1, 1));
-            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+            Assert.AreEqual("1", chunk.ExtractCell(0, 0).SafeToString());
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1).SafeToString());
+            Assert.AreEqual("abcde", chunk.ExtractCell(0, 2).SafeToString());
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0).SafeToString());
+            Assert.AreEqual("5.678", chunk.ExtractCell(1, 1).SafeToString());
+            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2).SafeToString());
         }
 
         [Test]
@@ -61,12 +61,12 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual(null, chunk.ExtractCell(0, 0));
-            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
-            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
-            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
-            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
-            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+            Assert.AreEqual(null, chunk.ExtractCell(0, 0).SafeToString());
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2).SafeToString());
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1).SafeToString());
+            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2).SafeToString());
         }
 
         [Test]
@@ -89,12 +89,12 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual(null, chunk.ExtractCell(0, 0));
-            Assert.AreEqual("2019-08-21T11:58:00", chunk.ExtractCell(0, 1));
-            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
-            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
-            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
-            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+            Assert.AreEqual(null, chunk.ExtractCell(0, 0).SafeToString());
+            Assert.AreEqual("2019-08-21T11:58:00", chunk.ExtractCell(0, 1).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2).SafeToString());
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1).SafeToString());
+            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2).SafeToString());
         }
 
         [Test]
@@ -117,12 +117,12 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual("\\åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
-            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
-            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
-            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
-            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
-            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2));
+            Assert.AreEqual("\\åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0).SafeToString());
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2).SafeToString());
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1).SafeToString());
+            Assert.AreEqual("fghi", chunk.ExtractCell(1, 2).SafeToString());
         }
 
         [Test]
@@ -146,12 +146,12 @@ namespace Snowflake.Data.Tests
 
             parser.ParseChunk(chunk);
 
-            Assert.AreEqual("åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0));
-            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1));
-            Assert.AreEqual(null, chunk.ExtractCell(0, 2));
-            Assert.AreEqual("2", chunk.ExtractCell(1, 0));
-            Assert.AreEqual(null, chunk.ExtractCell(1, 1));
-            Assert.AreEqual(longstring, chunk.ExtractCell(1, 2));
+            Assert.AreEqual("åäö\nÅÄÖ\r", chunk.ExtractCell(0, 0).SafeToString());
+            Assert.AreEqual("1.234", chunk.ExtractCell(0, 1).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(0, 2).SafeToString());
+            Assert.AreEqual("2", chunk.ExtractCell(1, 0).SafeToString());
+            Assert.AreEqual(null, chunk.ExtractCell(1, 1).SafeToString());
+            Assert.AreEqual(longstring, chunk.ExtractCell(1, 2).SafeToString());
         }
 
         [Test]
@@ -234,8 +234,8 @@ namespace Snowflake.Data.Tests
             chunk.Reset(chunkInfo, 0);
 
             parser.ParseChunk(chunk);
-            string val = chunk.ExtractCell(0, 0);
-            Assert.AreEqual("abc\t", chunk.ExtractCell(0, 0));
+            string val = chunk.ExtractCell(0, 0).SafeToString();
+            Assert.AreEqual("abc\t", chunk.ExtractCell(0, 0).SafeToString());
         }
     }
 }

--- a/Snowflake.Data/Core/FastMemoryStream.cs
+++ b/Snowflake.Data/Core/FastMemoryStream.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Snowflake.Data.Core
+{
+    // Optimized for maximum speed when adding one byte at a time to short buffers
+    public class FastMemoryStream
+    {
+        byte[] _buffer;
+        int _size;
+
+        public FastMemoryStream()
+        {
+            _buffer = new byte[256];
+            _size = 0;
+        }
+
+        public void WriteByte(byte b)
+        {
+            if (_size == _buffer.Length)
+                GrowBuffer();
+            _buffer[_size] = b;
+            _size++;
+        }
+
+        public void Clear()
+        {
+            // We reuse the same buffer, we also do not bother to clear the buffer
+            _size = 0;
+        }
+
+        public byte[] GetBuffer()
+        {
+            // Note that we return a reference to the actual buffer. No copying here
+            return _buffer;
+        }
+
+        public int Length => _size;
+
+        private void GrowBuffer()
+        {
+            // Create a new array with double the size and copy existing elements to the new array
+            byte[] newBuffer = new byte[_buffer.Length * 2];
+            Array.Copy(_buffer, newBuffer, _size);
+            _buffer = newBuffer;
+        }
+    }
+}

--- a/Snowflake.Data/Core/FastParser.cs
+++ b/Snowflake.Data/Core/FastParser.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Snowflake.Data.Core
+{
+    public class FastParser
+    {
+
+        public static Int64 FastParseInt64(byte[] s, int offset, int len)
+        {
+            Int64 result = 0;
+            int i = offset;
+            bool isMinus = false;
+            if (len > 0 && s[i] == '-')
+            {
+                isMinus = true;
+                i++;
+            }
+            int end = len + offset;
+            for (; i < end; i++)
+            {
+                if ((UInt64)result > (0x7fffffffffffffff / 10))
+                    throw new OverflowException();
+                int c = s[i] - '0';
+                if (c < 0 || c > 9)
+                    throw new FormatException();
+                result = result * 10 + c;
+            }
+            if (isMinus)
+            {
+                result = -result;
+                if (result > 0)
+                    throw new OverflowException();
+            }
+            else
+            {
+                if (result < 0)
+                    throw new OverflowException();
+            }
+            return result;
+        }
+
+        public static Int32 FastParseInt32(byte[] s, int offset, int len)
+        {
+            Int32 result = 0;
+            int i = offset;
+            bool isMinus = false;
+            if (len > 0 && s[i] == '-')
+            {
+                isMinus = true;
+                i++;
+            }
+            int end = len + offset;
+            for (; i < end; i++)
+            {
+                if ((UInt32)result > (0x7fffffff / 10))
+                    throw new OverflowException();
+                int c = s[i] - '0';
+                if (c < 0 || c > 9)
+                    throw new FormatException();
+                result = result * 10 + c;
+            }
+            if (isMinus)
+            {
+                result = -result;
+                if (result > 0)
+                    throw new OverflowException();
+            }
+            else
+            {
+                if (result < 0)
+                    throw new OverflowException();
+            }
+            return result;
+        }
+
+        public static decimal FastParseDecimal(byte[] s, int offset, int len)
+        {
+            // Find any decimal point
+            // Parse integer part and decimal part as 64-bit numbers
+            // Calculate decimal number to return
+            int decimalPos = Array.IndexOf<byte>(s, (byte)'.', offset, len);
+            if (decimalPos < 0)
+            {
+                // No decimal point found, just parse as integer
+                Int64 i1 = FastParseInt64(s, offset, len);
+                return (decimal)i1;
+            }
+            else
+            {
+                decimalPos -= offset;
+                int decimalLen = len - decimalPos - 1;
+                Int64 intPart = FastParseInt64(s, offset, decimalPos);
+                Int64 decimalPart = FastParseInt64(s, offset + decimalPos + 1, decimalLen);
+                bool isMinus = false;
+                if (decimalPart < 0)
+                    throw new FormatException();
+                if (intPart < 0)
+                {
+                    isMinus = true;
+                    intPart = -intPart;
+                    if (intPart < 0)
+                        throw new OverflowException();
+                }
+                decimal d1 = new decimal(intPart);
+                decimal d2 = new decimal((int)(decimalPart & 0xffffffff), (int)((decimalPart >> 32) & 0xffffffff), 0, false, (byte)decimalLen);
+                decimal result = d1 + d2;
+                if (isMinus)
+                    result = -result;
+                return result;
+            }
+        }
+    }
+}

--- a/Snowflake.Data/Core/IResultChunk.cs
+++ b/Snowflake.Data/Core/IResultChunk.cs
@@ -10,7 +10,7 @@ namespace Snowflake.Data.Core
 {
     public interface IResultChunk
     {
-        string ExtractCell(int rowIndex, int columnIndex);
+        UTF8Buffer ExtractCell(int rowIndex, int columnIndex);
 
         int GetRowCount();
 

--- a/Snowflake.Data/Core/ReusableChunkParser.cs
+++ b/Snowflake.Data/Core/ReusableChunkParser.cs
@@ -73,7 +73,7 @@ namespace Snowflake.Data.Core
             bool inString = false;
             int c;
             var input = new FastStreamWrapper(stream);
-            MemoryStream ms = new MemoryStream();
+            var ms = new FastMemoryStream();
             while ((c = input.ReadByte()) >= 0)
             {
                 if (!inString)
@@ -97,8 +97,8 @@ namespace Snowflake.Data.Core
                     // Anything else is saved in the buffer
                     if (c == '"')
                     {
-                        rc.AddCell(ms.GetBuffer(), (int)ms.Length);
-                        ms.SetLength(0);
+                        rc.AddCell(ms.GetBuffer(), ms.Length);
+                        ms.Clear();
                         inString = false;
                     }
                     else if (c == '\\')

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -3,10 +3,12 @@
  */
 
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core
 {
+
     abstract class SFBaseResultSet
     {
         internal SFStatement sfStatement;
@@ -21,20 +23,17 @@ namespace Snowflake.Data.Core
 
         internal abstract Task<bool> NextAsync();
 
-        protected abstract string getObjectInternal(int columnIndex);
-
-        private SFDataConverter dataConverter;
+        protected abstract UTF8Buffer getObjectInternal(int columnIndex);
 
         protected SFBaseResultSet()
         {
-            dataConverter = new SFDataConverter();
         }
 
         internal T GetValue<T>(int columnIndex)
         {
-            string val = getObjectInternal(columnIndex);
+            UTF8Buffer val = getObjectInternal(columnIndex);
             var types = sfResultSetMetaData.GetTypesByIndex(columnIndex);
-            return (T) dataConverter.ConvertToCSharpVal(val, types.Item1, typeof(T));
+            return (T)SFDataConverter.ConvertToCSharpVal(val, types.Item1, typeof(T));
         }
 
         internal string GetString(int columnIndex)
@@ -50,15 +49,15 @@ namespace Snowflake.Data.Core
                         sfResultSetMetaData.dateOutputFormat);
                 //TODO: Implement SqlFormat for timestamp type, aka parsing format specified by user and format the value
                 default:
-                    return getObjectInternal(columnIndex); 
+                    return getObjectInternal(columnIndex).SafeToString(); 
             }
         }
 
         internal object GetValue(int columnIndex)
         {
-            string val = getObjectInternal(columnIndex);
+            UTF8Buffer val = getObjectInternal(columnIndex);
             var types = sfResultSetMetaData.GetTypesByIndex(columnIndex);
-            return dataConverter.ConvertToCSharpVal(val, types.Item1, types.Item2);
+            return SFDataConverter.ConvertToCSharpVal(val, types.Item1, types.Item2);
         }
         
         internal void close()

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -79,11 +79,15 @@ namespace Snowflake.Data.Core
                 }
                 else if (destType == typeof(Int16))
                 {
-                    return (Int16)FastParser.FastParseInt32(srcVal.Buffer, srcVal.offset, srcVal.length);
+                    // Use checked keyword to make sure we generate an OverflowException if conversion fails
+                    int result = FastParser.FastParseInt32(srcVal.Buffer, srcVal.offset, srcVal.length);
+                    return checked((Int16)result);
                 }
                 else if (destType == typeof(byte))
                 {
-                    return (byte)FastParser.FastParseInt32(srcVal.Buffer, srcVal.offset, srcVal.length);
+                    // Use checked keyword to make sure we generate an OverflowException if conversion fails
+                    int result = FastParser.FastParseInt32(srcVal.Buffer, srcVal.offset, srcVal.length);
+                    return checked((byte)result);
                 }
                 else if (destType == typeof(double))
                 {

--- a/Snowflake.Data/Core/SFResultChunk.cs
+++ b/Snowflake.Data/Core/SFResultChunk.cs
@@ -2,6 +2,8 @@
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
  */
 
+using System.Text;
+
 namespace Snowflake.Data.Core
 {
     internal class SFResultChunk : IResultChunk
@@ -36,9 +38,14 @@ namespace Snowflake.Data.Core
             this.downloadState = DownloadState.NOT_STARTED;
         }
 
-        public string ExtractCell(int rowIndex, int columnIndex)
+        public UTF8Buffer ExtractCell(int rowIndex, int columnIndex)
         {
-            return rowSet[rowIndex, columnIndex];
+            // Convert string to UTF8Buffer. This makes this method a little slower, but this class is not used for large result sets
+            string s = rowSet[rowIndex, columnIndex];
+            if (s == null)
+                return null;
+            byte[] b = Encoding.UTF8.GetBytes(s);
+            return new UTF8Buffer(b);
         }
 
         public void addValue(string val, int rowCount, int colCount)

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -118,7 +118,7 @@ namespace Snowflake.Data.Core
            return false;
         }
 
-        protected override string getObjectInternal(int columnIndex)
+        protected override UTF8Buffer getObjectInternal(int columnIndex)
         {
             if (isClosed)
             {

--- a/Snowflake.Data/Core/SFReusableChunk.cs
+++ b/Snowflake.Data/Core/SFReusableChunk.cs
@@ -45,7 +45,7 @@ namespace Snowflake.Data.Core
             return chunkIndexToDownload;
         }
 
-        public string ExtractCell(int rowIndex, int columnIndex)
+        public UTF8Buffer ExtractCell(int rowIndex, int columnIndex)
         {
             return data.get(rowIndex * ColCount + columnIndex);
         }
@@ -95,7 +95,7 @@ namespace Snowflake.Data.Core
                 this.metaBlockCount = getMetaBlock(rowCount * colCount - 1) + 1;
             }
 
-            public String get(int index)
+            public UTF8Buffer get(int index)
             {
                 int length = lengths[getMetaBlock(index)]
                     [getMetaBlockIndex(index)];
@@ -124,11 +124,11 @@ namespace Snowflake.Data.Core
 
                             copied += copySize;
                         }
-                        return Encoding.UTF8.GetString(cell);
+                        return new UTF8Buffer(cell);
                     }
                     else
                     {
-                        return Encoding.UTF8.GetString(data[getBlock(offset)], getBlockOffset(offset), length);
+                        return new UTF8Buffer(data[getBlock(offset)], getBlockOffset(offset), length);
                     }
                 }
             }

--- a/Snowflake.Data/Core/UTF8Buffer.cs
+++ b/Snowflake.Data/Core/UTF8Buffer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Snowflake.Data.Core
+{
+    public class UTF8Buffer
+    {
+        // Cache for maximum performance
+        static Encoding UTF8 = Encoding.UTF8;
+
+        public byte[] Buffer;
+        public int offset;
+        public int length;
+
+        public UTF8Buffer(byte[] Buffer, int Offset, int Length)
+        {
+            this.Buffer = Buffer;
+            this.offset = Offset;
+            this.length = Length;
+        }
+
+        public UTF8Buffer(byte[] Buffer)
+        {
+            this.Buffer = Buffer;
+            this.offset = 0;
+            this.length = Buffer.Length;
+        }
+
+        public override string ToString() => UTF8.GetString(Buffer, offset, length);
+
+        public byte[] GetBytes()
+        {
+            // Return a new byte array containing only the relevant part of the buffer
+            var result = new byte[length];
+            Array.Copy(Buffer, offset, result, 0, length);
+            return result;
+        }
+
+    }
+
+    public static class UTF8BufferExtension
+    {
+        // Define an extension method that can safely be called even on null objects
+        // Calling ToString() on a null object causes an exception
+        public static string SafeToString(this UTF8Buffer v)
+        {
+            return v == null ? null : v.ToString();
+        }
+    }
+}


### PR DESCRIPTION
* Uses handwritten parsers for integers and decimals
* Keeps data in UTF8 format until we absolutely need to convert it to strings

In a testcase that downloads 266 million rows we had the following runtime before this change:

.Net Framework 00:13:16
Core           00:05:16

After this change the same testcase has the following runtime:

.Net Framework 00:02:18
Core           00:02:29

