### PR TITLE
Re-add Http message logging

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -253,6 +253,7 @@ namespace Snowflake.Data.Core
                     if (response != null)
                     {
                         if (response.IsSuccessStatusCode) {
+                            logger.Debug($"Success Response: {response.ToString()}");
                             return response;
                         }
                         else

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -56,6 +56,7 @@ namespace Snowflake.Data.Core
             using (var response = await SendAsync(HttpMethod.Post, request, cancellationToken).ConfigureAwait(false))
             {
                 var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                logger.Debug($"Post response: {json}");
                 return JsonConvert.DeserializeObject<T>(json);
             }
         }
@@ -71,18 +72,22 @@ namespace Snowflake.Data.Core
             using (HttpResponseMessage response = await GetAsync(request, cancellationToken).ConfigureAwait(false))
             { 
                 var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                logger.Debug($"Get response: {json}");
                 return JsonConvert.DeserializeObject<T>(json);
             }
         }
         
         public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
         {
+            HttpRequestMessage message = request.ToRequestMessage(HttpMethod.Get);
+            logger.Debug($"Http method: {message.ToString()}, http request message: {message.ToString()}");
             return SendAsync(HttpMethod.Get, request, cancellationToken);
         }
 
         public HttpResponseMessage Get(IRestRequest request)
         {
             HttpRequestMessage message = request.ToRequestMessage(HttpMethod.Get);
+            logger.Debug($"Http method: {message.ToString()}, http request message: {message.ToString()}");
 
             //Run synchronous in a new thread-pool task.
             return Task.Run(async () => await GetAsync(request, CancellationToken.None)).Result;


### PR DESCRIPTION
Since SecretDetector is in place, add the logging that was removed in https://github.com/snowflakedb/snowflake-connector-net/pull/188/