### PR TITLE
Add unit test for isRetryableHTTPCode() function

### DIFF
--- a/Snowflake.Data.Tests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/HttpUtilTest.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+namespace Snowflake.Data.Tests
+{
+    using NUnit.Framework;
+    using Snowflake.Data.Core;
+    using RichardSzalay.MockHttp;
+    using System.Threading.Tasks;
+    using System.Net;
+
+    [TestFixture]
+    class HttpUtilTest
+    {
+        [Test]
+        // Parameters: status code, force retry on 404, expected retryable value
+        [TestCase(HttpStatusCode.OK, false, false)]
+        [TestCase(HttpStatusCode.BadRequest, false, false)]
+        [TestCase(HttpStatusCode.Forbidden, false, true)]
+        [TestCase(HttpStatusCode.NotFound, false, false)]
+        [TestCase(HttpStatusCode.NotFound, true, true)] // force retry on 404
+        [TestCase(HttpStatusCode.RequestTimeout, false, true)]
+        [TestCase(HttpStatusCode.InternalServerError, false, true)]
+        [TestCase(HttpStatusCode.ServiceUnavailable, false, true)]
+        public async Task TestIsRetryableHTTPCode(HttpStatusCode statusCode, bool forceRetryOn404, bool expectedIsRetryable)
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://test.snowflakecomputing.com")
+            .Respond(statusCode);
+            var client = mockHttp.ToHttpClient();
+            var response = await client.GetAsync("https://test.snowflakecomputing.com");
+
+            bool actualIsRetryable = HttpUtil.isRetryableHTTPCode((int)response.StatusCode, forceRetryOn404);
+
+            Assert.AreEqual(expectedIsRetryable, actualIsRetryable);
+        }
+    }
+}

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\Snowflake.Data\Snowflake.Data.csproj" />
   </ItemGroup>

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -341,7 +341,7 @@ namespace Snowflake.Data.Core
                         else
                         {
                             logger.Debug($"Failed Response: StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
-                            bool isRetryable = isRetryableHTTPCode((int)response.StatusCode);
+                            bool isRetryable = isRetryableHTTPCode((int)response.StatusCode, forceRetryOn404);
 
                             if (!isRetryable || disableRetry)
                             {
@@ -376,22 +376,22 @@ namespace Snowflake.Data.Core
                     }
                 }
             }
+        }
 
-            /// <summary>
-            /// Check whether or not the error is retryable or not.
-            /// </summary>
-            /// <param name="statusCode">The http status code.</param>
-            /// <returns>True if the request should be retried, false otherwise.</returns>
-            private bool isRetryableHTTPCode(int statusCode)
-            {
-                if (forceRetryOn404 && statusCode == 404)
-                    return true;
-                return (500 <= statusCode) && (statusCode < 600) ||
-                // Forbidden
-                (statusCode == 403) ||
-                // Request timeout
-                (statusCode == 408);
-            }
+        /// <summary>
+        /// Check whether or not the error is retryable or not.
+        /// </summary>
+        /// <param name="statusCode">The http status code.</param>
+        /// <returns>True if the request should be retried, false otherwise.</returns>
+        static public bool isRetryableHTTPCode(int statusCode, bool forceRetryOn404)
+        {
+            if (forceRetryOn404 && statusCode == 404)
+                return true;
+            return (500 <= statusCode) && (statusCode < 600) ||
+            // Forbidden
+            (statusCode == 403) ||
+            // Request timeout
+            (statusCode == 408);
         }
     }
 }


### PR DESCRIPTION
Based on SF# 00373675

Refactored the isRetryableHTTPCode() function outside of the RetryHandler class to allow testing