### PR TITLE
Bug fix: issue 308, issue 311 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,10 +123,12 @@ jobs:
         with:
           name: code-coverage-report
           path: Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml
-      - name: Install Codecov
-        run: pip install codecov
-      - name: Run Codecoverage
-        run: codecov -f Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml -t ffc6a21d-8176-4849-9047-e3a631dcd35a
+#disable Code coverage for now as codecov is deprecated
+#https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
+#      - name: Install Codecov
+#        run: pip install codecov
+#      - name: Run Codecoverage
+#        run: codecov -f Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml -t ffc6a21d-8176-4849-9047-e3a631dcd35a
 
   test-linux:
     needs: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,9 @@ jobs:
       matrix:
         #dotnet: ['2.2.402']
         dotnet: ['net6.0']
-        cloud_env: ['azure', 'gcp', 'aws']
+        #REMOVE azure for now
+        #cloud_env: ['azure', 'gcp', 'aws']
+        cloud_env: ['gcp', 'aws']
     steps:
       - uses: actions/checkout@main
       - name: Setup Dotnet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,9 +139,7 @@ jobs:
       matrix:
         #dotnet: ['2.2.402']
         dotnet: ['net6.0']
-        #REMOVE azure for now
-        #cloud_env: ['azure', 'gcp', 'aws']
-        cloud_env: ['gcp', 'aws']
+        cloud_env: ['azure', 'gcp', 'aws']
     steps:
       - uses: actions/checkout@main
       - name: Setup Dotnet

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -197,9 +197,13 @@ namespace Snowflake.Data.Tests
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = "create schema \"dlSchema\"";
                 cmd.ExecuteNonQuery();
+                cmd.CommandText = "use schema \"dlSchema\"";
+                cmd.ExecuteNonQuery();
                 cmd.CommandText = "create table \"dlTest\".\"dlSchema\".test1 (col1 string, col2 int)";
+                //cmd.CommandText = "create table test1 (col1 string, col2 int)";
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = "insert into \"dlTest\".\"dlSchema\".test1 Values ('test 1', 1);";
+                //cmd.CommandText = "insert into test1 Values ('test 1', 1);";
                 cmd.ExecuteNonQuery();
             }
            
@@ -222,9 +226,9 @@ namespace Snowflake.Data.Tests
                 Assert.AreEqual(conn1.State, ConnectionState.Closed);
 
                 conn1.Open();
-                using (IDbCommand cmd = conn.CreateCommand())
+                using (IDbCommand cmd = conn1.CreateCommand())
                 {
-                    cmd.CommandText = "SELECT count(*) FROM \"dlTest\".\"dlSchema\".test1";
+                    cmd.CommandText = "SELECT count(*) FROM test1";
                     IDataReader reader = cmd.ExecuteReader();
                     Assert.IsTrue(reader.Read());
                     Assert.AreEqual(1, reader.GetInt32(0));
@@ -233,7 +237,7 @@ namespace Snowflake.Data.Tests
 
                 Assert.AreEqual(ConnectionState.Closed, conn1.State); 
             }
