### PR TITLE
PUT command refactors + proxy for S3 client

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/SFFileMetadata.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileMetadata.cs
@@ -23,6 +23,17 @@ namespace Snowflake.Data.Core.FileTransfer
     }
 
     /// <summary>
+    /// The proxy credentials of the client.
+    /// </summary>
+    internal class ProxyCredentials
+    {
+        public string ProxyHost { get; set; }
+        public int ProxyPort { get; set; }
+        public string ProxyUser { get; set; }
+        public string ProxyPassword { get; set; }
+    }
+
+    /// <summary>
     /// Metadata used by the remote storage client to upload or download a file/stream.
     /// </summary>
     internal class SFFileMetadata
@@ -108,5 +119,8 @@ namespace Snowflake.Data.Core.FileTransfer
         public bool sourceFromStream { get; set; }
 
         public MemoryStream memoryStream {get; set; }
+
+        // Proxy credentials of the remote storage client.
+        public ProxyCredentials proxyCredentials { get; set; }
     }
 }

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -764,7 +764,7 @@ namespace Snowflake.Data.Core
 
             RenewClientMutex.ReleaseMutex();
 
-            return SFRemoteStorageUtil.GetRemoteStorage(response.data);
+            return SFRemoteStorageUtil.GetRemoteStorage(response.data, fileMetadata.proxyCredentials);
         }
 
         /// <summary>
@@ -776,7 +776,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata, fileMetadata.proxyCredentials);
             SFFileMetadata resultMetadata = UploadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
@@ -805,7 +805,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata, fileMetadata.proxyCredentials);
             SFFileMetadata resultMetadata = DownloadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -394,7 +394,7 @@ namespace Snowflake.Data.Core
             // Extract file path from PUT command:
             // E.g. "PUT file://C:<path-to-file> @DB.SCHEMA.%TABLE;"
             int startIndex = query.IndexOf("file://") + "file://".Length;
