### PR TITLE
SNOW-777930 Bug fix: .NET application terminates when client_session_keep_alive=true due to unhandled exception

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,10 +123,12 @@ jobs:
         with:
           name: code-coverage-report
           path: Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml
-      - name: Install Codecov
-        run: pip install codecov
-      - name: Run Codecoverage
-        run: codecov -f Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml -t ffc6a21d-8176-4849-9047-e3a631dcd35a
+#disable Code coverage for now as codecov is deprecated
+#https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
+#      - name: Install Codecov
+#        run: pip install codecov
+#      - name: Run Codecoverage
+#        run: codecov -f Snowflake.Data.Tests\${{ matrix.dotnet }}_${{ matrix.cloud_env }}_coverage.xml -t ffc6a21d-8176-4849-9047-e3a631dcd35a
 
   test-linux:
     needs: test

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1391,16 +1391,34 @@ namespace Snowflake.Data.Tests
         [Test]
         public void TestKeepAlive()
         {
-            var connCount = 10;
-            for (int i = 0; i < connCount; i++)
+            // create 100 connections, one per second
+            var connCount = 100;
+            // pooled connectin expire in 5 seconds so after 5 seconds,
+            // one connection per second will be closed
+            SnowflakeDbConnectionPool.SetTimeout(5);
+            SnowflakeDbConnectionPool.SetMaxPoolSize(20);
+            // heart beat interval is validity/4 so send out per 5 seconds
+            HeartBeatBackground.setValidity(20);
+            try
             {
-                using (var conn = new SnowflakeDbConnection())
+                for (int i = 0; i < connCount; i++)
                 {
-                    conn.ConnectionString = ConnectionString + ";CLIENT_SESSION_KEEP_ALIVE=true";
-                    conn.Open();
+                    using (var conn = new SnowflakeDbConnection())
+                    {
+                        conn.ConnectionString = ConnectionString + ";CLIENT_SESSION_KEEP_ALIVE=true";
+                        conn.Open();
+                    }
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                    // roughly should only have 5 sessions in pool stay alive
+                    // check for 10 in case of bad timing, also much less than the
+                    // pool max size to ensure it's unpooled because of expire
+                    Assert.Less(HeartBeatBackground.getQueueLength(), 10);
                 }
-
-                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+            catch
+            {
+                // fail the test case if any exception is thrown
+                Assert.Fail();
             }
         }
     }

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1387,6 +1387,22 @@ namespace Snowflake.Data.Tests
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
             Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
         }
+
+        [Test]
+        public void TestKeepAlive()
+        {
+            var connCount = 10;
+            for (int i = 0; i < connCount; i++)
+            {
+                using (var conn = new SnowflakeDbConnection())
+                {
+                    conn.ConnectionString = ConnectionString + ";CLIENT_SESSION_KEEP_ALIVE=true";
+                    conn.Open();
+                }
+
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+        }
     }
 
     [TestFixture]