-
+            
             using (IDbCommand cmd = conn.CreateCommand())
             {
                 cmd.CommandText = "drop database \"dlTest\"";

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -225,7 +225,7 @@ namespace Snowflake.Data.Tests
                     conn1.Open();
                     using (IDbCommand cmd = conn.CreateCommand())
                     {
-                        cmd.CommandText = "SELECT count(*) FROM testPutArrayBind";
+                        cmd.CommandText = "SELECT count(*) FROM \"dlTest\".\"dlSchema\".test1";
                         IDataReader reader = cmd.ExecuteReader();
                         Assert.IsTrue(reader.Read());
                         Assert.AreEqual(1, reader.GetInt32(0));
@@ -247,7 +247,7 @@ namespace Snowflake.Data.Tests
             {
                 cmd.CommandText = "drop database \"dlTest\"";
                 cmd.ExecuteNonQuery();
-                cmd.CommandText = "use database TESTDB";
+                cmd.CommandText = "use database "+ testConfig.database;
                 cmd.ExecuteNonQuery();
             }
             conn.Close();

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -184,6 +184,115 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        public void TestConnectString()
+        {
+            var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = ConnectionString;
+            conn.Open();
+            using (IDbCommand cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "create database \"dlTest\"";
+                cmd.ExecuteNonQuery();
+                cmd.CommandText = "use database \"dlTest\"";
+                cmd.ExecuteNonQuery();
+                cmd.CommandText = "create schema \"dlSchema\"";
+                cmd.ExecuteNonQuery();
+                cmd.CommandText = "create table \"dlTest\".\"dlSchema\".test1 (col1 string, col2 int)";
+                cmd.ExecuteNonQuery();
+                cmd.CommandText = "insert into \"dlTest\".\"dlSchema\".test1 Values ('test 1', 1);";
+                cmd.ExecuteNonQuery();
+            }
+           
+            using (var conn1 = new SnowflakeDbConnection())
+            {
+                conn1.ConnectionString = String.Format("scheme={0};host={1};port={2};" +
+                    "account={3};role={4};db={5};schema={6};warehouse={7};user={8};password={9};",
+                        testConfig.protocol,
+                        testConfig.host,
+                        testConfig.port,
+                        testConfig.account,
+                        testConfig.role,
+                        "\"dlTest\"",
+                        //testConfig.database,
+                        "\"dlSchema\"",
+                        //testConfig.schema,
+                        testConfig.warehouse,
+                        testConfig.user,
+                        testConfig.password);
+                Assert.AreEqual(conn1.State, ConnectionState.Closed);
+                try
+                {
+                    conn1.Open();
+                    using (IDbCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT count(*) FROM testPutArrayBind";
+                        IDataReader reader = cmd.ExecuteReader();
+                        Assert.IsTrue(reader.Read());
+                        Assert.AreEqual(1, reader.GetInt32(0));
+                    }
+                    conn1.Close();
+
+                }
+                catch (SnowflakeDbException e)
+                {
+                    // Expected
+                    logger.Debug("Failed opening connection ", e);
+                    Assert.AreEqual("08006", e.SqlState); // Connection failure
+                }
+
+                Assert.AreEqual(ConnectionState.Closed, conn1.State); 
+            }
+
+            using (IDbCommand cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "drop database \"dlTest\"";
+                cmd.ExecuteNonQuery();
+                cmd.CommandText = "use database TESTDB";
+                cmd.ExecuteNonQuery();
+            }
+            conn.Close();
+        }
+
+        [Test]
+        [Ignore("TestConnectStringWithUserPwd, this will popup an internet browser for external login.")]
+        public void TestConnectStringWithUserPwd()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = String.Format("scheme={0};host={1};port={2};" +
+            "account={3};role={4};db={5};schema={6};warehouse={7};user={8};password={9};authenticator={10};",
+                    testConfig.protocol,
+                    testConfig.host,
+                    testConfig.port,
+                    testConfig.account,
+                    testConfig.role,
+                    testConfig.database,
+                    testConfig.schema,
+                    testConfig.warehouse,
+                    "",
+                    "",
+                    "externalbrowser");
+
+                Assert.AreEqual(conn.State, ConnectionState.Closed);
+                try
+                {
+                    conn.Open();
+                    Assert.Fail();
+
+                }
+                catch (SnowflakeDbException e)
+                {
+                    // Expected
+                    logger.Debug("Failed opening connection ", e);
+                    Assert.AreEqual("08006", e.SqlState); // Connection failure
+                }
+
+                Assert.AreEqual(ConnectionState.Closed, conn.State);
+            }
+        }
+
+
+        [Test]
         public void TestConnectViaSecureString()
         {
             String[] connEntries = ConnectionString.Split(';');

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -191,19 +191,19 @@ namespace Snowflake.Data.Tests
             conn.Open();
             using (IDbCommand cmd = conn.CreateCommand())
             {
-                cmd.CommandText = "create database \"dlTest\"";
-                cmd.ExecuteNonQuery();
-                cmd.CommandText = "use database \"dlTest\"";
-                cmd.ExecuteNonQuery();
+                //cmd.CommandText = "create database \"dlTest\"";
+                //cmd.ExecuteNonQuery();
+                //cmd.CommandText = "use database \"dlTest\"";
+                //cmd.ExecuteNonQuery();
                 cmd.CommandText = "create schema \"dlSchema\"";
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = "use schema \"dlSchema\"";
                 cmd.ExecuteNonQuery();
-                cmd.CommandText = "create table \"dlTest\".\"dlSchema\".test1 (col1 string, col2 int)";
-                //cmd.CommandText = "create table test1 (col1 string, col2 int)";
+                //cmd.CommandText = "create table \"dlTest\".\"dlSchema\".test1 (col1 string, col2 int)";
+                cmd.CommandText = "create table test1 (col1 string, col2 int)";
                 cmd.ExecuteNonQuery();
-                cmd.CommandText = "insert into \"dlTest\".\"dlSchema\".test1 Values ('test 1', 1);";
-                //cmd.CommandText = "insert into test1 Values ('test 1', 1);";
+                //cmd.CommandText = "insert into \"dlTest\".\"dlSchema\".test1 Values ('test 1', 1);";
+                cmd.CommandText = "insert into test1 Values ('test 1', 1);";
                 cmd.ExecuteNonQuery();
             }
            
@@ -216,8 +216,8 @@ namespace Snowflake.Data.Tests
                         testConfig.port,
                         testConfig.account,
                         testConfig.role,
-                        "\"dlTest\"",
-                        //testConfig.database,
+                        //"\"dlTest\"",
+                        testConfig.database,
                         "\"dlSchema\"",
                         //testConfig.schema,
                         testConfig.warehouse,
@@ -240,7 +240,8 @@ namespace Snowflake.Data.Tests
             
             using (IDbCommand cmd = conn.CreateCommand())
             {
-                cmd.CommandText = "drop database \"dlTest\"";
+                //cmd.CommandText = "drop database \"dlTest\"";
+                cmd.CommandText = "drop schema \"dlSchema\"";
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = "use database "+ testConfig.database;
                 cmd.ExecuteNonQuery();

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -220,25 +220,16 @@ namespace Snowflake.Data.Tests
                         testConfig.user,
                         testConfig.password);
                 Assert.AreEqual(conn1.State, ConnectionState.Closed);
-                try
-                {
-                    conn1.Open();
-                    using (IDbCommand cmd = conn.CreateCommand())
-                    {
-                        cmd.CommandText = "SELECT count(*) FROM \"dlTest\".\"dlSchema\".test1";
-                        IDataReader reader = cmd.ExecuteReader();
-                        Assert.IsTrue(reader.Read());
-                        Assert.AreEqual(1, reader.GetInt32(0));
-                    }
-                    conn1.Close();
 
-                }
-                catch (SnowflakeDbException e)
+                conn1.Open();
+                using (IDbCommand cmd = conn.CreateCommand())
                 {
-                    // Expected
-                    logger.Debug("Failed opening connection ", e);
-                    Assert.AreEqual("08006", e.SqlState); // Connection failure
+                    cmd.CommandText = "SELECT count(*) FROM \"dlTest\".\"dlSchema\".test1";
+                    IDataReader reader = cmd.ExecuteReader();
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual(1, reader.GetInt32(0));
                 }
+                conn1.Close();
 
                 Assert.AreEqual(ConnectionState.Closed, conn1.State); 
             }
