### PR TITLE
Log query cancellation failure as a warning

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -215,8 +215,17 @@ namespace Snowflake.Data.Client
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
             logger.Debug($"ExecuteDbDataReaderAsync, command: {CommandText}");
-            var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
-            return new SnowflakeDbDataReader(this, result);
+            try
+            {
+
+                var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
+                return new SnowflakeDbDataReader(this, result);
+            }
+            catch (Exception ex)
+            {
+                logger.Error("The command failed to execute.", ex);
+                throw ex;
+            }
         }
 
         private static Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -217,7 +217,6 @@ namespace Snowflake.Data.Client
             logger.Debug($"ExecuteDbDataReaderAsync, command: {CommandText}");
             try
             {
-
                 var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
                 return new SnowflakeDbDataReader(this, result);
             }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -216,6 +216,10 @@ namespace Snowflake.Data.Client
         {
             logger.Debug($"ExecuteDbDataReaderAsync, command: {CommandText}");
             var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
             return new SnowflakeDbDataReader(this, result);
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -216,10 +216,6 @@ namespace Snowflake.Data.Client
         {
             logger.Debug($"ExecuteDbDataReaderAsync, command: {CommandText}");
             var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return null;
-            }
             return new SnowflakeDbDataReader(this, result);
         }
 

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -112,10 +112,6 @@ namespace Snowflake.Data.Core
             }
             catch(Exception e)
             {
-                if (externalCancellationToken.IsCancellationRequested)
-                {
-                    return null;
-                }
                 throw restRequestTimeout.IsCancellationRequested ? new SnowflakeDbException(SFError.REQUEST_TIMEOUT) : e;
             }
         }

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -112,6 +112,10 @@ namespace Snowflake.Data.Core
             }
             catch(Exception e)
             {
+                if (externalCancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
                 throw restRequestTimeout.IsCancellationRequested ? new SnowflakeDbException(SFError.REQUEST_TIMEOUT) : e;
             }
         }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -199,9 +199,9 @@ namespace Snowflake.Data.Core
 
                 return BuildResultSet(response, cancellationToken);
             }
-            catch (Exception ex)
+            catch
             {
-                logger.Error("Query execution failed.", ex);
+                logger.Error("Query execution failed.");
                 throw;
             }
             finally

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -201,10 +201,6 @@ namespace Snowflake.Data.Core
             }
             catch (Exception ex)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return null;
-                }
                 logger.Error("Query execution failed.", ex);
                 throw;
             }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -201,6 +201,10 @@ namespace Snowflake.Data.Core
             }
             catch (Exception ex)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
                 logger.Error("Query execution failed.", ex);
                 throw;
             }
@@ -303,10 +307,7 @@ namespace Snowflake.Data.Core
             }
             else
             {
-                SnowflakeDbException e = new SnowflakeDbException(
-                    "", response.code, response.message, "");
-                logger.Error("Query cancellation failed.", e);
-                throw e;
+                logger.Warn("Query cancellation failed.");
             }
         }
         


### PR DESCRIPTION
Calling cancel on a query should not generate an exception when it fails: https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.cancel?view=net-5.0

This fixes the issue by logging the failed cancellation as a warning instead of throwing an exception.
Note: a different exception is still thrown since the command failed to execute. And is bubbled up to SnowflakeDbCommand for visibility