--- a/Snowflake.Data.Tests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/SFDbCommandIT.cs
@@ -599,6 +599,7 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        [Ignore("Ignore flaky unstable test case for now. Will revisit later and sdk issue created (210)")]
         public void testPutArrayBindAsync()
         {
             ArrayBindTest(ConnectionString, "testPutArrayBind", 250000);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -132,7 +132,6 @@ namespace Snowflake.Data.Client
         {
             if (SfSession != null)
             {
-                SfSession.stopHeartBeatForThisSession();
                 SfSession.close();
             }
         }
@@ -141,7 +140,6 @@ namespace Snowflake.Data.Client
         {
             if (SfSession != null)
             {
-                SfSession.stopHeartBeatForThisSession();
                 SfSession.CloseAsync(cancellationToken).ContinueWith(
                 previousTask =>
                 {

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -24,7 +24,7 @@ namespace Snowflake.Data.Client
 
         internal int _connectionTimeout;
 
-        internal long _poolTimeout;
+        internal long _poolTimeout = 0;
 
         private bool disposed = false;
 
@@ -362,6 +362,13 @@ namespace Snowflake.Data.Client
             {
                 externalCancellationToken.Register(() => { _connectionState = ConnectionState.Closed; });
             }
+        }
+
+        // Called by connection pooling when the connection is removed out of pool
+        // could be reused or destroyed when expire
+        internal void Unpool()
+        {
+            pooled = false;
         }
 
         ~SnowflakeDbConnection()

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -340,10 +340,14 @@ namespace Snowflake.Data.Client
                 // Prevent an exception from being thrown when disposing of this object
                 logger.Error("Unable to close connection", ex);
             }
-            
-            disposed = true;
 
-            base.Dispose(disposing);
+            // only dispose the connection when it's not pooled
+            if (!pooled)
+            {
+                disposed = true;
+
+                base.Dispose(disposing);
+            }
         }
 
 

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -118,7 +118,7 @@ namespace Snowflake.Data.Client
                 return false;
             long timeNow = DateTimeOffset.Now.ToUnixTimeSeconds();
             // Do not pool connection already expired
-            if (conn._poolTimeout <= timeNow)
+            if ((conn._poolTimeout != 0) && (conn._poolTimeout <= timeNow))
                 return false;
 
             lock (_connectionPoolLock)

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Client
         private long timeout;
         private int MAX_POOL_SIZE = 10;
         private const long TIMEOUT = 3600;
-        private bool pooling = false;// temporarily desiable connection pooling
+        private bool pooling = true;
 
         ConnectionPoolSingleton()
         {
@@ -166,10 +166,6 @@ namespace Snowflake.Data.Client
 
         public bool SetPooling(bool isEnable)
         {
-            // temporarily disable connection pooling
-            // as it's buggy and needs refactoring.
-            return false;
-            /*
             if (pooling == isEnable)
                 return false;
             pooling = isEnable;
@@ -178,7 +174,6 @@ namespace Snowflake.Data.Client
                 ClearAllPools();
             }
             return true;
-            */
         }
 
         public bool GetPooling()

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Client
         private long timeout;
         private int MAX_POOL_SIZE = 10;
         private const long TIMEOUT = 3600;
-        private bool pooling = true;
+        private bool pooling = false;// temporarily desiable connection pooling
 
         ConnectionPoolSingleton()
         {
@@ -166,6 +166,10 @@ namespace Snowflake.Data.Client
 
         public bool SetPooling(bool isEnable)
         {
+            // temporarily disable connection pooling
+            // as it's buggy and needs refactoring.
+            return false;
+            /*
             if (pooling == isEnable)
                 return false;
             pooling = isEnable;
@@ -174,6 +178,7 @@ namespace Snowflake.Data.Client
                 ClearAllPools();
             }
             return true;
+            */
         }
 
         public bool GetPooling()

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -67,10 +67,12 @@ namespace Snowflake.Data.Client
                     if (item._poolTimeout <= timeNow)
                     {
                         connectionPool.Remove(item);
-                        if (item.SfSession != null)
-                        {
-                            item.SfSession.close();
-                        }
+                        item.Unpool();
+                        // This will call SnowflakeDBConnection.Close()
+                        // Since the state of a pooled connection should be
+                        // Closed, also the poolTimeout is expired as well,
+                        // it won't be pooled again and will be destroyed
+                        item.Dispose();
                     }
                 }
             }
@@ -89,13 +91,15 @@ namespace Snowflake.Data.Client
                     {
                         SnowflakeDbConnection conn = connectionPool[i];
                         connectionPool.RemoveAt(i);
+                        conn.Unpool();
                         long timeNow = DateTimeOffset.Now.ToUnixTimeSeconds();
                         if (conn._poolTimeout <= timeNow)
                         {
-                            if (conn.SfSession != null)
-                            {
-                                conn.SfSession.close();
-                            }
+                            // This will call SnowflakeDBConnection.Close()
+                            // Since the state of a pooled connection should be
+                            // Closed, also the poolTimeout is expired as well,
+                            // it won't be pooled again and will be destroyed
+                            conn.Dispose();
                             i--;
                         }
                         else
@@ -112,28 +116,31 @@ namespace Snowflake.Data.Client
             logger.Debug("ConnectionPool::addConnection");
             if (!pooling)
                 return false;
+            long timeNow = DateTimeOffset.Now.ToUnixTimeSeconds();
+            // Do not pool connection already expired
+            if (conn._poolTimeout <= timeNow)
+                return false;
+
             lock (_connectionPoolLock)
             {
-                if (connectionPool.Count < maxPoolSize)
-                {
-                    long timeNow = DateTimeOffset.Now.ToUnixTimeSeconds();
-                    conn._poolTimeout = timeNow + timeout;
-                    connectionPool.Add(conn);
-                    return true;
-                }
-                else
+                if (connectionPool.Count >= maxPoolSize)
                 {
                     cleanExpiredConnections();
-                    if (connectionPool.Count < maxPoolSize)
-                    {
-                        long timeNow = DateTimeOffset.Now.ToUnixTimeSeconds();
-                        conn._poolTimeout = timeNow + timeout;
-                        connectionPool.Add(conn);
-                        return true;
-                    }
                 }
+                if (connectionPool.Count >= maxPoolSize)
+                {
+                    // pool is full
+                    return false;
+                }
+
+                // only setup pool timeout at the first time
+                if (conn._poolTimeout == 0)
+                {
+                    conn._poolTimeout = timeNow + timeout;
+                }
+                connectionPool.Add(conn);
+                return true;
             }
-            return false;
         }
 
         internal void ClearAllPools()
@@ -143,7 +150,12 @@ namespace Snowflake.Data.Client
             {
                 foreach (SnowflakeDbConnection conn in connectionPool)
                 {
-                    conn.PostClose();
+                    // It's better to always call Dispose to destroy
+                    // the connection as that should release all resources
+                    // It won't trigger pooling as a pooled connection always
+                    // closed.
+                    conn.Unpool();
+                    conn.Dispose();
                 }
                 connectionPool.Clear();
             }

--- a/Snowflake.Data/Core/HeartBeatBackground.cs
+++ b/Snowflake.Data/Core/HeartBeatBackground.cs
@@ -30,6 +30,23 @@ namespace Snowflake.Data.Core
             isHeartBeatEnd = true;
         }
 
+        internal static int getQueueLength()
+        {
+            lock (heartBeatLock)
+            {
+                if (heartBeatConns == null)
+                {
+                    return 0;
+                }
+                return heartBeatConns.Count();
+            }
+        }
+
+        internal static void setValidity(long validity)
+        {
+            masterTokenValidationTimeInSec = validity;
+        }
+
         public static HeartBeatBackground Instance
         {
             get
@@ -60,19 +77,17 @@ namespace Snowflake.Data.Core
                 }
 
                 heartBeatConns.Add(conn);
-                if(heartBeatThread == null)
+                // for test purpose that Validity can be set to non-zero value
+                if ((masterTokenValidationTimeInSec == 0) ||
+                    (masterTokenValidityInSecs < masterTokenValidationTimeInSec))
                 {
+                    //update validation time
                     masterTokenValidationTimeInSec = masterTokenValidityInSecs;
+                }
+                if (heartBeatThread == null)
+                {
                     heartBeatThread = new Thread(heartBeatAll) { IsBackground = true };
                     heartBeatThread.Start();
-                }
-                else
-                {
-                    if(masterTokenValidityInSecs < masterTokenValidationTimeInSec)
-                    {
-                        //update validation time
-                        masterTokenValidationTimeInSec = masterTokenValidityInSecs;
-                    }
                 }
             }
         }

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -71,6 +71,9 @@ namespace Snowflake.Data.Core
 
     internal class LoginResponseData
     {
+        [JsonProperty(PropertyName = "sessionId", NullValueHandling = NullValueHandling.Ignore)]
+        internal string sessionId { get; set; }
+
         [JsonProperty(PropertyName = "token", NullValueHandling = NullValueHandling.Ignore)]
         internal string token { get; set; }
 

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -71,6 +71,7 @@ namespace Snowflake.Data.Core
                 serverVersion = authnResponse.data.serverVersion;
                 masterValidityInSeconds = authnResponse.data.masterValidityInSeconds;
                 UpdateSessionParameterMap(authnResponse.data.nameValueParameter);
+                logger.Debug($"Session opened: {sessionId}");
             }
             else
             {
@@ -277,6 +278,7 @@ namespace Snowflake.Data.Core
                 logger.Debug($"Failed to delete session: {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
             }
 
+            logger.Debug($"Session closed: {sessionId}");
             // Just in case the session won't be closed twice
             sessionToken = null;
         }
