### PR TITLE
SNOW-304019 Change the bind parameter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,13 @@ using (IDbConnection conn = new SnowflakeDbConnection())
     conn.Open();
 
     IDbCommand cmd = conn.CreateCommand();
-    cmd.CommandText = "insert into t values (?),(?),(?)";
+    // Create the table for the example.
+    cmd.CommandText = "create or replace table t(c1 number, c2 number, c3 number)";
+    int count = cmd.ExecuteNonQuery();
+    Assert.AreEqual(0, count);
+
+    // Insert a row into the table.
+    cmd.CommandText = "insert into t (c1, c2, c3) values (?, ?, ?)";
 
     var p1 = cmd.CreateParameter();
     p1.ParameterName = "1";


### PR DESCRIPTION
# Overview

SNOW-304019

Description
Change the bind parameter example. Originally, the example inserted three rows into a table with a single column (probably copied from https://github.com/snowflakedb/snowflake-connector-net/blob/d3c692fb5a773fabf1e0e2636f4bc775a596f06b/Snowflake.Data.Tests/SFDbDataReaderIT.cs#L63).

Change the example to insert a row with three columns. Add the CREATE TABLE statement to provide information about the table used in the example.