### PR TITLE
Removed redundant 'NETFRAMEWORK' preprocessor symbol from csproj

### DIFF
--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -17,10 +17,6 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   
-  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
-	<DefineConstants>NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-	
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.4" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="2.5.0" />


### PR DESCRIPTION
Removed redundant 'NETFRAMEWORK' preprocessor symbol from csproj; this fixes #308 and #536

NETFRAMEWORK is a standard preprocessor symbol that is already defined for builds that target .NET Framework (but not .NET Core builds); therefore defining this symbol in the csproj (with an attempt to exclude it for dotnet-core builds using a regex) is not necessary.

The regex filter was not working as expecting, causing this symbol to be defined for all builds including dotnet core builds.

See here for a list of standard preprocessor symbols: https://learn.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget