### PR TITLE
bug fix .net 249 SNOW-756325: Calling Close() before Dispose() results in duplicate connections in the pool

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -300,7 +300,7 @@ namespace Snowflake.Data.Tests
         private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionPoolITAsync>();
 
         [Test]
-        //[Ignore("Disable test case to prevent the static variable changed at the same time.")]
+        [Ignore("Disable test case to prevent the static variable changed at the same time.")]
         public void TestConnectionPoolWithAsync()
         {
             using (var conn = new MockSnowflakeDbConnection())

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -268,6 +268,30 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
             Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
         }
+
+        [Test]
+        [Ignore("Disable test case to prevent the static variable changed at the same time.")]
+        public void TestConnectionPoolWithDispose()
+        {
+            SnowflakeDbConnectionPool.SetPooling(true);
+            SnowflakeDbConnectionPool.SetMaxPoolSize(1);
+            SnowflakeDbConnectionPool.ClearAllPools();
+             
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = "";
+            try
+            {
+                conn1.Open();
+            }
+            catch (SnowflakeDbException ex)
+            {
+                Console.WriteLine($"connection failed:"+ex);
+                conn1.Close();
+            }
+
+            Assert.AreEqual(ConnectionState.Closed, conn1.State);
+            Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
+        }
     }
 }
 

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -35,7 +35,7 @@ namespace Snowflake.Data.Tests
             SnowflakeDbConnectionPool.SetPooling(true);
             SnowflakeDbConnectionPool.SetMaxPoolSize(1);
             SnowflakeDbConnectionPool.ClearAllPools();
-            
+
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = ConnectionString;
             conn1.Open();
@@ -63,7 +63,7 @@ namespace Snowflake.Data.Tests
             conn2.Open();
             Assert.AreEqual(ConnectionState.Open, conn2.State);
             Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
-            
+
             conn2.Close();
             Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
@@ -201,7 +201,7 @@ namespace Snowflake.Data.Tests
             conn4.ConnectionString = ConnectionString + "  retryCount=3";
             conn4.Open();
             Assert.AreEqual(ConnectionState.Open, conn4.State);
-            
+
             conn3.Close();
             Assert.AreEqual(2, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             conn4.Close();
@@ -276,7 +276,7 @@ namespace Snowflake.Data.Tests
             SnowflakeDbConnectionPool.SetPooling(true);
             SnowflakeDbConnectionPool.SetMaxPoolSize(1);
             SnowflakeDbConnectionPool.ClearAllPools();
-             
+
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = "";
             try
@@ -285,12 +285,53 @@ namespace Snowflake.Data.Tests
             }
             catch (SnowflakeDbException ex)
             {
-                Console.WriteLine($"connection failed:"+ex);
+                Console.WriteLine($"connection failed:" + ex);
                 conn1.Close();
             }
 
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
             Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
+        }
+    }
+
+    [TestFixture]
+    class SFConnectionPoolITAsync : SFBaseTestAsync
+    {
+        private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionPoolITAsync>();
+
+        [Test]
+        //[Ignore("Disable test case to prevent the static variable changed at the same time.")]
+        public void TestConnectionPoolWithAsync()
+        {
+            using (var conn = new MockSnowflakeDbConnection())
+            {
+                SnowflakeDbConnectionPool.SetPooling(true);
+                SnowflakeDbConnectionPool.SetMaxPoolSize(1);
+                SnowflakeDbConnectionPool.ClearAllPools();
+
+                int timeoutSec = 0;
+                string infiniteLoginTimeOut = String.Format("" + ";connection_timeout={0}",
+                    timeoutSec);
+
+                conn.ConnectionString = infiniteLoginTimeOut;
+
+                Assert.AreEqual(conn.State, ConnectionState.Closed);
+
+                CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
+                try
+                {
+                    Task connectTask = conn.OpenAsync(connectionCancelToken.Token);
+                }
+                catch (SnowflakeDbException ex)
+                {
+                    Console.WriteLine($"connection failed:" + ex);
+                    conn.CloseAsync(connectionCancelToken.Token);
+                }
+
+                Thread.Sleep(10 * 1000);
+                Assert.AreEqual(ConnectionState.Closed, conn.State);
+                Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
+            }
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -166,7 +166,7 @@ namespace Snowflake.Data.Client
             }
             else
             {
-                logger.Debug("Session not opened. Nothing to do.");
+                logger.Debug("Session still open and inside the connection pool. Nothing to do.");
                 task.SetResult(null);
             }
         }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -114,8 +114,11 @@ namespace Snowflake.Data.Client
         public override void Close()
         {
             logger.Debug("Close Connection.");
-            _connectionState = ConnectionState.Closed;
-            PostClose();
+            if (_connectionState != ConnectionState.Closed)
+            {
+                _connectionState = ConnectionState.Closed;
+                PostClose();
+            }
         }
 
         internal void PostClose()


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/249
test case is added, if the given connection string isn't able to create connection, it will not add to the connection pool after it closed.