### PR TITLE
Prevent unhandled exception when calling Cancel

### DIFF
--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -157,7 +157,7 @@ namespace Snowflake.Data.Core
                     }
                     catch (Exception ex)
                     {
-                        // Prevent an exception from being thrown if Cancel request fails
+                        // Prevent an unhandled exception from being thrown
                         logger.Error("Unable to cancel query.", ex);
                     }
                 });

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -297,15 +297,23 @@ namespace Snowflake.Data.Core
             if (request == null)
                 return;
 
-            var response = _restRequester.Post<NullDataResponse>(request);
+            try
+            {
+                var response = _restRequester.Post<NullDataResponse>(request);
 
-            if (response.success)
+                if (response.success)
+                {
+                    logger.Info("Query cancellation succeed");
+                }
+                else
+                {
+                    logger.Warn("Query cancellation failed.");
+                }
+            } 
+            catch (Exception ex)
             {
-                logger.Info("Query cancellation succeed");
-            }
-            else
-            {
-                logger.Warn("Query cancellation failed.");
+                // Prevent an exception from being thrown if Cancel request fails
+                logger.Error("Unable to cancel query.", ex);
             }
         }
         


### PR DESCRIPTION
Similar to https://github.com/snowflakedb/snowflake-connector-net/pull/296, I ran into the following issue. If for some reason the Cancel request throws an exception when being called by the CancellationToken Register delegate, then it results in an Unhandled Exception that crashes the process. To prevent that issue from occurring, I'm just wrapping this one spot in a Try/Catch with a log message if an exception is caught.

Example of the error from the Event Viewer:
```
instance of Win32_NTLogEvent
{
	Computer = "XXXXX";
	EventCode = 1026;
	EventIdentifier = 1026;
	Logfile = "Application";
	RecordNumber = 145917;
	SourceName = ".NET Runtime";
	TimeGenerated = "20210518150523.000000-000";
	TimeWritten = "20210518150523.000000-000";
	Type = "Error";
	EventType = 1;
	Category = 0;
	CategoryString = "None";
	Message = "Application: w3wp.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Threading.Tasks.TaskCanceledException

Exception Info: System.AggregateException
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean)
   at System.Threading.Tasks.Task`1[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].GetResultCore(Boolean)
   at Snowflake.Data.Core.SFStatement.Cancel()
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.CancellationCallbackInfo.ExecuteCallback()
   at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork(System.Threading.CancellationCallbackCoreWorkArguments)
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean)

Exception Info: System.AggregateException
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean)
   at System.Threading.CancellationTokenSource.NotifyCancellation(Boolean)
   at System.Threading.CancellationCallbackInfo.ExecuteCallback()
   at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork(System.Threading.CancellationCallbackCoreWorkArguments)
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean)

Exception Info: System.AggregateException
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean)
   at System.Threading.CancellationTokenSource.NotifyCancellation(Boolean)
   at System.Threading.CancellationTokenSource.TimerCallbackLogic(System.Object)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.TimerQueueTimer.CallCallback()
   at System.Threading.TimerQueueTimer.Fire()
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```