### PR TITLE
Better dispose of CancellationTokenSources

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -245,12 +245,17 @@ namespace Snowflake.Data.Core
                         }
                     }
 
+                    if (childCts != null)
+                    {
+                        childCts.Dispose();
+                    }
+
                     if (response != null)
                     {
                         if (response.IsSuccessStatusCode) {
                             return response;
                         }
-                        else 
+                        else
                         {
                             logger.Debug($"Failed Response: {response.ToString()}");
                             bool isRetryable = isRetryableHTTPCode((int)response.StatusCode);
@@ -261,7 +266,7 @@ namespace Snowflake.Data.Core
                             }
                         }
                     }
-                    else 
+                    else
                     {
                         logger.Info("Response returned was null.");
                     }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Core
         
         // Merged cancellation token source for all canellation signal. 
         // Cancel callback will be registered under token issued by this source.
-        private CancellationTokenSource _linkedCancellationTokenSouce;
+        private CancellationTokenSource _linkedCancellationTokenSource;
 
         internal SFStatement(SFSession session, IRestRequester rest)
         {
@@ -119,6 +119,22 @@ namespace Snowflake.Data.Core
             };
         }
 
+        private void CleanUpCancellationTokenSources()
+        {
+            if (_linkedCancellationTokenSource != null)
+            {
+                // This should also take care of cleaning up the cancellation callback that was registered.
+                // https://github.com/microsoft/referencesource/blob/master/mscorlib/system/threading/CancellationTokenSource.cs#L552
+                _linkedCancellationTokenSource.Dispose();
+                _linkedCancellationTokenSource = null;
+            }
+            if (_timeoutTokenSource != null)
+            {
+                _timeoutTokenSource.Dispose();
+                _timeoutTokenSource = null;
+            }
+        }
+
         private SFBaseResultSet BuildResultSet(QueryExecResponse response, CancellationToken cancellationToken)
         {
             if (response.success)
@@ -145,11 +161,11 @@ namespace Snowflake.Data.Core
         private void registerQueryCancellationCallback(int timeout, CancellationToken externalCancellationToken)
         {
             SetTimeout(timeout);
-            _linkedCancellationTokenSouce = CancellationTokenSource.CreateLinkedTokenSource(_timeoutTokenSource.Token,
+            _linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_timeoutTokenSource.Token,
                 externalCancellationToken);
-            if (!_linkedCancellationTokenSouce.IsCancellationRequested)
+            if (!_linkedCancellationTokenSource.IsCancellationRequested)
             {
-                _linkedCancellationTokenSouce.Token.Register(() => 
+                _linkedCancellationTokenSource.Token.Register(() =>
                 {
                     try
                     {
@@ -219,6 +235,7 @@ namespace Snowflake.Data.Core
             }
             finally
             {
+                CleanUpCancellationTokenSources();
                 ClearQueryRequestId();
             }
         }
@@ -271,6 +288,7 @@ namespace Snowflake.Data.Core
             }
             finally
             {
+                CleanUpCancellationTokenSources();
                 ClearQueryRequestId();
             }
         }
@@ -301,12 +319,15 @@ namespace Snowflake.Data.Core
                 };
             }
         }
-        
+
         internal void Cancel()
         {
             SFRestRequest request = BuildCancelQueryRequest();
             if (request == null)
+            {
+                CleanUpCancellationTokenSources();
                 return;
+            }
 
             var response = _restRequester.Post<NullDataResponse>(request);
 
@@ -318,7 +339,7 @@ namespace Snowflake.Data.Core
             {
                 logger.Warn("Query cancellation failed.");
             }
+            CleanUpCancellationTokenSources();
         }
-        
     }
 }


### PR DESCRIPTION
`CancellationTokenSource` implements `IDisposable` so should be disposed. My experience suggests that these do get GC'd eventually as it currently stands, but it seems like explicit handling is more desirable.