### PR TITLE
Supports using full account name with region and cloud platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ The following table lists all valid connection properties:
 
 | Connection Property        | Required | Comment                                                                       |
 |----------------------------|----------|-------------------------------------------------------------------------------|
-| ACCOUNT                    | Yes      | Account should not include region or cloud provider information. e.g. account should be XXX instead of XXX.us-east-1.|
+| ACCOUNT                    | Yes      | Your full account name might include additional segments that identify the region and cloud platform where your account is hosted	|
 | DB                         | No       |                                                                               |
-| HOST                       | No       | If no value is specified, the driver uses \<ACCOUNT\>.snowflakecomputing.com. However, if you are not in us-west deployment, or you want to use global url, HOST is required, e.g. XXX.us-east-1.snowflakecomputing.com, or XXX-jkabfvdjisoa778wqfgeruishafeuw89q.global.snowflakecomputing.com|
+| HOST                       | No       | Specifies the hostname for your account in the following format: \<ACCOUNT\>.snowflakecomputing.com. <br /> If no value is specified, the driver uses \<ACCOUNT\>.snowflakecomputing.com. |
 | PASSWORD                   | Depends  | Required if AUTHENTICATOR is set to `snowflake` (the default value) or the URL for native SSO through Okta. Ignored for all the other authentication types.|
 | ROLE                       | No       |                                                                               |
 | SCHEMA                     | No       |                                                                               |

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -215,8 +215,8 @@ namespace Snowflake.Data.Core
             // Trim the account name to remove the region and cloud platform if any were provided
             // because the login request data does not expect region and cloud information to be 
             // passed on for account_name
-            string account = properties[SFSessionProperty.ACCOUNT];
-            properties[SFSessionProperty.ACCOUNT] = account.Substring(0, account.IndexOf('.'));
+            properties[SFSessionProperty.ACCOUNT] = properties[SFSessionProperty.ACCOUNT].Split('.')[0];
+            
 
             return properties;
         }

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -212,6 +212,12 @@ namespace Snowflake.Data.Core
                 logger.Info($"Compose host name: {hostName}");
             }
 
+            // Trim the account name to remove the region and cloud platform if any were provided
+            // because the login request data does not expect region and cloud information to be 
+            // passed on for account_name
+            string account = properties[SFSessionProperty.ACCOUNT];
+            properties[SFSessionProperty.ACCOUNT] = account.Substring(0, account.IndexOf('.'));
+
             return properties;
         }
 


### PR DESCRIPTION
Adding the capability for the user to provide the full account name directly in the Account setting instead of having to provide it via the Host setting in conjunction with the Account setting as done before.
For example, if the previous connection string was : 
`host={accountVal}.{region}.{cloudPlatform}.snowflakecomputing.com;authenticator=externalbrowser;user=xxx;account={accountVal}`
 
The new connection string is : 
`account={accountVal}.{region}.{cloudPlatform};authenticator=externalbrowser;user=xxx`