### PR TITLE
Update Azure.Storage dependencies

### DIFF
--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.4" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="2.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Azure.Storage.Common" Version="12.9.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Common" Version="12.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />


### PR DESCRIPTION
Update Azure.Storage.Blobs from 12.10.0 to 12.13.0 based on https://github.com/snowflakedb/snowflake-connector-net/pull/493

Also update Azure.Storage.Common from 12.9.0 to 12.12.0 due to build error if only Azure.Storage.Blobs was updated - [NU1605: Detected package downgrade: Azure.Storage.Common from 12.12.0 to 12.9.0](https://github.com/snowflakedb/snowflake-connector-net/actions/runs/4106285098/jobs/7084311623#step:7:24)