### PR TITLE
csharpValToSfVal should allow at least SFDataType.TEXT

### DIFF
--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -312,6 +312,8 @@ namespace Snowflake.Data.Core
                     {
                        return ((long)(((DateTimeOffset)srcVal).UtcTicks - UnixEpoch.Ticks) * 100).ToString();
                     }
+                case SFDataType.TEXT:
+                    return srcVal.ToString();
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
All values other than `SFDataType.TIMESTAMP_LTZ` thow an exception,

See https://github.com/snowflakedb/snowflake-connector-net/issues/285