-            int endIndex = query.Substring(startIndex).IndexOf(' ');
+            int endIndex = query.Substring(startIndex).IndexOf('@') - 1;
             string filePath = query.Substring(startIndex, endIndex);
             return filePath;
         }

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -928,8 +928,6 @@ namespace Snowflake.Data.Core
 
             for (int count = 0; count < 10; count++)
             {
-                resultMetadata = UploadSingleFile(fileMetadata);
-
                 if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
                 {
                     fileMetadata.client = renewExpiredClient(fileMetadata.proxyCredentials);

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Core
         /// <summary>
         /// The file metadata. Applies to all files being uploaded/downloaded
         /// </summary>
-        private readonly PutGetResponseData TransferMetadata;
+        private PutGetResponseData TransferMetadata;
 
         /// <summary>
         /// The path to the user home directory.

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -592,7 +592,7 @@ namespace Snowflake.Data.Core
                     };
 
                     /// The storage client used to upload data from files or streams
-                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
 
                     if (!fileMetadata.requireCompress)
                     {
@@ -651,7 +651,7 @@ namespace Snowflake.Data.Core
                     };
 
                     /// The storage client used to download data from files or streams
-                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+                    fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
                     FileHeader fileHeader = fileMetadata.client.GetFileHeader(fileMetadata);
 
                     if (fileHeader != null)
@@ -1040,8 +1040,6 @@ namespace Snowflake.Data.Core
         private async Task DownloadFilesInSequentialAsync(
             SFFileMetadata fileMetadata, CancellationToken cancellationToken)
         {
-            /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
             SFFileMetadata resultMetadata = await DownloadSingleFileAsync(fileMetadata, cancellationToken).ConfigureAwait(false);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -747,7 +747,7 @@ namespace Snowflake.Data.Core
         /// Renew expired client.
         /// </summary>
         /// <returns>The renewed storage client.</returns>
-        private ISFRemoteStorageClient renewExpiredClient()
+        private ISFRemoteStorageClient renewExpiredClient(ProxyCredentials proxyCredentials)
         {
             RenewClientMutex.WaitOne();
 
@@ -764,7 +764,7 @@ namespace Snowflake.Data.Core
 
             RenewClientMutex.ReleaseMutex();
 
-            return SFRemoteStorageUtil.GetRemoteStorage(response.data, fileMetadata.proxyCredentials);
+            return SFRemoteStorageUtil.GetRemoteStorage(response.data, proxyCredentials);
         }
 
         /// <summary>
@@ -781,7 +781,7 @@ namespace Snowflake.Data.Core
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
             {
-                fileMetadata.client = renewExpiredClient();
+                fileMetadata.client = renewExpiredClient(fileMetadata.proxyCredentials);
             }
             else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
             {
@@ -810,7 +810,7 @@ namespace Snowflake.Data.Core
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
             {
-                fileMetadata.client = renewExpiredClient();
+                fileMetadata.client = renewExpiredClient(fileMetadata.proxyCredentials);
             }
             else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
             {

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -472,6 +472,7 @@ namespace Snowflake.Data.Core
                         parallel = (memoryStream == null) && (fileInfo.Length > TransferMetadata.threshold) ?
                             TransferMetadata.parallel : 1,
                         memoryStream = memoryStream,
+                        proxyCredentials = null
                     };
 
                     if (!fileMetadata.requireCompress)
@@ -490,6 +491,24 @@ namespace Snowflake.Data.Core
                     if (EncryptionMaterials.Count > 0)
                     {
                         fileMetadata.encryptionMaterial = EncryptionMaterials[0];
+                    }
+
+                    if (Session.properties.ContainsKey(SFSessionProperty.PROXYHOST))
+                    {
+                        string host, port, user, password;
+                        Session.properties.TryGetValue(SFSessionProperty.PROXYHOST, out host);
+                        Session.properties.TryGetValue(SFSessionProperty.PROXYPORT, out port);
+                        Session.properties.TryGetValue(SFSessionProperty.PROXYUSER, out user);
+                        Session.properties.TryGetValue(SFSessionProperty.PROXYPASSWORD, out password);
+
+
+                        fileMetadata.proxyCredentials = new ProxyCredentials()
+                        {
+                            ProxyHost = host,
+                            ProxyPort = Convert.ToInt32(port),
+                            ProxyUser = host,
+                            ProxyPassword = password
+                        };
                     }
 
                     FilesMetas.Add(fileMetadata);

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -734,7 +734,7 @@ namespace Snowflake.Data.Core
                     null,
                     false);
 
-            return SFRemoteStorageUtil.GetRemoteStorageType(response.data);
+            return SFRemoteStorageUtil.GetRemoteStorage(response.data);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
             SFFileMetadata resultMetadata = UploadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
@@ -775,7 +775,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
             SFFileMetadata resultMetadata = DownloadSingleFile(fileMetadata);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -892,7 +892,7 @@ namespace Snowflake.Data.Core
                     false,
                     cancellationToken).ConfigureAwait(false);
 
-            return SFRemoteStorageUtil.GetRemoteStorageType(response.data);
+            return SFRemoteStorageUtil.GetRemoteStorage(response.data);
         }
 
         /// <summary>
@@ -952,7 +952,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata, CancellationToken cancellationToken)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
             SFFileMetadata resultMetadata = await UploadSingleFileAsync(fileMetadata, cancellationToken).ConfigureAwait(false);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())
