### PR TITLE
SNOW-344228 - Case insensitive authenticator settings comparison

### DIFF
--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -241,13 +241,17 @@ namespace Snowflake.Data.Core
         {
             if (sessionProperty.Equals(SFSessionProperty.PASSWORD))
             {
-                var authenticatorDefined = 
+                var authenticatorDefined =
                     properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var authenticator);
 
                 // External browser, jwt and oauth don't require a password for authenticating
-                return !(authenticatorDefined && (authenticator == ExternalBrowserAuthenticator.AUTH_NAME ||
-                            authenticator == KeyPairAuthenticator.AUTH_NAME ||
-                            authenticator == OAuthAuthenticator.AUTH_NAME));
+                return !(authenticatorDefined &&
+                        (authenticator.Equals(ExternalBrowserAuthenticator.AUTH_NAME,
+                            StringComparison.OrdinalIgnoreCase) ||
+                        authenticator.Equals(KeyPairAuthenticator.AUTH_NAME,
+                            StringComparison.OrdinalIgnoreCase) ||
+                        authenticator.Equals(OAuthAuthenticator.AUTH_NAME,
+                        StringComparison.OrdinalIgnoreCase)));
             }
             else if (sessionProperty.Equals(SFSessionProperty.USER))
             {
@@ -255,7 +259,8 @@ namespace Snowflake.Data.Core
                    properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var authenticator);
 
                 // Oauth don't require a username for authenticating
-                return !(authenticatorDefined && (authenticator == OAuthAuthenticator.AUTH_NAME));
+                return !(authenticatorDefined && (
+                    authenticator.Equals(OAuthAuthenticator.AUTH_NAME, StringComparison.OrdinalIgnoreCase)));
             }
             else
             {


### PR DESCRIPTION
Current connector is processing "Authenticator" setting values using case sensitive comparison. This is an issue because when using authenticator=SNOWFLAKE_JWT for example, the connector does not identify the authentication mechanism as JWT and falls back to the default Snowflake authentication mechanism with username and password. It then fail because the password is not provided.

With this change, it validates the required connection string properties using case insensitive comparison.
