### PR TITLE
Flush block after copying decrypted stream

### DIFF
--- a/Snowflake.Data.Tests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/SFPutGetTest.cs
@@ -216,7 +216,7 @@ namespace Snowflake.Data.Tests
                                 Assert.AreEqual(reader.GetString(4), DOWNLOADED);
 
                                 // Check file contents
-                                using (var streamReader = new StreamReader($@"{tempDirectory}\{fileName}"))
+                                using (var streamReader = new StreamReader($@"{tempDirectory}/{fileName}"))
                                 {
                                     while (!streamReader.EndOfStream)
                                     {

--- a/Snowflake.Data.Tests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/SFPutGetTest.cs
@@ -214,6 +214,20 @@ namespace Snowflake.Data.Tests
                             {
                                 // Check file status
                                 Assert.AreEqual(reader.GetString(4), DOWNLOADED);
+
+                                // Check file contents
+                                using (var streamReader = new StreamReader($@"{tempDirectory}\{fileName}"))
+                                {
+                                    while (!streamReader.EndOfStream)
+                                    {
+                                        var line = streamReader.ReadLine();
+                                        var values = line.Split(',');
+
+                                        Assert.AreEqual(COL1_DATA, values[0]);
+                                        Assert.AreEqual(COL2_DATA, values[1]);
+                                        Assert.AreEqual(COL3_DATA, values[2]);
+                                    }
+                                }
                             }
 
                             // Delete downloaded files

--- a/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
@@ -241,6 +241,7 @@ namespace Snowflake.Data.Core.FileTransfer
             {
                 inStream.CopyTo(cryptoStream);
             }
+            cryptoStream.FlushFinalBlock();
 
             return targetStream.ToArray();
         }

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -133,6 +133,11 @@ namespace Snowflake.Data.Core
         private string destStagePath = null;
 
         /// <summary>
+        /// Placeholder threshold value.
+        /// </summary>
+        private long DATA_SIZE_THRESHOLD = 9223372036854775807;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         public SFFileTransferAgent(
@@ -221,7 +226,7 @@ namespace Snowflake.Data.Core
             {
                 // If the file is larger than the threshold, add it to the large files list
                 // Otherwise add it to the small files list
-                if (fileMetadata.srcFileSize > TransferMetadata.threshold)
+                if (fileMetadata.srcFileSize > DATA_SIZE_THRESHOLD)
                 {
                     LargeFilesMetas.Add(fileMetadata);
                 }
@@ -464,7 +469,7 @@ namespace Snowflake.Data.Core
                         sourceCompression = compressionType,
                         presignedUrl = TransferMetadata.stageInfo.presignedUrl,
                         // If the file is under the threshold, don't upload in chunks, set parallel to 1
-                        parallel = (memoryStream == null) && (fileInfo.Length > TransferMetadata.threshold) ?
+                        parallel = (memoryStream == null) && (fileInfo.Length > DATA_SIZE_THRESHOLD) ?
                             TransferMetadata.parallel : 1,
                         memoryStream = memoryStream,
                     };

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -474,6 +474,9 @@ namespace Snowflake.Data.Core
                         memoryStream = memoryStream,
                     };
 
+                    /// The storage client used to upload data from files or streams
+                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+
                     if (!fileMetadata.requireCompress)
                     {
                         // The file is already compressed
@@ -511,6 +514,15 @@ namespace Snowflake.Data.Core
                         parallel = TransferMetadata.parallel,
                         encryptionMaterial = TransferMetadata.encryptionMaterial[index]
                     };
+
+                    /// The storage client used to download data from files or streams
+                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+                    FileHeader fileHeader = fileMetadata.client.GetFileHeader(fileMetadata);
+
+                    if (fileHeader != null)
+                    {
+                        fileMetadata.srcFileSize = fileHeader.contentLength;
+                    }
 
                     FilesMetas.Add(fileMetadata);
                 }