@@ -274,23 +265,11 @@ namespace Snowflake.Data.Tests
                     "externalbrowser");
 
                 Assert.AreEqual(conn.State, ConnectionState.Closed);
-                try
-                {
-                    conn.Open();
-                    Assert.Fail();
-
-                }
-                catch (SnowflakeDbException e)
-                {
-                    // Expected
-                    logger.Debug("Failed opening connection ", e);
-                    Assert.AreEqual("08006", e.SqlState); // Connection failure
-                }
-
+                conn.Open();
+                conn.Close();
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
             }
         }
-
 
         [Test]
         public void TestConnectViaSecureString()

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -177,7 +177,8 @@ namespace Snowflake.Data.Core
                 if(keyVal.Length > 0)
                 {
                     string[] tokens = keyVal.Split(new string[] { "=" }, StringSplitOptions.None);
-                    if(tokens[0].ToUpper() == "DB" || tokens[0].ToLower() == "SCHEMA" || tokens[0].ToLower() == "WAREHOUSE")
+                    if(tokens[0].ToUpper() == "DB" || tokens[0].ToLower() == "SCHEMA" ||
+                        tokens[0].ToLower() == "WAREHOUSE" || tokens[0].ToLower() == "ROLE")
                     {
                         if (tokens.Length == 2)
                         {

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -170,6 +170,34 @@ namespace Snowflake.Data.Core
                 }
             }
 
+            //handle DbConnectionStringBuilder missing cases
+            string[] propertyEntry = connectionString.Split(';');
+            foreach(string keyVal in propertyEntry)
+            {
+                if(keyVal.Length > 0)
+                {
+                    string[] tokens = keyVal.Split(new string[] { "=" }, StringSplitOptions.None);
+                    if(tokens[0].ToUpper() == "DB" || tokens[0].ToLower() == "SCHEMA" || tokens[0].ToLower() == "WAREHOUSE")
+                    {
+                        if (tokens.Length == 2)
+                        {
+                            SFSessionProperty p = (SFSessionProperty)Enum.Parse(
+                                typeof(SFSessionProperty), tokens[0].ToUpper());
+                            properties[p]= tokens[1];
+                        }
+                    }
+                    if(tokens[0].ToUpper() == "USER" || tokens[0].ToUpper() == "PASSWORD")
+                    {
+                        SFSessionProperty p = (SFSessionProperty)Enum.Parse(
+                                typeof(SFSessionProperty), tokens[0].ToUpper());
+                        if (!properties.ContainsKey(p))
+                        {
+                            properties.Add(p, "");
+                        }
+                    }
+                }
+            }
+
             bool useProxy = false;
             if (properties.ContainsKey(SFSessionProperty.USEPROXY))
             {

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -177,8 +177,8 @@ namespace Snowflake.Data.Core
                 if(keyVal.Length > 0)
                 {
                     string[] tokens = keyVal.Split(new string[] { "=" }, StringSplitOptions.None);
-                    if(tokens[0].ToUpper() == "DB" || tokens[0].ToLower() == "SCHEMA" ||
-                        tokens[0].ToLower() == "WAREHOUSE" || tokens[0].ToLower() == "ROLE")
+                    if(tokens[0].ToUpper() == "DB" || tokens[0].ToUpper() == "SCHEMA" ||
+                        tokens[0].ToLower() == "WAREHOUSE" || tokens[0].ToUpper() == "ROLE")
                     {
                         if (tokens.Length == 2)
                         {


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/308
USER property is mandatory for external browser auth.
root cause is after using DbConnectionStringBuilder, when we have user=;password=; DbConnectionStringBuilder will not add this to connection string properties, but the old version we still add it with empty string. 
solve it by reading the input connection string, if user or password exist, and not exist from DbConnectionStringBuilder, add user or password with empty string.

https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/311
Customer can't access lowercase database from connection string. 
root cause is DbConnectionStringBuilder will remove all double quotes in front or after the property value. So for those properties which will convert to upper case by default (if not double quotes wrapped), such as database, schema, warehouse and role. We will get the value from the old way. 
