### PR TITLE
reduce one version number at csproj file

### DIFF
--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -55,9 +55,7 @@
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <!--The version number to be send to server at run time-->
-    <!--Always have three parts here and never add forth part-->
-    <AssemblyVersion>2.0.19</AssemblyVersion>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
reduce one version number at csproj file, we have version and AssemblyVersion on csproj file, after this fix, we only have to update version on csproj, AssemblyVersion will use the same version number automatically. 