@@ -750,8 +762,6 @@ namespace Snowflake.Data.Core
         private void UploadFilesInSequential(
             SFFileMetadata fileMetadata)
         {
-            /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
             SFFileMetadata resultMetadata = UploadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
@@ -779,8 +789,6 @@ namespace Snowflake.Data.Core
         private void DownloadFilesInSequential(
             SFFileMetadata fileMetadata)
         {
-            /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
             SFFileMetadata resultMetadata = DownloadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -133,9 +133,9 @@ namespace Snowflake.Data.Core
         private string destStagePath = null;
 
         /// <summary>
-        /// Placeholder threshold value.
+        /// Placeholder threshold value using max long value.
         /// </summary>
-        private long DATA_SIZE_THRESHOLD = 9223372036854775807;
+        private long DATA_SIZE_THRESHOLD = Int64.MaxValue;
 
         /// <summary>
         /// Constructor.

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -149,6 +149,7 @@ namespace Snowflake.Data.Core
             Query = query;
             Session = session;
             TransferMetadata = responseData;
+            TransferMetadata.threshold = DATA_SIZE_THRESHOLD;
             CommandType = (CommandTypes)Enum.Parse(typeof(CommandTypes), TransferMetadata.command, true);
             externalCancellationToken = cancellationToken;
         }
@@ -164,6 +165,7 @@ namespace Snowflake.Data.Core
             Query = query;
             Session = session;
             TransferMetadata = responseData;
+            TransferMetadata.threshold = DATA_SIZE_THRESHOLD;
             memoryStream = inputStream;
             streamDestFileName = filename;
             destStagePath = stagePath;
@@ -226,7 +228,7 @@ namespace Snowflake.Data.Core
             {
                 // If the file is larger than the threshold, add it to the large files list
                 // Otherwise add it to the small files list
-                if (fileMetadata.srcFileSize > DATA_SIZE_THRESHOLD)
+                if (fileMetadata.srcFileSize > TransferMetadata.threshold)
                 {
                     LargeFilesMetas.Add(fileMetadata);
                 }
@@ -469,7 +471,7 @@ namespace Snowflake.Data.Core
                         sourceCompression = compressionType,
                         presignedUrl = TransferMetadata.stageInfo.presignedUrl,
                         // If the file is under the threshold, don't upload in chunks, set parallel to 1
-                        parallel = (memoryStream == null) && (fileInfo.Length > DATA_SIZE_THRESHOLD) ?
+                        parallel = (memoryStream == null) && (fileInfo.Length > TransferMetadata.threshold) ?
                             TransferMetadata.parallel : 1,
                         memoryStream = memoryStream,
                     };

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -524,6 +524,7 @@ namespace Snowflake.Data.Core
                     if (fileHeader != null)
                     {
                         fileMetadata.srcFileSize = fileHeader.contentLength;
+                        fileMetadata.encryptionMetadata = fileHeader.encryptionMetadata;
                     }
 
                     FilesMetas.Add(fileMetadata);

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
@@ -269,16 +269,18 @@ namespace Snowflake.Data.Core.FileTransfer
                           * One example of this is the utils that use presigned url
                           * for upload / download and not the storage client library.
                           **/
-                        FileHeader fileHeader = client.GetFileHeader(fileMetadata);
+                        FileHeader fileHeader = null;
                         if (fileMetadata.presignedUrl != null)
                         {
                             fileHeader = client.GetFileHeader(fileMetadata);
                         }
 
+                        SFEncryptionMetadata encryptionMetadata = fileHeader != null ? fileHeader.encryptionMetadata : fileMetadata.encryptionMetadata;
+
                         string tmpDstName = EncryptionProvider.DecryptFile(
                           fullDstPath,
                           fileMetadata.encryptionMaterial,
-                          fileHeader.encryptionMetadata
+                          encryptionMetadata
                           );
 
                         File.Delete(fullDstPath);

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
@@ -245,12 +245,6 @@ namespace Snowflake.Data.Core.FileTransfer
             }
 
             ISFRemoteStorageClient client = fileMetadata.client;
-            FileHeader fileHeader = client.GetFileHeader(fileMetadata);
-
-            if (fileHeader != null)
-            {
-                fileMetadata.srcFileSize = fileHeader.contentLength;
-            }
 
             int maxConcurrency = fileMetadata.parallel;
             Exception lastErr = null;
@@ -275,6 +269,7 @@ namespace Snowflake.Data.Core.FileTransfer
                           * One example of this is the utils that use presigned url
                           * for upload / download and not the storage client library.
                           **/
+                        FileHeader fileHeader = client.GetFileHeader(fileMetadata);
                         if (fileMetadata.presignedUrl != null)
                         {
                             fileHeader = client.GetFileHeader(fileMetadata);

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -282,7 +282,7 @@ namespace Snowflake.Data.Core
         internal int parallel { get; set; }
 
         [JsonProperty(PropertyName = "threshold", NullValueHandling = NullValueHandling.Ignore)]
-        internal int threshold { get; set; }
+        internal long threshold { get; set; }
 
         [JsonProperty(PropertyName = "autoCompress", NullValueHandling = NullValueHandling.Ignore)]
         internal bool autoCompress { get; set; }


### PR DESCRIPTION
Fix issue where block is not flushed after decrypted stream causing the downloaded file to be incomplete