### PR TITLE
Add localhost as a port to make sure openAsync and open in functionality

### DIFF
--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -49,7 +49,6 @@ namespace Snowflake.Data.Core.Authenticator
             int localPort = GetRandomUnusedPort();
             using (var httpListener = GetHttpListener(localPort))
             {
-                
                 httpListener.Prefixes.Add("http://localhost:" + localPort + "/");
                 httpListener.Start();
 

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -49,6 +49,7 @@ namespace Snowflake.Data.Core.Authenticator
             int localPort = GetRandomUnusedPort();
             using (var httpListener = GetHttpListener(localPort))
             {
+                httpListener.Prefixes.Add("http://localhost:" + localPort + "/");
                 httpListener.Start();
 
                 logger.Debug("Get IdpUrl and ProofKey");

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -49,6 +49,7 @@ namespace Snowflake.Data.Core.Authenticator
             int localPort = GetRandomUnusedPort();
             using (var httpListener = GetHttpListener(localPort))
             {
+                
                 httpListener.Prefixes.Add("http://localhost:" + localPort + "/");
                 httpListener.Start();
 


### PR DESCRIPTION
I noticed when using `Open` the request worked fine, but we've been using `OpenAsync` which seems to have slightly different functionality and I can't see any obvious reason as to why within the code.

Doing this allows me to use the same flow as for `Open` and `OpenAsync`, and not have to manually chang the returned URL from `localhost:{port}` to `127.0.0.1:{port}`.