### PR TITLE
Retry request on HTTP status 429

### DIFF
--- a/Snowflake.Data.Tests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/HttpUtilTest.cs
@@ -21,6 +21,7 @@ namespace Snowflake.Data.Tests
         [TestCase(HttpStatusCode.NotFound, false, false)]
         [TestCase(HttpStatusCode.NotFound, true, true)] // force retry on 404
         [TestCase(HttpStatusCode.RequestTimeout, false, true)]
+        [TestCase((HttpStatusCode)429, false, true)] // HttpStatusCode.TooManyRequests is not available on .NET Framework
         [TestCase(HttpStatusCode.InternalServerError, false, true)]
         [TestCase(HttpStatusCode.ServiceUnavailable, false, true)]
         public async Task TestIsRetryableHTTPCode(HttpStatusCode statusCode, bool forceRetryOn404, bool expectedIsRetryable)

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -419,7 +419,9 @@ namespace Snowflake.Data.Core
             // Forbidden
             (statusCode == 403) ||
             // Request timeout
-            (statusCode == 408);
+            (statusCode == 408) ||
+            // Too many requests
+            (statusCode == 429);
         }
     }
 }


### PR DESCRIPTION
Regarding https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/72 and https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/117

Connector will retry when receiving HTTP status 429 (Too Many Requests)