### PR TITLE
Update README.md: ".NET Core 6.0" to just ".NET 6.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Snowflake .NET connector supports the the following .NET framework and libra
 - .NET Framework 4.7.1
 - .NET Framework 4.7.2
 - .NET Framework 4.7.3
-- .NET Core 6.0
+- .NET 6.0
 
 Please refer to the Notice section below for information about safe usage of the .NET Driver
 


### PR DESCRIPTION
I know this is silly PR, but "Core" has been removed from framework name with .NET 5.0, see [Target frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#latest-versions).

// look for image: ralph I'm helping