### PR TITLE
SNOW-219780 - Decimal conversion overflow issue

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -208,6 +208,15 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        [TestCase("79228162514264337593543950336")] // Max decimal value + 1
+        [TestCase("-79228162514264337593543950336")] // Min decimal value - 1
+        [TestCase("79228162514264337593543950335.9999999999999999999999999999")] // The scaling factor range is 0 to 28. Scaling factor = 29 and fractional part > MaxValue
+        public void TestOverflowDecimal(string s)
+        {
+            Assert.Throws<OverflowException>(() => SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal)));
+        }
+
+        [Test]
         [TestCase("9223372036854775807.9223372036854775807")]
         [TestCase("-9223372036854775807.1234567890")]
         [TestCase("-1.300")]

--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -193,6 +193,12 @@ namespace Snowflake.Data.Tests
         [TestCase("999999999999999999.000000000000100000000000")]
         [TestCase("4294967295.4294967296")]
         [TestCase("-0.999")]
+        [TestCase("307.48100000000000000000")]
+        [TestCase("79228162514264337593543950335")] // Max decimal value
+        [TestCase("-79228162514264337593543950335")] // Min decimal value
+        [TestCase("9.9999999999999999999999999999")] // The scaling factor range is 0 to 28
+        [TestCase("-9.9999999999999999999999999999")] // The scaling factor range is 0 to 28
+        [TestCase("79228162514264337593543950334.9999999999999999999999999999")] //A Decimal object has 29 digits of precision. If s represents a number that has more than 29 digits, but has a fractional part and is within the range of MaxValue and MinValue, the number is rounded
         public void TestConvertToDecimal(string s)
         {
             decimal actual = (decimal)SFDataConverter.ConvertToCSharpVal(s, SFDataType.FIXED, typeof(decimal));

--- a/Snowflake.Data/Core/FastParser.cs
+++ b/Snowflake.Data/Core/FastParser.cs
@@ -81,18 +81,45 @@ namespace Snowflake.Data.Core
             // Parse integer part and decimal part as 64-bit numbers
             // Calculate decimal number to return
             int decimalPos = Array.IndexOf<byte>(s, (byte)'.', offset, len);
+
+            // No decimal point found, just parse as integer
             if (decimalPos < 0)
             {
-                // No decimal point found, just parse as integer
-                Int64 i1 = FastParseInt64(s, offset, len);
-                return (decimal)i1;
+                // If len > 19 (the number of digits in int64.MaxValue), the value is likely bigger
+                // than max int64. Potentially, if it is a negative number it could be ok, but it 
+                // is better to not to find out during the call to FastParseInt64.
+                // Fallback to regular decimal constructor from string instead.
+                if (len > 19)
+                    return decimal.Parse(UTF8Buffer.UTF8.GetString(s, offset, len));
+
+                try
+                {
+                    Int64 i1 = FastParseInt64(s, offset, len);
+                    return (decimal)i1;
+                }
+                catch (OverflowException)
+                {
+                    // Fallback to regular decimal constructor from string instead.
+                    return decimal.Parse(UTF8Buffer.UTF8.GetString(s, offset, len));
+                }
             }
             else
             {
                 decimalPos -= offset;
                 int decimalLen = len - decimalPos - 1;
-                Int64 intPart = FastParseInt64(s, offset, decimalPos);
-                Int64 decimalPart = FastParseInt64(s, offset + decimalPos + 1, decimalLen);
+                Int64 intPart = 0;
+                Int64 decimalPart = 0;
+                try
+                {
+                    intPart = FastParseInt64(s, offset, decimalPos);
+                    decimalPart = FastParseInt64(s, offset + decimalPos + 1, decimalLen);
+                }
+                catch (OverflowException)
+                {
+                    // Fallback to regular decimal constructor from string instead.
+                    return decimal.Parse(UTF8Buffer.UTF8.GetString(s, offset, len));
+                }
+
                 bool isMinus = false;
                 if (decimalPart < 0)
                     throw new FormatException();

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -113,9 +113,9 @@ namespace Snowflake.Data.Core
                     throw new SnowflakeDbException(SFError.INTERNAL_ERROR, "Invalid destination type.");
                 }
             }
-            catch (OverflowException)
+            catch (OverflowException e)
             {
-                throw new OverflowException($"Error converting '{srcVal} to {destType.Name}'. Use GetString() to handle very large values");
+                throw new OverflowException($"Error converting '{srcVal} to {destType.Name}'. Use GetString() to handle very large values", e);
             }
         }
 

--- a/Snowflake.Data/Core/UTF8Buffer.cs
+++ b/Snowflake.Data/Core/UTF8Buffer.cs
@@ -7,7 +7,7 @@ namespace Snowflake.Data.Core
     public class UTF8Buffer
     {
         // Cache for maximum performance
-        static Encoding UTF8 = Encoding.UTF8;
+        public static Encoding UTF8 = Encoding.UTF8;
 
         public byte[] Buffer;
         public int offset;


### PR DESCRIPTION
If either the "integer" or fractional part was greater than max int64, the conversion would fail with an overflow error.
The driver now falls back to using the generic decimal.Parse in these cases to prevent incorrect overflow error.
Note that Snowflake numeric can still cause overflow when converted to C# decimal because the C# decimal range is 29 while Snowflake numeric is 38.