### PR TITLE
Ignore hanging test for now

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -139,6 +139,7 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        [Ignore("Disable unstable test cases for now")]
         public void TestConnectionPoolFull()
         {
             SnowflakeDbConnectionPool.ClearAllPools();

--- a/Snowflake.Data.Tests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/SFPutGetTest.cs
@@ -24,6 +24,9 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        // PutGetTest hang on AWS so ignore it for now until we find the root cause
+        [IgnoreOnEnvIs("snowflake_cloud_env",
+                       new string[] { "AWS" })]
         [TestCase("gzip")]
         [TestCase("bzip2")]
         [TestCase("brotli")]


### PR DESCRIPTION
put get test case start to hang on AWS+Windows+.net472 on github. It doesn't seem to related to recent changes and can't be reproduced locally. Ignore it for now until we find the root cause.