@@ -306,6 +308,10 @@ namespace Snowflake.Data.Core
             {
                 logger.Debug($"Failed to delete session {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
             }
+
+            logger.Debug($"Session closed: {sessionId}");
+            // Just in case the session won't be closed twice
+            sessionToken = null;
         }
 
         internal void renewSession()

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -276,6 +276,9 @@ namespace Snowflake.Data.Core
             {
                 logger.Debug($"Failed to delete session: {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
             }
+
+            // Just in case the session won't be closed twice
+            sessionToken = null;
         }
 
         internal async Task CloseAsync(CancellationToken cancellationToken)
@@ -490,6 +493,8 @@ namespace Snowflake.Data.Core
                             try
                             {
                                 renewSession();
+                                retry = true;
+                                continue;
                             }
                             catch (Exception ex)
                             {
@@ -499,8 +504,6 @@ namespace Snowflake.Data.Core
                                 // thrown from renewSession(), simply ignore that
                                 logger.Error($"renew session (ID: {sessionId}) failed.", ex);
                             }
-                            retry = true;
-                            continue;
                         }
                         else
                         {

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -391,12 +391,12 @@ namespace Snowflake.Data.Core
             }
             if (ParameterMap.ContainsKey(SFSessionParameter.CLIENT_STAGE_ARRAY_BINDING_THRESHOLD))
             {
-                string val = (string)ParameterMap[SFSessionParameter.CLIENT_STAGE_ARRAY_BINDING_THRESHOLD];
+                string val = ParameterMap[SFSessionParameter.CLIENT_STAGE_ARRAY_BINDING_THRESHOLD].ToString();
                 this.arrayBindStageThreshold = Int32.Parse(val);
             }
             if (ParameterMap.ContainsKey(SFSessionParameter.CLIENT_SESSION_KEEP_ALIVE))
             {
-                bool keepAlive = Boolean.Parse((string)ParameterMap[SFSessionParameter.CLIENT_SESSION_KEEP_ALIVE]);
+                bool keepAlive = Boolean.Parse(ParameterMap[SFSessionParameter.CLIENT_SESSION_KEEP_ALIVE].ToString());
                 if(keepAlive)
                 {
                     startHeartBeatForThisSession();


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/307

There were mainly two issues:
1. unhandled exception from heartbeat session renew crashes upper application
2. heartbeat queue growth possibly uncontrolled

The root cause of issue 1 is that when trying to send heart beat for a session, there could be a bad timing that the session token expired so renew session is triggered, and the session is closed right after so renew session could fail, and the unhandled exception was thrown there. 
Removing the exception throw will fix this issue.

There are multiple reason for issue 2 though.
- SFSession.Close() doesn't remove the session out of heart beat queue. https://github.com/snowflakedb/snowflake-connector-net/blob/v2.0.22/Snowflake.Data/Core/SFSession.cs#L258
- SFSnowflakeConnection.Dispose() set disposed flag even when the connection is pooled, so when the connection is reused by a new connection and disposed again, nothing would happen as the disposed flag is set to true already so the session was leaked. https://github.com/snowflakedb/snowflake-connector-net/blob/v2.0.22/Snowflake.Data/Client/SnowflakeDbConnection.cs#L335
To fix issue 2, always call stopHeartBeatForThisSession() when close the session, also in SFSnowflakeConnection.Dispose() only set disposed when it's not pooled.

There are other bug fixes as well:
- CLIENT_SESSION_KEEP_ALIVE in connection string. It's actually not working as the driver didn't send it to server as session parameter
- pooling timeout was reset each time when the connection is reused and pooled again. This could make the connection never expire and application could get error when the session expired. Set pooling timeout only at the first time it's pooled.

Some other minor changes:
- add logging of session id.
- add some internal functions in HeartBeatBackground for test purpose.
- remove usage of codecov as it's deprecated and fail the test run.
- Ignore known test failure as it's been there for months and we have [sdk issue #210](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/210) for that already.