### PR TITLE
Fix for FIPS Gov Issue ServiceURL in S3 SDK MUST BE URL

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -305,7 +305,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 {
                     endpoint = endpoint.Substring(start + 1, end - start - 1);
                 }
-                clientConfig.ServiceURL = endpoint;
+                clientConfig.ServiceURL = "https://" + endpoint;
             }
 
             // The region information used to determine the endpoint for the service.


### PR DESCRIPTION
This is a fix for the FIPS Gov issue