### PR TITLE
Encryption streams

### DIFF
--- a/Snowflake.Data.Tests/EncryptionStreamTest.cs
+++ b/Snowflake.Data.Tests/EncryptionStreamTest.cs
@@ -32,16 +32,16 @@ namespace Snowflake.Data.Tests
             
             try
             {
-                var readStream = new MemoryStream(rawData, false);
                 // first, write the data to the crypt file
-                using (var encryptStream = new EncryptionStream(File.OpenWrite(randomFileNameCrypt), EncryptionStream.CryptMode.Encrypt, pgMaterial, metaData, false))
+                using (var encryptStream = EncryptionStream.Create(new MemoryStream(rawData, false), EncryptionStream.CryptMode.Encrypt, pgMaterial, metaData, false))
+                using (var dest = File.OpenWrite(randomFileNameCrypt))
                 {
-                    readStream.CopyTo(encryptStream);
+                    encryptStream.CopyTo(dest);
                 }
 
                 var newStream = new MemoryStream();
                 // next read the data from the encrypted file into the newStream
-                using (var decryptStream = new EncryptionStream(File.OpenRead(randomFileNameCrypt), EncryptionStream.CryptMode.Decrypt, pgMaterial, metaData, false))
+                using (var decryptStream = EncryptionStream.Create(File.OpenRead(randomFileNameCrypt), EncryptionStream.CryptMode.Decrypt, pgMaterial, metaData, false))
                 {
                     decryptStream.CopyTo(newStream);
                 }

--- a/Snowflake.Data.Tests/EncryptionStreamTest.cs
+++ b/Snowflake.Data.Tests/EncryptionStreamTest.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using Snowflake.Data.Core.FileTransfer;
+
+namespace Snowflake.Data.Tests
+{
+    using NUnit.Framework;
+    using Snowflake.Data.Core;
+
+    [TestFixture]
+    class EncryptionStreamTest
+    {
+        [Test]
+        public void CanWriteAndReadEncryptedStream()
+        {
+            var randomFileNameCrypt = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var random = RandomNumberGenerator.Create();
+            var rawData = new byte[100000];
+            random.GetBytes(rawData);
+
+            var pgMaterial = new PutGetEncryptionMaterial();
+            var metaData = new SFEncryptionMetadata();
+
+            using (var aes = Aes.Create())
+            {
+                // create a random master key
+                var keyBytes = new byte[aes.KeySize/8];
+                random.GetBytes(keyBytes);
+                pgMaterial.queryStageMasterKey = Convert.ToBase64String(keyBytes);
+            }
+            
+            try
+            {
+                var readStream = new MemoryStream(rawData, false);
+                // first, write the data to the crypt file
+                using (var encryptStream = new EncryptionStream(File.OpenWrite(randomFileNameCrypt), EncryptionStream.CryptMode.Encrypt, pgMaterial, metaData, false))
+                {
+                    readStream.CopyTo(encryptStream);
+                }
+
+                var newStream = new MemoryStream();
+                // next read the data from the encrypted file into the newStream
+                using (var decryptStream = new EncryptionStream(File.OpenRead(randomFileNameCrypt), EncryptionStream.CryptMode.Decrypt, pgMaterial, metaData, false))
+                {
+                    decryptStream.CopyTo(newStream);
+                }
+
+                var newBytes = newStream.ToArray();
+
+                // make sure the bytes are the same
+                Assert.AreEqual(rawData, newBytes);
+            }
+            finally
+            {
+                // cleanup the temporary file
+                File.Delete(randomFileNameCrypt);
+            }
+        }
+
+    }
+}

--- a/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
@@ -21,11 +21,6 @@ namespace Snowflake.Data.Core.FileTransfer
     class EncryptionProvider
     {
         /// <summary>
-        /// The logger.
-        /// </summary>
-        private static readonly SFLogger Logger = SFLoggerFactory.GetLogger<EncryptionProvider>();
-
-        /// <summary>
         /// Encrypt data and write to the outStream.
         /// </summary>
         /// <param name="inFile">The data to write onto the stream.</param>

--- a/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
@@ -22,10 +22,6 @@ namespace Snowflake.Data.Core.FileTransfer
     /// </summary>
     class EncryptionProvider
     {
-        // The default block size for AES
-        private const int AES_BLOCK_SIZE = 128;
-        private const int blockSize = AES_BLOCK_SIZE / 8;  // in bytes
-
         /// <summary>
         /// The logger.
         /// </summary>
@@ -38,122 +34,32 @@ namespace Snowflake.Data.Core.FileTransfer
         /// <param name="encryptionMaterial">Contains the query stage master key, query id, and smk id.</param>
         /// <param name="encryptionMetadata">Store the encryption metadata into</param>
         /// <returns>The encrypted bytes of the file to upload.</returns>
-        static public byte[] EncryptFile(
+        static public Stream EncryptFile(
             string inFile,
             PutGetEncryptionMaterial encryptionMaterial,
             SFEncryptionMetadata encryptionMetadata)
         {
-            using (FileStream fileStream = File.OpenRead(inFile))
-            {
-                MemoryStream ms = new MemoryStream();
-                fileStream.CopyTo(ms);
-                return EncryptStream(ms, encryptionMaterial, encryptionMetadata);
-            }
+            return EncryptStream(File.OpenRead(inFile), encryptionMaterial, encryptionMetadata, false);
         }
 
         /// <summary>
         /// Encrypt data and write to the outStream.
         /// </summary>
-        /// <param name="memoryStream">The data to write onto the stream.</param>
+        /// <param name="stream">The data to write onto the stream.</param>
         /// <param name="encryptionMaterial">Contains the query stage master key, query id, and smk id.</param>
         /// <param name="encryptionMetadata">Store the encryption metadata into</param>
+        /// <param name="leaveOpen">Pass true to avoid closing the <paramref name="stream"/>></param>
         /// <returns>The encrypted bytes of the file to upload.</returns>
-        static public byte[] EncryptStream(
-            MemoryStream memoryStream,
+        static public Stream EncryptStream(
+            Stream stream,
             PutGetEncryptionMaterial encryptionMaterial,
-            SFEncryptionMetadata encryptionMetadata)
+            SFEncryptionMetadata encryptionMetadata,
+            bool leaveOpen)
         {
-            byte[] decodedMasterKey = Convert.FromBase64String(encryptionMaterial.queryStageMasterKey);
-            int masterKeySize = decodedMasterKey.Length;
-            Logger.Debug($"Master key size : {masterKeySize}");
-
-            // Generate file key
-            byte[] ivData = new byte[blockSize];
-            byte[] keyData = new byte[blockSize];
-
-            var random = new Random();
-            random.NextBytes(ivData);
-            random.NextBytes(keyData);
-
-            // Byte[] to encrypt data into
-            byte[] encryptedBytes = CreateEncryptedBytes(
-                memoryStream,
-                keyData,
-                ivData);
-
-            // Encrypt file key
-            byte[] encryptedFileKey = encryptFileKey(decodedMasterKey, keyData);
-            
-            // Store encryption metadata information
-            MaterialDescriptor matDesc = new MaterialDescriptor
-            {
-                smkId = encryptionMaterial.smkId.ToString(),
-                queryId = encryptionMaterial.queryId,
-                keySize = (masterKeySize * 8).ToString()
-            };
-
-            string ivBase64 = Convert.ToBase64String(ivData);
-            string keyBase64 = Convert.ToBase64String(encryptedFileKey);
-
-            encryptionMetadata.iv = ivBase64;
-            encryptionMetadata.key = keyBase64;
-            encryptionMetadata.matDesc = Newtonsoft.Json.JsonConvert.SerializeObject(matDesc).ToString();
-
-            return encryptedBytes;
+            return new EncryptionStream(stream, encryptionMaterial, encryptionMetadata, leaveOpen);
         }
 
-        /// <summary>
-        /// Encrypt the newly generated file key using the master key.
-        /// </summary>
-        /// <param name="masterKey">The key to use for encryption.</param>
-        /// <param name="unencryptedFileKey">The file key to encrypt.</param>
-        /// <returns>The encrypted key.</returns>
-        static private byte[] encryptFileKey(byte[] masterKey, byte[] unencryptedFileKey)
-        {
-            Aes aes = Aes.Create();            
-            aes.Key = masterKey;
-            aes.Mode = CipherMode.ECB;
-            aes.Padding = PaddingMode.PKCS7;
 
-            MemoryStream cipherStream = new MemoryStream();
-            CryptoStream cryptoStream = new CryptoStream(cipherStream, aes.CreateEncryptor(), CryptoStreamMode.Write);            
-            cryptoStream.Write(unencryptedFileKey, 0, unencryptedFileKey.Length);
-            cryptoStream.FlushFinalBlock();
-
-            return cipherStream.ToArray();
-        }
-
-        /// <summary>
-        /// Creates a new byte array containing the encrypted/decrypted data.
-        /// </summary>
-        /// <param name="memoryStream">The path of the file to write onto the stream.</param>
-        /// <param name="key">The encryption key.</param>
-        /// <param name="iv">The encryption IV or null if it needs to be generated.</param>
-        /// <returns>The encrypted bytes.</returns>
-        static private byte[] CreateEncryptedBytes(
-            MemoryStream memoryStream,
-            byte[] key,
-            byte[] iv)
-        {
-            Aes aes = Aes.Create();            
-            aes.Key = key;
-            aes.Mode = CipherMode.CBC;
-            aes.Padding = PaddingMode.PKCS7;
-            aes.IV = iv;
-            memoryStream.Position = 0;
-
-            MemoryStream targetStream = new MemoryStream();
-            CryptoStream cryptoStream = new CryptoStream(targetStream, aes.CreateEncryptor(), CryptoStreamMode.Write);
-            byte[] buffer = new byte[1024000];
-            int bytesRead;
-            while ((bytesRead = memoryStream.Read(buffer, 0, buffer.Length)) > 0)
-            {
-                cryptoStream.Write(buffer, 0, bytesRead);
-            }
-            cryptoStream.FlushFinalBlock();
-
-            return targetStream.ToArray();
-        }
 
         /// <summary>
         /// Decrypt data and write to the outStream.

--- a/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Snowflake.Data.Log;
 
 namespace Snowflake.Data.Core.FileTransfer
 {
@@ -49,7 +48,7 @@ namespace Snowflake.Data.Core.FileTransfer
             SFEncryptionMetadata encryptionMetadata,
             bool leaveOpen)
         {
-            return new EncryptionStream(stream, EncryptionStream.CryptMode.Encrypt, encryptionMaterial, encryptionMetadata, leaveOpen);
+            return EncryptionStream.Create(stream, EncryptionStream.CryptMode.Encrypt, encryptionMaterial, encryptionMetadata, leaveOpen);
         }
 
         /// <summary>
@@ -67,9 +66,9 @@ namespace Snowflake.Data.Core.FileTransfer
             // Create temp file
             string tempFileName = Path.Combine(Path.GetTempPath(), Path.GetFileName(inFile));
 
-            using (var writeStream = new EncryptionStream(File.Create(tempFileName), EncryptionStream.CryptMode.Decrypt, encryptionMaterial, encryptionMetadata, false))
+            using (var readStream = EncryptionStream.Create(File.OpenRead(inFile), EncryptionStream.CryptMode.Decrypt, encryptionMaterial, encryptionMetadata, false))
             {
-                using (var readStream = File.OpenRead(inFile))
+                using (var writeStream = File.Create(tempFileName))
                 {
                     readStream.CopyTo(writeStream);
                 }

--- a/Snowflake.Data/Core/FileTransfer/EncryptionStream.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionStream.cs
@@ -1,0 +1,159 @@
+﻿using Snowflake.Data.Log;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Snowflake.Data.Core.FileTransfer
+{
+    internal class EncryptionStream : Stream
+    {
+        private readonly bool leaveOpen;
+
+        // The default block size for AES
+        private const int AES_BLOCK_SIZE = 128;
+        private const int blockSize = AES_BLOCK_SIZE / 8;  // in bytes
+
+        /// <summary>
+        /// The logger.
+        /// </summary>
+        private static readonly SFLogger Logger = SFLoggerFactory.GetLogger<EncryptionProvider>();
+
+        private static readonly RandomNumberGenerator Randomizer = RandomNumberGenerator.Create();
+        /// <summary>
+        /// the stream to read/write the encrypted data
+        /// </summary>
+        private readonly Stream targetStream;
+        
+        public enum CryptMode
+        {
+            Encrypt,
+            Decrypt
+        }
+
+        /// <summary>
+        /// Creates an encryption stream
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="encryptionMaterial"></param>
+        /// <param name="encryptionMetadata"></param>
+        /// <param name="leaveOpen"></param>
+        public EncryptionStream(
+            Stream stream,
+            PutGetEncryptionMaterial encryptionMaterial,
+            SFEncryptionMetadata encryptionMetadata,
+            bool leaveOpen = false)
+        {
+            this.leaveOpen = leaveOpen;
+            this.Mode = CryptMode.Encrypt;
+
+            byte[] decodedMasterKey = Convert.FromBase64String(encryptionMaterial.queryStageMasterKey);
+            int masterKeySize = decodedMasterKey.Length;
+            Logger.Debug($"Master key size : {masterKeySize}");
+
+            // Generate file key
+
+            byte[] ivData = new byte[blockSize];
+            byte[] keyData = new byte[blockSize];
+            Randomizer.GetBytes(ivData);
+            Randomizer.GetBytes(keyData);
+
+            byte[] encryptedFileKey = encryptFileKey(decodedMasterKey, keyData);
+
+            // Store encryption metadata information
+            MaterialDescriptor matDesc = new MaterialDescriptor
+            {
+                smkId = encryptionMaterial.smkId.ToString(),
+                queryId = encryptionMaterial.queryId,
+                keySize = (masterKeySize * 8).ToString()
+            };
+
+            string ivBase64 = Convert.ToBase64String(ivData);
+            string keyBase64 = Convert.ToBase64String(encryptedFileKey);
+
+            encryptionMetadata.iv = ivBase64;
+            encryptionMetadata.key = keyBase64;
+            encryptionMetadata.matDesc = Newtonsoft.Json.JsonConvert.SerializeObject(matDesc).ToString();
+
+            using (Aes aes = Aes.Create())
+            {
+                aes.Key = keyData;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                aes.IV = ivData;
+
+                this.targetStream = new CryptoStream(stream, aes.CreateEncryptor(), CryptoStreamMode.Write, leaveOpen: this.leaveOpen);
+            }
+        }
+
+        public CryptMode Mode { get; }
+
+        public override void Flush()
+        {
+            this.targetStream.Flush();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.targetStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.targetStream.Write(buffer, offset, count);
+        }
+
+        public override bool CanRead => Mode == CryptMode.Decrypt;
+        public override bool CanSeek => false;
+        public override bool CanWrite => Mode == CryptMode.Encrypt;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+
+            set => throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Encrypt the newly generated file key using the master key.
+        /// </summary>
+        /// <param name="masterKey">The key to use for encryption.</param>
+        /// <param name="unencryptedFileKey">The file key to encrypt.</param>
+        /// <returns>The encrypted key.</returns>
+        static private byte[] encryptFileKey(byte[] masterKey, byte[] unencryptedFileKey)
+        {
+            Aes aes = Aes.Create();
+            aes.Key = masterKey;
+            aes.Mode = CipherMode.ECB;
+            aes.Padding = PaddingMode.PKCS7;
+
+            MemoryStream cipherStream = new MemoryStream();
+            CryptoStream cryptoStream = new CryptoStream(cipherStream, aes.CreateEncryptor(), CryptoStreamMode.Write);
+            cryptoStream.Write(unencryptedFileKey, 0, unencryptedFileKey.Length);
+            cryptoStream.FlushFinalBlock();
+
+            return cipherStream.ToArray();
+        }
+    }
+}

--- a/Snowflake.Data/Core/FileTransfer/EncryptionStream.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionStream.cs
@@ -112,7 +112,7 @@ namespace Snowflake.Data.Core.FileTransfer
                     aes.Padding = PaddingMode.PKCS7;
                     aes.IV = ivBytes;
 
-                    this.targetStream = new CryptoStream(stream, aes.CreateDecryptor(), CryptoStreamMode.Write, leaveOpen: leaveOpen);
+                    this.targetStream = new CryptoStream(stream, aes.CreateDecryptor(), CryptoStreamMode.Read, leaveOpen: leaveOpen);
                 }
             }
         }
@@ -136,7 +136,7 @@ namespace Snowflake.Data.Core.FileTransfer
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            throw new NotImplementedException();
+            return this.targetStream.Read(buffer, offset, count);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/ISFRemoteStorageClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/ISFRemoteStorageClient.cs
@@ -64,12 +64,12 @@ namespace Snowflake.Data.Core.FileTransfer
         /// <summary>
         /// Attempt upload of a file and retry if fails.
         /// </summary>
-        void UploadFile(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata);
+        void UploadFile(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata);
 
         /// <summary>
         /// Attempt upload of a file and retry if fails.
         /// </summary>
-        Task UploadFileAsync(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken);
+        Task UploadFileAsync(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken);
 
         /// <summary>
         /// Attempt download of a file and retry if fails.

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
@@ -288,9 +288,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the GCS location.
         /// </summary>
         /// <param name="fileMetadata">The GCS file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public void UploadFile(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata)
+        public void UploadFile(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata)
         {
             String encryptionData = GetUploadEncryptionData(encryptionMetadata);
             try
@@ -298,8 +298,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 HttpWebRequest request = GetUploadFileRequest(fileMetadata, encryptionMetadata, encryptionData);
 
                 Stream dataStream = request.GetRequestStream();
-                dataStream.Write(fileBytes, 0, fileBytes.Length);
+                sourceStream.CopyTo(dataStream);
                 dataStream.Close();
+                sourceStream.Close();
 
                 using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
                 {
@@ -318,9 +319,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the GCS location.
         /// </summary>
         /// <param name="fileMetadata">The GCS file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public async Task UploadFileAsync(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
+        public async Task UploadFileAsync(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
         {
             String encryptionData = GetUploadEncryptionData(encryptionMetadata);
             try
@@ -328,8 +329,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 HttpWebRequest request = GetUploadFileRequest(fileMetadata, encryptionMetadata, encryptionData);
 
                 Stream dataStream = await request.GetRequestStreamAsync().ConfigureAwait(false);
-                dataStream.Write(fileBytes, 0, fileBytes.Length);
+                await sourceStream.CopyToAsync(dataStream, 81920, cancellationToken).ConfigureAwait(false);
                 dataStream.Close();
+                sourceStream.Close();
 
                 WebResponse webResponse = await request.GetResponseAsync().ConfigureAwait(false);
                 using (HttpWebResponse response = (HttpWebResponse)webResponse)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -328,14 +328,14 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the S3 location.
         /// </summary>
         /// <param name="fileMetadata">The S3 file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public void UploadFile(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata)
+        public void UploadFile(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata)
         {
             // Get the client
             SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
             AmazonS3Client client = SFS3Client.S3Client;
-            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytes, encryptionMetadata);
+            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, sourceStream, encryptionMetadata);
 
             try
             {
@@ -366,14 +366,14 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the S3 location.
         /// </summary>
         /// <param name="fileMetadata">The S3 file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public async Task UploadFileAsync(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
+        public async Task UploadFileAsync(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
         {
             // Get the client
             SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
             AmazonS3Client client = SFS3Client.S3Client;
-            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytes, encryptionMetadata);
+            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, sourceStream, encryptionMetadata);
 
             try
             {
@@ -404,23 +404,20 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// </summary>
         /// <param name="client"> Amazon S3 client.</param>
         /// <param name="fileMetadata">The S3 file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
         /// <returns>The Put Object request.</returns>
-        private PutObjectRequest GetPutObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata)
+        private PutObjectRequest GetPutObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata)
         {
             PutGetStageInfo stageInfo = fileMetadata.stageInfo;
             RemoteLocation location = ExtractBucketNameAndPath(stageInfo.location);
-
-            // Convert file bytes to memory stream
-            Stream stream = new MemoryStream(fileBytes);
 
             // Create S3 PUT request
             PutObjectRequest putObjectRequest = new PutObjectRequest
             {
                 BucketName = location.bucket,
                 Key = location.key + fileMetadata.destFileName,
-                InputStream = stream,
+                InputStream = sourceStream,
                 ContentType = HTTP_HEADER_VALUE_OCTET_STREAM
             };
 

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -172,9 +172,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the Azure location.
         /// </summary>
         /// <param name="fileMetadata">The Azure file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public void UploadFile(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata)
+        public void UploadFile(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata)
         {
             // Create the metadata to use for the header
             IDictionary<string, string> metadata =
@@ -184,7 +184,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             try
             {
                 // Issue the POST/PUT request
-                blobClient.Upload(new MemoryStream(fileBytes));
+                blobClient.Upload(sourceStream);
                 blobClient.SetMetadata(metadata);
             }
             catch (RequestFailedException ex)
@@ -201,9 +201,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// Upload the file to the Azure location.
         /// </summary>
         /// <param name="fileMetadata">The Azure file metadata.</param>
-        /// <param name="fileBytes">The file bytes to upload.</param>
+        /// <param name="sourceStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
-        public async Task UploadFileAsync(SFFileMetadata fileMetadata, byte[] fileBytes, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
+        public async Task UploadFileAsync(SFFileMetadata fileMetadata, Stream sourceStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
         {
             // Create the metadata to use for the header
             IDictionary<string, string> metadata =
@@ -213,7 +213,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             try
             {
                 // Issue the POST/PUT request
-                await blobClient.UploadAsync(new MemoryStream(fileBytes), cancellationToken);
+                await blobClient.UploadAsync(sourceStream, cancellationToken);
                 blobClient.SetMetadata(metadata);
             }
             catch (RequestFailedException ex)


### PR DESCRIPTION
An effort to reduce memory usage when uploading or download files.  Stop using MemoryStream/byte[] and instead use a temporary file stream.  The temporary files are automatically closed when the stream is closed/disposed.

Can resolve issue https://github.com/snowflakedb/snowflake-connector-net/issues/621
