### PR TITLE
allow for http streaming on all frameworks, not just `NETFRAMEWORK`

### DIFF
--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -99,13 +99,7 @@ namespace Snowflake.Data.Core
 
             try
             {
-#if NETFRAMEWORK
-                // The following optimization is going to cause test failure in net core 2.0 when testing against Azure deployment
-                // We might want to revisit when we upgrade the framework.
                 var response = await HttpUtil.getHttpClient().SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token).ConfigureAwait(false);
-#else
-                var response = await HttpUtil.getHttpClient().SendAsync(request, linkedCts.Token).ConfigureAwait(false);
-#endif
                 response.EnsureSuccessStatusCode();
 
                 return response;


### PR DESCRIPTION
This is a long standing issue, I am looking to reopen it as it seems like this repository is getting a bit more focus in the recent timeframe.

Original PRs:

* https://github.com/snowflakedb/snowflake-connector-net/pull/161
* https://github.com/snowflakedb/snowflake-connector-net/pull/163

I and @tdg5 have an internal fork of this library because we require the streaming behavior and our apps run on `netcoreapp3.1` and/or `net5.0`.  We've been using them with this change for quite some time and it seems to work well. I am hoping the [previous problem with Azure automated tests](https://github.com/snowflakedb/snowflake-connector-net/pull/161#issuecomment-523207912) isn't a problem anymore, we'll see when the checks for this PR get run. We'd love to just rely on the official fork, with some of the recent developments in the new 2.0.0 build it seems like we are getting close to being able to do that. However, we can't do that without this change.