### PR TITLE
Avoid creating a ServiceCollection to build a HttpClient.

### DIFF
--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -21,9 +21,7 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.15.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />


### PR DESCRIPTION
Simplify the creation of the HttpClient. 
This will avoid the library to depends on heavy dependencies.