### PR TITLE
bug fit issue 52, SNOW-701875: .net connector throwing error: System.Net.Http.WinHttpException (80072EE2, 12002): Error 12002 calling WINHTTP_CALLBACK_STATUS_REQUEST_ERROR

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1473,10 +1473,10 @@ namespace Snowflake.Data.Tests
                     stopwatch.Stop();
                     int detla = 10; //in case server time slower.
 
-                    // Should timeout after 5sec
-                    Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 5 * 1000 - detla);
+                    // Should timeout after 5sec + 3 retry 20 sec
+                    Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 20 * 1000 - detla);
                     // But never more than 1 sec (max backoff) after the default timeout
-                    Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (6) * 1000);
+                    Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (24) * 1000);
 
                     Assert.AreEqual(ConnectionState.Closed, conn.State);
                     Assert.AreEqual(5, conn.ConnectionTimeout);
@@ -1508,10 +1508,10 @@ namespace Snowflake.Data.Tests
                 stopwatch.Stop();
                 int detla = 10; //in case server time slower.
 
-                // Should timeout after the default timeout (120 sec)
-                Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 120 * 1000 - detla);
+                // Should timeout after the default timeout (120 sec + 3 retry 480 sec)
+                Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 480 * 1000 - detla);
                 // But never more than 16 sec (max backoff) after the default timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (120 + 16) * 1000);
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (480 + 16) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(120, conn.ConnectionTimeout);
@@ -1601,7 +1601,7 @@ namespace Snowflake.Data.Tests
                 // Close the opened connection
                 task =  conn.CloseAsync(new CancellationTokenSource().Token);
                 try
-                { 
+                {
                     task.Wait();
                     Assert.Fail();
                 }

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -64,7 +64,7 @@ namespace Snowflake.Data.Core
 
     public sealed class HttpUtil
     {
-
+        static internal readonly int MAX_RETRY = 3;
         private static readonly SFLogger logger = SFLoggerFactory.GetLogger<HttpUtil>();
 
         private static readonly HttpUtil instance = new HttpUtil();

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Core
                     }
                     else
                     {
-                        throw new Exception("parse post response error: " + e);
+                        throw;
                     }
                 }
             } while (retry);
@@ -138,7 +138,7 @@ namespace Snowflake.Data.Core
                     }
                     else
                     {
-                        throw new Exception("parse post response error: " + e);
+                        throw;
                     }
                 }
             } while (retry);

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -41,7 +41,6 @@ namespace Snowflake.Data.Core
         private static SFLogger logger = SFLoggerFactory.GetLogger<RestRequester>();
 
         protected HttpClient _HttpClient;
-        const int MAX_RETRY = 3;
 
         public RestRequester(HttpClient httpClient)
         {
@@ -80,7 +79,7 @@ namespace Snowflake.Data.Core
                 }
                 catch (Exception e)
                 {
-                    if (retryCount < MAX_RETRY)
+                    if (retryCount < HttpUtil.MAX_RETRY)
                     {
                         logger.Debug($"PostAsync Exception, retry="+ retryCount);
                         retry = true;
@@ -129,7 +128,7 @@ namespace Snowflake.Data.Core
                 }
                 catch (Exception e)
                 {
-                    if (retryCount < MAX_RETRY)
+                    if (retryCount < HttpUtil.MAX_RETRY)
                     {
                         logger.Debug($"GetAsync Exception, retry=" + retryCount);
                         retry = true;

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -82,6 +82,7 @@ namespace Snowflake.Data.Core
                 {
                     if (retryCount < MAX_RETRY)
                     {
+                        logger.Debug($"PostAsync Exception, retry="+ retryCount);
                         retry = true;
                         await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
                         ++retryCount;
@@ -130,6 +131,7 @@ namespace Snowflake.Data.Core
                 {
                     if (retryCount < MAX_RETRY)
                     {
+                        logger.Debug($"GetAsync Exception, retry=" + retryCount);
                         retry = true;
                         await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
                         ++retryCount;

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -135,7 +135,6 @@ namespace Snowflake.Data.Core
             SFReusableChunk chunk;
             bool retry = false;
             int retryCount = 0;
-            int maxRetry = 3;
 
             //this is used for test case
             bool forceParseError = Boolean.Parse((string)sessionProperies[SFSessionProperty.FORCEPARSEERROR]);
@@ -190,7 +189,7 @@ namespace Snowflake.Data.Core
                     catch (Exception e)
                     {
                         forceParseError = false;
-                        if (retryCount < maxRetry)
+                        if (retryCount < HttpUtil.MAX_RETRY)
                         {
                             retry = true;
                             await Task.Delay(TimeSpan.FromSeconds(backOffInSec), downloadContext.cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/52
add retry logic on put and get request. 
added local debug code for testing, but comment out for release version. 