### PR TITLE
Fix out of bounds error when trimming SQL

### DIFF
--- a/Snowflake.Data.Tests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/SFStatementTest.cs
@@ -69,5 +69,65 @@ namespace Snowflake.Data.Tests
                 Assert.AreEqual(expectServiceName, sfSession.ParameterMap[SFSessionParameter.SERVICE_NAME]);
             }
         }
+
+        /// <summary>
+        /// Ensure TrimSql stops reading the query when no more characters after a block comment
+        /// </summary>
+        [Test]
+        public void TestTrimSqlBlockComment()
+        {
+            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            SFStatement statement = new SFStatement(sfSession);
+            SFBaseResultSet resultSet = statement.Execute(0, "/*comment*/select 1/*comment*/", null, false);
+            Assert.AreEqual(true, resultSet.Next());
+            Assert.AreEqual("1", resultSet.GetString(0));
+        }
+
+        /// <summary>
+        /// Ensure TrimSql stops reading the query when no more characters after a multiline block comment
+        /// </summary>
+        [Test]
+        public void TestTrimSqlBlockCommentMultiline()
+        {
+            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            SFStatement statement = new SFStatement(sfSession);
+            SFBaseResultSet resultSet = statement.Execute(0, "/*comment\r\ncomment*/select 1/*comment\r\ncomment*/", null, false);
+            Assert.AreEqual(true, resultSet.Next());
+            Assert.AreEqual("1", resultSet.GetString(0));
+        }
+
+        /// <summary>
+        /// Ensure TrimSql stops reading the query when no more characters after a line comment
+        /// </summary>
+        [Test]
+        public void TestTrimSqlLineComment()
+        {
+            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            SFStatement statement = new SFStatement(sfSession);
+            SFBaseResultSet resultSet = statement.Execute(0, "--comment\r\nselect 1\r\n--comment", null, false);
+            Assert.AreEqual(true, resultSet.Next());
+            Assert.AreEqual("1", resultSet.GetString(0));
+        }
+
+        /// <summary>
+        /// Ensure TrimSql stops reading the query when no more characters after a line comment with a closing newline
+        /// </summary>
+        [Test]
+        public void TestTrimSqlLineCommentWithClosingNewline()
+        {
+            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            SFStatement statement = new SFStatement(sfSession);
+            SFBaseResultSet resultSet = statement.Execute(0, "--comment\r\nselect 1\r\n--comment\r\n", null, false);
+            Assert.AreEqual(true, resultSet.Next());
+            Assert.AreEqual("1", resultSet.GetString(0));
+        }
     }
 }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -665,6 +665,12 @@ namespace Snowflake.Data.Core
                     }
                 }
 
+                // No more characters after the closing comment character, stop trimming the query
+                if (idx >= sqlQueryLen)
+                {
+                    break;
+                }
+
                 builder.Append(sqlQueryBuf[idx]);
                 idx++;
             }


### PR DESCRIPTION
Regarding https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/100

Based off https://github.com/snowflakedb/snowflake-connector-net/pull/573

Checks if there are still characters after a closing comment to prevent index out of bounds error when trimming the SQL query.
Also add test cases for SQL queries with line and block comments