### PR TITLE
snow-380 00236853: .NET connection pooling request

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -42,7 +42,7 @@ namespace Snowflake.Data.Tests
                 }
 
                 conn.Close();
-                Assert.AreEqual(ConnectionState.Closed, conn.State);
+                Assert.AreEqual(ConnectionState.Open, conn.State);
             }
         }
 
@@ -63,7 +63,7 @@ namespace Snowflake.Data.Tests
                     Assert.AreEqual(ConnectionState.Open, conn.State);
 
                     conn.Close();
-                    Assert.AreEqual(ConnectionState.Closed, conn.State);
+                    Assert.AreEqual(ConnectionState.Open, conn.State);
                 }
             }
 
@@ -1432,12 +1432,12 @@ namespace Snowflake.Data.Tests
                 // Close the opened connection
                 task = conn.CloseAsync(new CancellationTokenSource().Token);
                 task.Wait();
-                Assert.AreEqual(conn.State, ConnectionState.Closed);
+                Assert.AreEqual(conn.State, ConnectionState.Open);
 
                 // Close the connection again.
                 task = conn.CloseAsync(new CancellationTokenSource().Token);
                 task.Wait();
-                Assert.AreEqual(conn.State, ConnectionState.Closed);
+                Assert.AreEqual(conn.State, ConnectionState.Open);
             }
         }
 

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1259,6 +1259,7 @@ namespace Snowflake.Data.Tests
         {
             using (var conn = new MockSnowflakeDbConnection())
             {
+                SnowflakeDbConnection.ClearAllPools();
                 // No timeout
                 int timeoutSec = 0;
                 string infiniteLoginTimeOut = String.Format(ConnectionString + ";connection_timeout={0}",
@@ -1309,6 +1310,7 @@ namespace Snowflake.Data.Tests
             {
                 using (var conn = new MockSnowflakeDbConnection())
                 {
+                    SnowflakeDbConnection.ClearAllPools();
                     int timeoutSec = 5;
                     string loginTimeOut5sec = String.Format(ConnectionString + "connection_timeout={0}",
                         timeoutSec);
@@ -1347,6 +1349,7 @@ namespace Snowflake.Data.Tests
         {
             using (var conn = new MockSnowflakeDbConnection())
             {
+                SnowflakeDbConnection.ClearAllPools();
                 conn.ConnectionString = ConnectionString;
 
                 Assert.AreEqual(conn.State, ConnectionState.Closed);
@@ -1380,6 +1383,7 @@ namespace Snowflake.Data.Tests
         {
             using (var conn = new SnowflakeDbConnection())
             {
+                SnowflakeDbConnection.ClearAllPools();
                 // Just a way to get a 404 on the login request and make sure there are no retry
                 string invalidConnectionString = "host=docs.microsoft.com;"
                     + "connection_timeout=0;account=testFailFast;user=testFailFast;password=testFailFast;";

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -1,0 +1,204 @@
+﻿/*
+ * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ */
+
+namespace Snowflake.Data.Tests
+{
+    using NUnit.Framework;
+    using Snowflake.Data.Client;
+    using System.Data;
+    using System;
+    using Snowflake.Data.Core;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using Snowflake.Data.Log;
+    using System.Diagnostics;
+    using Snowflake.Data.Tests.Mock;
+    using System.Runtime.InteropServices;
+
+    [TestFixture]
+    class SFConnectionPoolT : SFBaseTest
+    {
+        private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionPoolT>();
+
+        [Test]
+        public void TestBasicConnectionPool()
+        {
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            conn1.Close();
+
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            SnowflakeDbConnection.ClearAllPools();
+        }
+
+        [Test]
+        public void TestReuseConnectionPool()
+        {
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+
+            var conn2 = new SnowflakeDbConnection();
+            conn2.ConnectionString = ConnectionString;
+            conn2.Open();
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+
+            conn1.Close();
+            conn2.Close();
+
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+            SnowflakeDbConnection.ClearAllPools();
+        }
+
+        [Test]
+        public void TestConnectionPoolIsFull()
+        {
+            SnowflakeDbConnection.ClearAllPools();
+            SnowflakeDbConnection.SetMaxPoolSize(2);
+            
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+
+            var conn2 = new SnowflakeDbConnection();
+            conn2.ConnectionString = ConnectionString + " retryCount=1";
+            conn2.Open();
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+
+            var conn3 = new SnowflakeDbConnection();
+            conn3.ConnectionString = ConnectionString + "  retryCount=2";
+            conn3.Open();
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+
+            conn1.Close();
+            conn2.Close();
+            conn3.Close();
+
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+            Assert.AreEqual(ConnectionState.Closed, conn3.State); //out of the pool, so connection state is closed
+            SnowflakeDbConnection.ClearAllPools();
+        }
+
+        [Test]
+        public void TestConnectionPoolClean()
+        {
+            SnowflakeDbConnection.ClearAllPools();
+            SnowflakeDbConnection.SetMaxPoolSize(2);
+
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+
+            var conn2 = new SnowflakeDbConnection();
+            conn2.ConnectionString = ConnectionString + " retryCount=1";
+            conn2.Open();
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+
+            conn2.Close();
+            SnowflakeDbConnection.ClearPool(conn2);
+
+            var conn3 = new SnowflakeDbConnection();
+            conn3.ConnectionString = ConnectionString + "  retryCount=2";
+            conn3.Open();
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+
+
+            conn1.Close();
+            conn3.Close();
+
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            Assert.AreEqual(ConnectionState.Closed, conn2.State);
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+            SnowflakeDbConnection.ClearAllPools();
+        }
+
+        [Test]
+        public void TestConnectionPoolCleanNonActive()
+        {
+            SnowflakeDbConnection.ClearAllPools();
+            SnowflakeDbConnection.SetMaxPoolSize(2);
+
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+
+            var conn2 = new SnowflakeDbConnection();
+            conn2.ConnectionString = ConnectionString + " retryCount=1";
+            conn2.Open();
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+
+            conn1.Close();
+
+            var conn3 = new SnowflakeDbConnection();
+            conn3.ConnectionString = ConnectionString + "  retryCount=2";
+            conn3.Open();
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+
+            var conn4 = new SnowflakeDbConnection();
+            conn4.ConnectionString = ConnectionString + "  retryCount=3";
+            conn4.Open();
+            Assert.AreEqual(ConnectionState.Open, conn4.State);
+
+            conn2.Close();
+            conn3.Close();
+            conn4.Close();
+
+            Assert.AreEqual(ConnectionState.Closed, conn1.State);
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+            Assert.AreEqual(ConnectionState.Closed, conn4.State);
+            SnowflakeDbConnection.ClearAllPools();
+        }
+
+        [Test]
+        public void TestConnectionPoolMinPoolSize()
+        {
+            SnowflakeDbConnection.ClearAllPools();
+            SnowflakeDbConnection.SetMinPoolSize(1);
+            SnowflakeDbConnection.SetMaxPoolSize(2);
+
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+
+            var conn2 = new SnowflakeDbConnection();
+            conn2.ConnectionString = ConnectionString + " retryCount=1";
+            conn2.Open();
+            Assert.AreEqual(ConnectionState.Open, conn2.State);
+
+            conn1.Close();
+            conn2.Close();
+
+            var conn3 = new SnowflakeDbConnection();
+            conn3.ConnectionString = ConnectionString + "  retryCount=2";
+            conn3.Open();
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+
+            var conn4 = new SnowflakeDbConnection();
+            conn4.ConnectionString = ConnectionString + "  retryCount=3";
+            conn4.Open();
+            Assert.AreEqual(ConnectionState.Open, conn4.State);
+
+            conn3.Close();
+            conn4.Close();
+
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            Assert.AreEqual(ConnectionState.Closed, conn2.State);
+            Assert.AreEqual(ConnectionState.Open, conn3.State);
+            Assert.AreEqual(ConnectionState.Closed, conn4.State);
+            SnowflakeDbConnection.ClearAllPools();
+        }
+    }
+}
+
+        

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -202,20 +202,18 @@ namespace Snowflake.Data.Tests
         [Test]
         public void TestConnectionPoolMultiThreading()
         {
-            /*
             SnowflakeDbConnection.ClearAllPools();
-            Thread t1 = new Thread(ThreadProcess1);
-            Thread t2 = new Thread(ThreadProcess2);
+            Thread t1 = new Thread(() => ThreadProcess1(ConnectionString));
+            Thread t2 = new Thread(() => ThreadProcess2(ConnectionString));
 
             t1.Start();
             t2.Start();
-            */
         }
 
-        static void ThreadProcess1()
+        static void ThreadProcess1(string connstr)
         {
             var conn1 = new SnowflakeDbConnection();
-            conn1.ConnectionString = "";
+            conn1.ConnectionString = connstr;
             conn1.Open();
             Thread.Sleep(1000);
             conn1.Close();
@@ -225,10 +223,10 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
         }
 
-        static void ThreadProcess2()
+        static void ThreadProcess2(string connstr)
         {
             var conn1 = new SnowflakeDbConnection();
-            conn1.ConnectionString = "";
+            conn1.ConnectionString = connstr;
             conn1.Open();
 
             Thread.Sleep(5000);

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -218,6 +218,7 @@ namespace Snowflake.Data.Tests
             Thread.Sleep(1000);
             conn1.Close();
             Assert.AreEqual(ConnectionState.Open, conn1.State);
+            Thread.Sleep(4000);
             SnowflakeDbConnection.ClearAllPools();
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
         }

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -202,18 +202,20 @@ namespace Snowflake.Data.Tests
         [Test]
         public void TestConnectionPoolMultiThreading()
         {
+            /*
             SnowflakeDbConnection.ClearAllPools();
             Thread t1 = new Thread(ThreadProcess1);
             Thread t2 = new Thread(ThreadProcess2);
 
             t1.Start();
             t2.Start();
+            */
         }
 
         static void ThreadProcess1()
         {
             var conn1 = new SnowflakeDbConnection();
-            conn1.ConnectionString = "scheme=https;host=simbapartner.snowflakecomputing.com;port=443;account=simbapartner;role=SYSADMIN;db=TESTDB;schema=SEN;warehouse=SIMBA_WH_TEST;user=SEN;password=Sunshine4u4SEN;";
+            conn1.ConnectionString = "";
             conn1.Open();
             Thread.Sleep(1000);
             conn1.Close();
@@ -226,7 +228,7 @@ namespace Snowflake.Data.Tests
         static void ThreadProcess2()
         {
             var conn1 = new SnowflakeDbConnection();
-            conn1.ConnectionString = "scheme=https;host=simbapartner.snowflakecomputing.com;port=443;account=simbapartner;role=SYSADMIN;db=TESTDB;schema=SEN;warehouse=SIMBA_WH_TEST;user=SEN;password=Sunshine4u4SEN;";
+            conn1.ConnectionString = "";
             conn1.Open();
 
             Thread.Sleep(5000);

--- a/Snowflake.Data.Tests/SFPutTest.cs
+++ b/Snowflake.Data.Tests/SFPutTest.cs
@@ -120,7 +120,7 @@ namespace Snowflake.Data.Tests
                 File.Delete(filePath);
 
                 conn.Close();
-                Assert.AreEqual(ConnectionState.Closed, conn.State);
+                Assert.AreEqual(ConnectionState.Open, conn.State);
             }
         }
     }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Data.Client
 
         internal int _connectionTimeout;
 
-        internal bool isActive = false;
+        internal int _refCount = 0;
 
         private bool disposed = false;
 
@@ -70,7 +70,7 @@ namespace Snowflake.Data.Client
             this.SfSession = conn.SfSession;
             this._connectionState = conn._connectionState;
             this._connectionTimeout = conn._connectionTimeout;
-            this.isActive = conn.isActive;
+            this._refCount = conn._refCount;
             this.disposed = conn.disposed;
             this.ConnectionString = conn.ConnectionString;
             this.Password = conn.Password;
@@ -146,7 +146,7 @@ namespace Snowflake.Data.Client
             SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString, this.Password);
             if (conn != null)
             {
-                conn.isActive = false;
+                conn._refCount--;
             }
             else
             {
@@ -159,7 +159,7 @@ namespace Snowflake.Data.Client
             SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString, this.Password);
             if (conn != null)
             {
-                conn.isActive = false;
+                conn._refCount--;
                 return Task.CompletedTask;
             }
             else
@@ -218,7 +218,7 @@ namespace Snowflake.Data.Client
             SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString, this.Password);
             if(conn != null)
             {
-                conn.isActive = true;
+                conn._refCount++;
                 this.copy(conn);
             }
             else
@@ -234,6 +234,7 @@ namespace Snowflake.Data.Client
             SetSession();
             try
             {
+                _refCount++;
                 SfSession.Open();
             }
             catch (Exception e)
@@ -264,7 +265,6 @@ namespace Snowflake.Data.Client
             SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString, this.Password);
             if (conn != null)
             {
-                conn.isActive = true;
                 this.copy(conn);
                 return Task.CompletedTask;
             }
@@ -392,7 +392,7 @@ namespace Snowflake.Data.Client
         {
             if (SnowflakeDbConnectionPool.getConnection(this.ConnectionString, this.Password) != null)
             {
-                this.isActive = false;
+                this._refCount--;
             }
             else
             {

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Client
             }
             else
             {
-                conn.CloseConnection();
+                CloseConnection();
             }
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using System.Data;
 using System.Threading;
 using Snowflake.Data.Log;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Snowflake.Data.Client
 {
@@ -24,7 +26,154 @@ namespace Snowflake.Data.Client
 
         internal int _connectionTimeout;
 
+        private bool isActive = false;
+
         private bool disposed = false;
+
+        /// <summary>
+        ///     Connection pool 
+        /// </summary>
+        private static ConcurrentDictionary<Tuple<string, SecureString>, SnowflakeDbConnection> connectionPool;
+        private static int minPoolSize;
+        private static int maxPoolSize;
+        private static int cleanupCounter;
+        private static int currentCounter;
+        private const int MIN_POOL_SIZE = 0;
+        private const int MAX_POOL_SIZE = 10;
+        private const int CLEANUP_COUNTER = 0;
+
+        private static void initConnectionPool()
+        {
+            connectionPool = new ConcurrentDictionary<Tuple<string, SecureString>, SnowflakeDbConnection>();
+            minPoolSize = MIN_POOL_SIZE;
+            maxPoolSize = MAX_POOL_SIZE;
+            cleanupCounter = CLEANUP_COUNTER;
+            currentCounter = 0;
+        }
+
+        private static void cleanNonActiveConnections()
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            List<Tuple<string, SecureString>> keys = new List<Tuple<string, SecureString>>(connectionPool.Keys);
+            int curSize = keys.Count;
+            foreach (var item in keys)
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(item, out conn);
+                if (!conn.isActive && curSize > minPoolSize)
+                {
+                    connectionPool.TryRemove(item, out conn);
+                    conn.CloseConnection();
+                    conn.Dispose(false);
+                    curSize--;
+                }
+            }
+        }
+
+        private static SnowflakeDbConnection getConnection(string connStr, SecureString pw)
+        {
+            var connKey = Tuple.Create(connStr, pw);
+            if (connectionPool == null)
+            {
+                initConnectionPool();
+            }
+            if (connectionPool.ContainsKey(connKey))
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(connKey, out conn);
+                return conn;
+            }
+            return null;
+        }
+
+        private static bool addConnection(SnowflakeDbConnection conn)
+        {
+            var connKey = Tuple.Create(conn.ConnectionString, conn.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                conn.isActive = true;
+                return false;
+            }
+
+            if (connectionPool.Count >= maxPoolSize)
+            {
+                if (currentCounter > 0)
+                {
+                    currentCounter--;
+                    return false;
+                }
+                else
+                {
+                    currentCounter = cleanupCounter;
+                    cleanNonActiveConnections();
+                    if (connectionPool.Count >= maxPoolSize)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            conn.isActive = true;
+            connectionPool.TryAdd(connKey, conn);
+            return true;
+        }
+
+        public static void ClearAllPools()
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            List<Tuple<string, SecureString>> keys = new List<Tuple<string, SecureString>>(connectionPool.Keys);
+            foreach (var item in keys)
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(item, out conn);
+                connectionPool.TryRemove(item, out conn);
+                conn.isActive = false;
+                conn.CloseConnection();
+                conn.Dispose(false);
+            }
+        }
+
+        public static bool ClearPool(SnowflakeDbConnection conn)
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            var connKey = Tuple.Create(conn.ConnectionString, conn.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                connectionPool.TryRemove(connKey, out conn);
+                conn.isActive = false;
+                conn.CloseConnection();
+                conn.Dispose(false);
+                return true;
+            }
+            return false;
+        }
+
+        public static void SetMinPoolSize(int size)
+        {
+            minPoolSize = size;
+        }
+
+        public static void SetMaxPoolSize(int size)
+        {
+            maxPoolSize = size;
+        }
+
+        public static void SetCleanupCounter(int size)
+        {
+            cleanupCounter = size;
+        }
 
         public SnowflakeDbConnection()
         {
@@ -32,6 +181,18 @@ namespace Snowflake.Data.Client
             _connectionTimeout = 
                 int.Parse(SFSessionProperty.CONNECTION_TIMEOUT.GetAttribute<SFSessionPropertyAttr>().
                     defaultValue);
+        }
+
+        private void copy(SnowflakeDbConnection conn)
+        {
+            this.logger = conn.logger;
+            this.SfSession = conn.SfSession;
+            this._connectionState = conn._connectionState;
+            this._connectionTimeout = conn._connectionTimeout;
+            this.isActive = conn.isActive;
+            this.disposed = conn.disposed;
+            this.ConnectionString = conn.ConnectionString;
+            this.Password = conn.Password;
         }
 
         public override string ConnectionString
@@ -88,10 +249,9 @@ namespace Snowflake.Data.Client
             }
         }
 
-        public override void Close()
+        private void CloseConnection()
         {
             logger.Debug("Close Connection.");
-
             if (_connectionState != ConnectionState.Closed && SfSession != null)
             {
                 SfSession.close();
@@ -100,9 +260,36 @@ namespace Snowflake.Data.Client
             _connectionState = ConnectionState.Closed;
         }
 
+        public override void Close()
+        {
+            SnowflakeDbConnection conn = getConnection(this.ConnectionString, this.Password);
+            if (conn != null)
+            {
+                conn.isActive = false;
+            }
+            else
+            {
+                CloseConnection();
+            }
+        }
+
         public Task CloseAsync(CancellationToken cancellationToken)
         {
-            logger.Debug("Close Connection.");
+            SnowflakeDbConnection conn = getConnection(this.ConnectionString, this.Password);
+            if (conn != null)
+            {
+                conn.isActive = false;
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return CloseConnectionAsync(cancellationToken);
+            }
+        }
+
+        private Task CloseConnectionAsync(CancellationToken cancellationToken)
+        {
+            logger.Debug("Close Connection Async.");
             TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
             if (cancellationToken.IsCancellationRequested)
@@ -147,6 +334,26 @@ namespace Snowflake.Data.Client
 
         public override void Open()
         {
+            if(null == connectionPool)
+            {
+                initConnectionPool();
+            }
+            
+            SnowflakeDbConnection conn = getConnection(this.ConnectionString, this.Password);
+            if(conn != null)
+            {
+                conn.isActive = true;
+                this.copy(conn);
+            }
+            else
+            {
+                ConnectionOpen();
+                addConnection(this);
+            }
+        }
+
+        private void ConnectionOpen()
+        {
             logger.Debug("Open Connection.");
             SetSession();
             try
@@ -160,7 +367,7 @@ namespace Snowflake.Data.Client
                 logger.Error("Unable to connect", e);
                 if (!(e.GetType() == typeof(SnowflakeDbException)))
                 {
-                    throw 
+                    throw
                        new SnowflakeDbException(
                            e,
                            SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
@@ -175,9 +382,29 @@ namespace Snowflake.Data.Client
             OnSessionEstablished();
         }
 
+
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
-            logger.Debug("Open Connection.");
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+            SnowflakeDbConnection conn = getConnection(this.ConnectionString, this.Password);
+            if (conn != null)
+            {
+                conn.isActive = true;
+                this.copy(conn);
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return OpenConnectionAsync(cancellationToken);
+            }
+        }
+
+        private Task OpenConnectionAsync(CancellationToken cancellationToken)
+        { 
+            logger.Debug("Open Connection Async.");
             registerConnectionCancellationCallback(cancellationToken);
             SetSession();
 
@@ -206,6 +433,7 @@ namespace Snowflake.Data.Client
                         logger.Debug("All good");
                         // Only continue if the session was opened successfully
                         OnSessionEstablished();
+                        addConnection(this);
                     }
                 },
                 cancellationToken);
@@ -246,6 +474,12 @@ namespace Snowflake.Data.Client
 
         protected override void Dispose(bool disposing)
         {
+            var connKey = Tuple.Create(this.ConnectionString, this.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                ClearPool(this);
+            }
+
             if (disposed)
                 return;
 
@@ -280,7 +514,15 @@ namespace Snowflake.Data.Client
 
         ~SnowflakeDbConnection()
         {
-            Dispose(false);
-        }
+            var connKey = Tuple.Create(this.ConnectionString, this.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                this.isActive = false;
+            }
+            else
+            {
+                Dispose(false);
+            }
+        }        
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -164,7 +164,7 @@ namespace Snowflake.Data.Client
             }
             else
             {
-                return conn.CloseConnectionAsync(cancellationToken);
+                return this.CloseConnectionAsync(cancellationToken);
             }
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Collections.Concurrent;
+using System.Security;
+
+namespace Snowflake.Data.Client
+{
+    class SnowflakeDbConnectionPool
+    {
+        private static ConcurrentDictionary<Tuple<string, SecureString>, SnowflakeDbConnection> connectionPool;
+        private static int minPoolSize;
+        private static int maxPoolSize;
+        private static int cleanupCounter;
+        private static int currentCounter;
+        private const int MIN_POOL_SIZE = 0;
+        private const int MAX_POOL_SIZE = 10;
+        private const int CLEANUP_COUNTER = 0;
+
+        private static void initConnectionPool()
+        {
+            connectionPool = new ConcurrentDictionary<Tuple<string, SecureString>, SnowflakeDbConnection>();
+            minPoolSize = MIN_POOL_SIZE;
+            maxPoolSize = MAX_POOL_SIZE;
+            cleanupCounter = CLEANUP_COUNTER;
+            currentCounter = 0;
+        }
+
+        private static void cleanNonActiveConnections()
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            List<Tuple<string, SecureString>> keys = new List<Tuple<string, SecureString>>(connectionPool.Keys);
+            int curSize = keys.Count;
+            foreach (var item in keys)
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(item, out conn);
+                if (!conn.isActive && curSize > minPoolSize)
+                {
+                    connectionPool.TryRemove(item, out conn);
+                    conn.CloseConnection();
+                    conn.DisposeConnection(false);
+                    curSize--;
+                }
+            }
+        }
+
+        internal static SnowflakeDbConnection getConnection(string connStr, SecureString pw)
+        {
+            var connKey = Tuple.Create(connStr, pw);
+            if (connectionPool == null)
+            {
+                initConnectionPool();
+            }
+            if (connectionPool.ContainsKey(connKey))
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(connKey, out conn);
+                return conn;
+            }
+            return null;
+        }
+
+        internal static bool addConnection(SnowflakeDbConnection conn)
+        {
+            var connKey = Tuple.Create(conn.ConnectionString, conn.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                conn.isActive = true;
+                return false;
+            }
+
+            if (connectionPool.Count >= maxPoolSize)
+            {
+                if (currentCounter > 0)
+                {
+                    currentCounter--;
+                    return false;
+                }
+                else
+                {
+                    currentCounter = cleanupCounter;
+                    cleanNonActiveConnections();
+                    if (connectionPool.Count >= maxPoolSize)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            conn.isActive = true;
+            connectionPool.TryAdd(connKey, conn);
+            return true;
+        }
+
+        public static void ClearAllPools()
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            List<Tuple<string, SecureString>> keys = new List<Tuple<string, SecureString>>(connectionPool.Keys);
+            foreach (var item in keys)
+            {
+                SnowflakeDbConnection conn;
+                connectionPool.TryGetValue(item, out conn);
+                connectionPool.TryRemove(item, out conn);
+                conn.isActive = false;
+                conn.CloseConnection();
+                conn.DisposeConnection(false);
+            }
+        }
+
+        public static bool ClearPool(SnowflakeDbConnection conn)
+        {
+            if (null == connectionPool)
+            {
+                initConnectionPool();
+            }
+
+            var connKey = Tuple.Create(conn.ConnectionString, conn.Password);
+            if (connectionPool.ContainsKey(connKey))
+            {
+                connectionPool.TryRemove(connKey, out conn);
+                conn.isActive = false;
+                conn.CloseConnection();
+                conn.DisposeConnection(false);
+                return true;
+            }
+            return false;
+        }
+
+        public static void SetMinPoolSize(int size)
+        {
+            minPoolSize = size;
+        }
+
+        public static void SetMaxPoolSize(int size)
+        {
+            maxPoolSize = size;
+        }
+
+        public static void SetCleanupCounter(int size)
+        {
+            cleanupCounter = size;
+        }
+    }
+}

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -67,11 +67,6 @@ namespace Snowflake.Data.Core
         private static readonly string COMPRESSION_AUTO_DETECT = "auto_detect";
 
         /// <summary>
-        /// none keyword for no source compression.
-        /// </summary>
-        private static readonly string COMPRESSION_NONE = "none";
-
-        /// <summary>
         /// The Snowflake query
         /// </summary>
         private string Query;


### PR DESCRIPTION
I created a static Concurrent Dictionary for the connection pool. And updated those open and close functions for the connection pool feature. Therefore the old test case I have to change the connection status from close to open, after connection close, because that connection remains at the connection pool.
