### PR TITLE
SNOW-726382: Update jira_issue.yml

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -35,7 +35,7 @@ jobs:
           summary: '${{ github.event.issue.title }}'
           description: |
             ${{ github.event.issue.body }} \\ \\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
-          fields: '{ "customfield_11401": {"id": "13475"}, "assignee": {"id": "61027a219798100070592b20"} }'
+          fields: '{ "customfield_11401": {"id": "14583"}, "assignee": {"id": "61027a219798100070592b20"} }'
 
       - name: Update GitHub Issue
         uses: ./jira/gajira-issue-update


### PR DESCRIPTION
[SNOW-726382](https://snowflakecomputing.atlassian.net/browse/SNOW-726382)

Jira area numbers have changed, this PR aims to update the GitHub Action to use the new correct Area id.

[SNOW-726382]: https://snowflakecomputing.atlassian.net/browse/SNOW-726382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