### PR TITLE
Add AnsiString support to SFDataConverter.csharpTypeValToSfTypeVal

### DIFF
--- a/Snowflake.Data.Tests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/SFDataConverterTest.cs
@@ -34,6 +34,16 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        [TestCase(System.Data.DbType.AnsiString, "abc", "TEXT", "abc")]
+        [TestCase(System.Data.DbType.AnsiStringFixedLength, "abc", "TEXT", "abc")]
+        public void TestCsharpTypeValToSfTypeVal(System.Data.DbType inputType, object inputValue, string outputType, string outputValue)
+        {
+            Tuple<string, string> actual = SFDataConverter.csharpTypeValToSfTypeVal(inputType, inputValue);
+            Assert.AreEqual(outputType, actual.Item1);
+            Assert.AreEqual(outputValue, actual.Item2);
+        }
+
+        [Test]
         [TestCase("0", false)]
         [TestCase("t", true)]
         [TestCase("T", true)]

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -237,6 +237,8 @@ namespace Snowflake.Data.Core
                     destType = SFDataType.REAL;
                     break;
 
+                case DbType.AnsiString:
+                case DbType.AnsiStringFixedLength:
                 case DbType.Guid:
                 case DbType.String:
                 case DbType.StringFixedLength:


### PR DESCRIPTION
Add AnsiString support to SFDataConverter.csharpTypeValToSfTypeVal, fixing #344 