### PR TITLE
issue 257 connection not terminate session when connection pooling enable

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -292,6 +292,28 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
             Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
         }
+
+        [Test]
+        [Ignore("Disable test case to prevent the static variable changed at the same time.")]
+        public void TestConnectionPoolTurnOff()
+        {
+            SnowflakeDbConnectionPool.SetPooling(false);
+            SnowflakeDbConnectionPool.SetPooling(true);
+            SnowflakeDbConnectionPool.SetMaxPoolSize(1);
+            SnowflakeDbConnectionPool.ClearAllPools();
+
+            var conn1 = new SnowflakeDbConnection();
+            conn1.ConnectionString = ConnectionString;
+            conn1.Open();
+            Assert.AreEqual(ConnectionState.Open, conn1.State);
+            conn1.Close();
+
+            Assert.AreEqual(ConnectionState.Closed, conn1.State);
+            Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
+
+            SnowflakeDbConnectionPool.SetPooling(false);
+            //Put a breakpoint at SFSession close function, after connection pool is off, it will send close session request.
+        }
     }
 
     [TestFixture]

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -272,6 +272,7 @@ namespace Snowflake.Data.Core
                 authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken)
             };
 
+            logger.Debug($"Send closeSessionRequest");
             var response = restRequester.Post<CloseResponse>(closeSessionRequest);
             if (!response.success)
             {
@@ -296,6 +297,7 @@ namespace Snowflake.Data.Core
                 authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken)
             };
 
+            logger.Debug($"Send async closeSessionRequest");
             var response = await restRequester.PostAsync<CloseResponse>(closeSessionRequest, cancellationToken).ConfigureAwait(false);
             if (!response.success)
             {


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/257
The root case of this issue is no clean up logic for connection pool. Since the connection pool functions are all static, so no instance for it to handle the application exit. Adding ConnectionPoolSingleton when connection pool being used. The destructor will run when the application exit.
