### PR TITLE
SNOW-344502 - Fix conversion issue for decimal negative value between -1 and 0

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -180,6 +180,7 @@ namespace Snowflake.Data.Tests
         [TestCase("-1.300")]
         [TestCase("999999999999999999.000000000000100000000000")]
         [TestCase("4294967295.4294967296")]
+        [TestCase("-0.999")]
         public void TestConvertToDecimal(string s)
         {
             decimal actual = (decimal)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal));
@@ -192,6 +193,7 @@ namespace Snowflake.Data.Tests
         [TestCase("9223372036854775807.9223372036854775807")]
         [TestCase("-9223372036854775807.1234567890")]
         [TestCase("-1.300")]
+        [TestCase("-0.999")]
         [TestCase("999999999999999999.000000000000100000000000")]
         [TestCase("4294967295.4294967296")]
         [TestCase("1.5e-36")]
@@ -214,6 +216,7 @@ namespace Snowflake.Data.Tests
 
         [Test]
         [TestCase("thisIsNotAValidValue")]
+        [TestCase("-0.999")]
         [TestCase("-1.300")]
         [TestCase("425.426")]
         [TestCase("1.5e-36")]

--- a/Snowflake.Data/Core/FastParser.cs
+++ b/Snowflake.Data/Core/FastParser.cs
@@ -103,6 +103,14 @@ namespace Snowflake.Data.Core
                     if (intPart < 0)
                         throw new OverflowException();
                 }
+                else if (intPart == 0)
+                {
+                    // Sign is stripped from the Int64 for value of "-0"
+                    if (s[offset] == '-')
+                    {
+                        isMinus = true;
+                    }
+                }
                 decimal d1 = new decimal(intPart);
                 decimal d2 = new decimal((int)(decimalPart & 0xffffffff), (int)((decimalPart >> 32) & 0xffffffff), 0, false, (byte)decimalLen);
                 decimal result = d1 + d2;


### PR DESCRIPTION
For values v in -1<{v}<0, the sign was lost and for example -0.99 would be converted to 0.99. This was because 0 doesn't really has a sign and the conversion was splitting up the raw data in 2 parts : int part and decimal part. Loosing the sign.