@@ -1010,7 +1010,7 @@ namespace Snowflake.Data.Core
             SFFileMetadata fileMetadata, CancellationToken cancellationToken)
         {
             /// The storage client used to upload/download data from files or streams
-            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorageType(TransferMetadata);
+            fileMetadata.client = SFRemoteStorageUtil.GetRemoteStorage(TransferMetadata);
             SFFileMetadata resultMetadata = await DownloadSingleFileAsync(fileMetadata, cancellationToken).ConfigureAwait(false);
 
             if (resultMetadata.resultStatus == ResultStatus.RENEW_TOKEN.ToString())

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Data.Core.FileTransfer
         /// </summary>
         /// <param name="stageInfo">The stage info used to create the client.</param>
         /// <returns>A new instance of the storage client.</returns>
-        internal static ISFRemoteStorageClient GetRemoteStorage(PutGetResponseData response)
+        internal static ISFRemoteStorageClient GetRemoteStorage(PutGetResponseData response, ProxyCredentials proxyCredentials = null)
         {
             PutGetStageInfo stageInfo = response.stageInfo;
             string stageLocationType = stageInfo.locationType;
@@ -60,7 +60,8 @@ namespace Snowflake.Data.Core.FileTransfer
             {
                 return new SFS3Client(stageInfo,
                     DEFAULT_MAX_RETRY,
-                    response.parallel
+                    response.parallel,
+                    proxyCredentials
                     );
             }
             else if (stageLocationType == AZURE_FS)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Data.Core.FileTransfer
         /// </summary>
         /// <param name="stageInfo">The stage info used to create the client.</param>
         /// <returns>A new instance of the storage client.</returns>
-        internal static ISFRemoteStorageClient GetRemoteStorageType(PutGetResponseData response)
+        internal static ISFRemoteStorageClient GetRemoteStorage(PutGetResponseData response)
         {
             PutGetStageInfo stageInfo = response.stageInfo;
             string stageLocationType = stageInfo.locationType;

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -143,13 +143,12 @@ namespace Snowflake.Data.Core
         internal string value { get; set; }
     }
 
-    internal class QueryExecResponse : BaseRestResponse
+    internal class QueryExecResponse : BaseQueryExecResponse<QueryExecResponseData>
     {
-        [JsonProperty(PropertyName = "data")]
-        internal QueryExecResponseData data { get; set; }
+        // data property already defined in BaseQueryExecResponse
     }
 
-    internal class QueryExecResponseData
+    internal class QueryExecResponseData : IQueryExecResponseData
     {
         [JsonProperty(PropertyName = "parameters", NullValueHandling = NullValueHandling.Ignore)]
         internal List<NameValueParameter> parameters { get; set; }
@@ -167,10 +166,10 @@ namespace Snowflake.Data.Core
         internal Int64 returned { get; set; }
 
         [JsonProperty(PropertyName = "queryId", NullValueHandling = NullValueHandling.Ignore)]
-        internal string queryId { get; set; }
+        public string queryId { get; set; }
 
         [JsonProperty(PropertyName = "sqlState", NullValueHandling = NullValueHandling.Ignore)]
-        internal string sqlState { get; set; }
+        public string sqlState { get; set; }
 
         [JsonProperty(PropertyName = "databaseProvider", NullValueHandling = NullValueHandling.Ignore)]
         internal string databaseProvider { get; set; }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -308,7 +308,7 @@ namespace Snowflake.Data.Core
 
             try
             {
-                if (trimmedSql.StartsWith("PUT") || trimmedSql.StartsWith("GET"))
+                if (IsPutOrGetCommand(trimmedSql))
                 {
                     isPutGetQuery = true;
                     PutGetExecResponse response =
@@ -601,6 +601,17 @@ namespace Snowflake.Data.Core
             logger.Debug("Trimmed query : " + trimmedQuery);
 
             return trimmedQuery;
+        }
+
+        /// <summary>
+        /// Check if query is PUT or GET command.
+        /// </summary>
+        /// <param name="query">The sql query.</param>
+        /// <returns>The boolean value if the query is a PUT or GET command.</returns>
+        private bool IsPutOrGetCommand(string query)
+        {
+            return (query.Substring(0, 3).ToUpper() == "PUT") ||
+                (query.Substring(0, 3).ToUpper() == "GET");
         }
 
         private static int GetBindingCount(Dictionary<string, BindingDTO> binding)

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -570,6 +570,7 @@ namespace Snowflake.Data.Core
             while (idx < sqlQueryLen);
 
             var trimmedQuery = builder.ToString();
+            trimmedQuery = trimmedQuery.Trim();
             logger.Debug("Trimmed query : " + trimmedQuery);
 
             return trimmedQuery;


### PR DESCRIPTION
PUT refactoring + adding proxy for S3 client:
- PUT/GET command is now case insensitive
- Trim white spaces in beginning and end of queries
- Allow white spaces in file paths for PUT queries
- Update the response data when client is renewed
- Move retry logic for when client is renewed and/or presigned url is updated

PR for error handling: https://github.com/snowflakedb/snowflake-connector-net/pull/501
PR to use async/await : https://github.com/snowflakedb/snowflake-connector-net/pull/510

The PR to remove the cloud dependencies SDK and use the REST API is in progress