### PR TITLE
Fixes to PUT implementation

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -6,6 +6,7 @@ using Snowflake.Data.Client;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Snowflake.Data.Core.FileTransfer
 {
@@ -108,31 +109,13 @@ namespace Snowflake.Data.Core.FileTransfer
             /// <returns></returns>
             public bool matchMagicNumber(byte[] header)
             {
-                bool isEquals = true;
-                if ((null != _magicNumbers) && (null != header))
-                {
-                    for (int i = 0; i < _magicNumbers.Length; i++)
-                    {
-                        if (header.Length >= _magicNumbers[i].Length)
-                        {
-                            for (int j = 0; j < _magicNumbers[i].Length; j++)
-                            {
-                                if (header[j] != _magicNumbers[i][j])
-                                {
-                                    isEquals = false;
-                                    break;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            isEquals = false;
-                            break;
-                        }
-                    }
-                }
+                if (_magicNumbers != null && _magicNumbers.Length > 0)
+                    foreach (byte[] m in _magicNumbers)
+                        if (m != null && header != null && m.Length > 0 && header.Length > 0)
+                            if (new ReadOnlySpan<byte>(m).SequenceEqual(new ReadOnlySpan<byte>(header, 0, m.Length)))
+                                return true;
 
-                return isEquals;
+                return false;
             }
 
             internal string FileExtension { get; }

--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -213,7 +213,23 @@ namespace Snowflake.Data.Core.FileTransfer
             }
 
             // Couldn't find a match, last fallback using the file name extension
-            return LookUpByName(new FileInfo(filePath).Extension);
+            return LookUpByFileExtension(new FileInfo(filePath).Extension);
+        }
+
+        public static SFFileCompressionType LookUpByFileExtension(string fileExtension)
+        {
+            if (!fileExtension.StartsWith("."))
+            {
+                fileExtension = "." + fileExtension;
+            }
+            foreach (SFFileCompressionType compType in compressionTypes)
+            {
+                if (compType.FileExtension.Equals(fileExtension, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return compType;
+                }
+            }
+            return NONE;
         }
 
         /// <summary>

--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -205,6 +205,10 @@ namespace Snowflake.Data.Core.FileTransfer
                     {
                         return BROTLI;
                     }
+                    else 
+                    { 
+                        return compType;
+                    }
                 }
             }
 

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -282,37 +282,37 @@ namespace Snowflake.Data.Core
             // For each file metadata, set the result set variables
             for (int index = 0; index < ResultsMetas.Count; index++)
             {
-                TransferMetadata.rowSet[index, 0] = ResultsMetas[index].srcFileName;
-                TransferMetadata.rowSet[index, 1] = ResultsMetas[index].destFileName;
-                TransferMetadata.rowSet[index, 2] = ResultsMetas[index].srcFileSize.ToString();
-                TransferMetadata.rowSet[index, 3] = ResultsMetas[index].destFileSize.ToString();
-                TransferMetadata.rowSet[index, 4] = ResultsMetas[index].resultStatus;
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceFileName        ] = ResultsMetas[index].srcFileName;
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationFileName   ] = ResultsMetas[index].destFileName;
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceFileSize        ] = ResultsMetas[index].srcFileSize.ToString();
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationFileSize   ] = ResultsMetas[index].destFileSize.ToString();
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceCompressionType ] = ResultsMetas[index].resultStatus;
 
                 if (ResultsMetas[index].lastError != null)
                 {
-                    TransferMetadata.rowSet[index, 5] = ResultsMetas[index].lastError.ToString();
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = ResultsMetas[index].lastError.ToString();
                 }
                 else
                 {
-                    TransferMetadata.rowSet[index, 5] = null;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = null;
                 }
 
                 if (ResultsMetas[index].sourceCompression.Name != null)
                 {
-                    TransferMetadata.rowSet[index, 6] = ResultsMetas[index].sourceCompression.Name;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ResultStatus] = ResultsMetas[index].sourceCompression.Name;
                 }
                 else
                 {
-                    TransferMetadata.rowSet[index, 6] = null;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ResultStatus] = null;
                 }
 
                 if (ResultsMetas[index].targetCompression.Name != null)
                 {
-                    TransferMetadata.rowSet[index, 7] = ResultsMetas[index].targetCompression.Name;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ErrorDetails] = ResultsMetas[index].targetCompression.Name;
                 }
                 else
                 {
-                    TransferMetadata.rowSet[index, 7] = null;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ErrorDetails] = null;
                 }
             }
             

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -286,33 +286,33 @@ namespace Snowflake.Data.Core
                 TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationFileName   ] = ResultsMetas[index].destFileName;
                 TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceFileSize        ] = ResultsMetas[index].srcFileSize.ToString();
                 TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationFileSize   ] = ResultsMetas[index].destFileSize.ToString();
