### PR TITLE
Refactor the exception thrown for incorrect private key

### DIFF
--- a/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
@@ -135,6 +135,7 @@ namespace Snowflake.Data.Core.Authenticator
                 catch (Exception e)
                 {
                     throw new SnowflakeDbException(
+                        e,
                         SFError.JWT_ERROR_READING_PK,
                         hasPkPath ? pkPath : "with value passed in connection string",
                         (pkContent == null) ? e.ToString() : "incorrect private key value or " +


### PR DESCRIPTION
Follow up PR for https://github.com/snowflakedb/snowflake-connector-net/pull/459
Based off https://github.com/snowflakedb/snowflake-connector-net/pull/452

Added the missing exception for key pair