### PR TITLE
Remove unneeded dispose field copy

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -47,7 +47,6 @@ namespace Snowflake.Data.Client
             this.SfSession = conn.SfSession;
             this._connectionState = conn._connectionState;
             this._connectionTimeout = conn._connectionTimeout;
-            this.disposed = conn.disposed;
             this.ConnectionString = conn.ConnectionString;
             this.Password = conn.Password;
         }


### PR DESCRIPTION
Copying this field from a pooled connection was causing 2 problems:
Firstly it meant that the new connection would never get disposed
Secondly a connection can only be pooled once (as the disposed path would repool the connection) 

This only occurs when connections are disposed rather than closed explicitly