-                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceCompressionType ] = ResultsMetas[index].resultStatus;
+                TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ResultStatus          ] = ResultsMetas[index].resultStatus;
 
                 if (ResultsMetas[index].lastError != null)
                 {
-                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = ResultsMetas[index].lastError.ToString();
-                }
-                else
-                {
-                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = null;
-                }
-
-                if (ResultsMetas[index].sourceCompression.Name != null)
-                {
-                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ResultStatus] = ResultsMetas[index].sourceCompression.Name;
-                }
-                else
-                {
-                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ResultStatus] = null;
-                }
-
-                if (ResultsMetas[index].targetCompression.Name != null)
-                {
-                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ErrorDetails] = ResultsMetas[index].targetCompression.Name;
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ErrorDetails] = ResultsMetas[index].lastError.ToString();
                 }
                 else
                 {
                     TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.ErrorDetails] = null;
+                }
+
+                if (ResultsMetas[index].sourceCompression.Name != null)
+                {
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceCompressionType] = ResultsMetas[index].sourceCompression.Name;
+                }
+                else
+                {
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.SourceCompressionType] = null;
+                }
+
+                if (ResultsMetas[index].targetCompression.Name != null)
+                {
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = ResultsMetas[index].targetCompression.Name;
+                }
+                else
+                {
+                    TransferMetadata.rowSet[index, (int)SFResultSet.PutGetResponseRowTypeInfo.DestinationCompressionType] = null;
                 }
             }
             

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -50,24 +50,24 @@ namespace Snowflake.Data.Core
             queryId = responseData.queryId;
         }
 
-        string[] PutGetResponseRowTypeInfo = {
-            "SourceFileName",
-            "DestinationFileName",
-            "SourceFileSize",
-            "DestinationFileSize",
-            "SourceCompressionType",
-            "DestinationCompressionType",
-            "ResultStatus",
-            "ErrorDetails"
-        };
+        public enum PutGetResponseRowTypeInfo {   
+            SourceFileName                    = 0,
+            DestinationFileName               = 1,
+            SourceFileSize                    = 2,
+            DestinationFileSize               = 3,
+            SourceCompressionType             = 4,
+            DestinationCompressionType        = 5,
+            ResultStatus                      = 6,
+            ErrorDetails                      = 7
+            }
 
         public void initializePutGetRowType(List<ExecResponseRowType> rowType)
         {
-            foreach (string name in PutGetResponseRowTypeInfo)
+         foreach (PutGetResponseRowTypeInfo t in System.Enum.GetValues(typeof(PutGetResponseRowTypeInfo)))
             {
                 rowType.Add(new ExecResponseRowType()
                 {
-                    name = name,
+                    name = t.ToString(),
                     type = "text"
                 });
             }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -247,6 +247,10 @@ namespace Snowflake.Data.Core
             // Trim the sql query and check if this is a PUT/GET command
             string trimmedSql = TrimSql(sql);
 
+            if (IsPutOrGetCommand(trimmedSql)) {
+                throw new NotImplementedException("Get and Put are not supported in async calls.  Use Execute() instead of ExecuteAsync().");
+            }
+
             registerQueryCancellationCallback(timeout, cancellationToken);
             
             int arrayBindingThreshold = 0;


### PR DESCRIPTION
Fixes multiple bugs with the PUT command. There are 6 small commits in the branch. Each is separate, but builds upon those prior. Reading them from the oldest to newest, it should be pretty clear. If not, please LMK.

I'm trying to use PUT with pre-gzipped files, and process the server response. Without these fixes, it's not possible. Here's the list

From the issue that I created: #469 
Put command has several problems:

Put and Get commands should be case insensitive
Put and Get commands fail in asynchronous execute with a unclear error (because they are not supported)
Put fails to properly determine existing compression, and then fails to properly put the file to the server
When a file is 'put', the server response is mapped to incorrect fields in the result. This renders the result unusable.