### PR TITLE
A command may be executed within an unexpected transaction.

### DIFF
--- a/Snowflake.Data.Tests/Util/SnowflakeResourceReferencesTest.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeResourceReferencesTest.cs
@@ -1,0 +1,273 @@
+﻿using NUnit.Framework;
+using Snowflake.Data.Util;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Snowflake.Data.Tests.Util
+{
+    public class SnowflakeResourceReferencesTest
+    {
+        [Test]
+        public void TestAdd()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource();
+            refs.Add(res1);
+            Assert.AreEqual(1, refs.Count);
+            Assert.IsTrue(refs.TryGetValue<TestResource>(res1.ResourceID, out var actual1));
+            Assert.True(object.ReferenceEquals(res1, actual1));
+
+            var res2 = new TestResource();
+            refs.Add(res2);
+            Assert.AreEqual(2, refs.Count);
+            Assert.IsTrue(refs.TryGetValue<TestResource>(res2.ResourceID, out var actual2));
+            Assert.True(object.ReferenceEquals(res2, actual2));
+        }
+
+        [Test]
+        public void TestRemove()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            var res2 = new TestResource(refs);
+
+            refs.Remove(res1);
+            Assert.AreEqual(1, refs.Count);
+            Assert.IsFalse(refs.TryGetValue<TestResource>(res1.ResourceID, out var actual1));
+
+            refs.Remove(res2);
+            Assert.AreEqual(0, refs.Count);
+            Assert.IsFalse(refs.TryGetValue<TestResource>(res2.ResourceID, out var actual2));
+        }
+
+        [Test]
+        public void TestRemove_is_missing()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var notJoinedRes = new TestResource();
+
+            Assert.DoesNotThrow(() => refs.Remove(notJoinedRes));
+            Assert.AreEqual(0, refs.Count);
+        }
+
+        [Test]
+        public void TryGetValue()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            var res2 = new TestResource(refs);
+
+            Assert.IsTrue(refs.TryGetValue<TestResource>(res1.ResourceID, out var actual1));
+            Assert.True(object.ReferenceEquals(res1, actual1));
+
+            Assert.IsTrue(refs.TryGetValue<TestResource>(res2.ResourceID, out var actual2));
+            Assert.True(object.ReferenceEquals(res2, actual2));
+        }
+
+        [Test]
+        public void TryGetValue_is_missing()
+        {
+            var refs = new SnowflakeResourceReferences();
+
+            Assert.IsFalse(refs.TryGetValue<TestResource>("missing", out var actual));
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void TryGetValue_is_already_gc()
+        {
+            var refs = new SnowflakeResourceReferences();
+            string volatileResouceId = null;
+            Task.Run(() =>
+            {
+                var res = new TestResource(refs);
+                volatileResouceId = res.ResourceID;
+            }).Wait();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsNotNull(volatileResouceId);
+            Assert.AreEqual(1, refs.Count);
+            Assert.IsFalse(refs.TryGetValue<TestResource>(volatileResouceId, out var actual));
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void TestDisposeAll()
+        {
+            var disposingOrder = new List<ISnowflakeResource>();
+
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            res1.BeforeDispose += (sender, e) => disposingOrder.Add(sender);
+            var res2 = new TestResource(refs);
+            res2.BeforeDispose += (sender, e) => disposingOrder.Add(sender);
+
+            refs.DisposeAll();
+
+            Assert.IsTrue(refs.IsDisposed);
+            Assert.AreEqual(0, refs.Count);
+            Assert.AreEqual(1, res1.DispoedEvents.Count);
+            Assert.AreEqual(1, res2.DispoedEvents.Count);
+            Assert.AreEqual(2, disposingOrder.Count);
+            Assert.AreEqual(res2.ResourceID, disposingOrder[0].ResourceID);
+            Assert.AreEqual(res1.ResourceID, disposingOrder[1].ResourceID);
+        }
+
+        [Test]
+        public void TestDisposeAll_empty()
+        {
+            var refs = new SnowflakeResourceReferences();
+
+            refs.DisposeAll();
+
+            Assert.IsTrue(refs.IsDisposed);
+            Assert.AreEqual(0, refs.Count);
+        }
+
+        [Test]
+        public void TestDisposeAll_thrownException()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            var res2 = new TestResource(refs);
+            res2.BeforeDispose += (sender, e) => throw new Exception();
+            var res3 = new TestResource(refs);
+
+            Assert.Throws<Exception>(() => refs.DisposeAll());
+
+            Assert.IsFalse(refs.IsDisposed);
+            Assert.AreEqual(2, refs.Count);
+            Assert.IsFalse(refs.TryGetValue<ISnowflakeResource>(res3.ResourceID, out var actual3));
+            Assert.AreEqual(0, res1.DispoedEvents.Count);
+            Assert.AreEqual(0, res2.DispoedEvents.Count);
+            Assert.AreEqual(1, res3.DispoedEvents.Count);
+        }
+
+        [Test]
+        public void TestDisposeAllSilently()
+        {
+            var refs = new SnowflakeResourceReferences();
+            new TestResource(refs);
+            new TestResource(refs);
+
+            var actual = refs.DisposeAllSilently();
+
+            Assert.IsTrue(actual);
+            Assert.IsTrue(refs.IsDisposed);
+            Assert.AreEqual(0, refs.Count);
+        }
+
+        [Test]
+        public void TestDisposeAllSilently_thrownException()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            var res2 = new TestResource(refs);
+            res2.BeforeDispose += (sender, e) => throw new Exception();
+            var res3 = new TestResource(refs);
+
+            var actual = refs.DisposeAllSilently();
+
+            Assert.IsFalse(actual);
+            Assert.IsFalse(refs.IsDisposed);
+            Assert.AreEqual(2, refs.Count);
+            Assert.IsFalse(refs.TryGetValue<ISnowflakeResource>(res3.ResourceID, out var actual3));
+        }
+
+        [Test]
+        public void TestDispose()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            var res2 = new TestResource(refs);
+
+            refs.Dispose();
+
+            Assert.IsTrue(refs.IsDisposed);
+            Assert.AreEqual(0, refs.Count);
+            Assert.AreEqual(1, res1.DispoedEvents.Count);
+            Assert.AreEqual(1, res2.DispoedEvents.Count);
+        }
+
+        [Test]
+        public void TestDispose_thrownException()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            res1.BeforeDispose += (sender, e) => throw new Exception();
+            var res2 = new TestResource(refs);
+
+            Assert.DoesNotThrow(() => refs.Dispose());
+
+            Assert.IsFalse(refs.IsDisposed);
+            Assert.AreEqual(1, refs.Count);
+            Assert.AreEqual(0, res1.DispoedEvents.Count);
+            Assert.AreEqual(1, res2.DispoedEvents.Count);
+        }
+
+        [Test]
+        public void TestDispose_doubleCall()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+
+            refs.Dispose();
+            Assert.AreEqual(0, refs.Count);
+            Assert.AreEqual(1, res1.DispoedEvents.Count);
+
+            refs.Dispose();
+            Assert.AreEqual(0, refs.Count);
+            Assert.AreEqual(1, res1.DispoedEvents.Count);
+        }
+
+        [Test]
+        public void TestDispose_afterAdd()
+        {
+            var refs = new SnowflakeResourceReferences();
+            var res1 = new TestResource(refs);
+            refs.Dispose();
+            Assert.IsTrue(refs.IsDisposed);
+
+            var res2 = new TestResource(refs);
+            Assert.IsFalse(refs.IsDisposed);
+            refs.Dispose();
+
+            Assert.IsTrue(refs.IsDisposed);
+            Assert.AreEqual(0, refs.Count);
+            Assert.AreEqual(1, res1.DispoedEvents.Count);
+            Assert.AreEqual(1, res2.DispoedEvents.Count);
+        }
+
+        public class TestResource : ISnowflakeResource
+        {
+            public string ResourceID { get; } = Guid.NewGuid().ToString();
+
+            public event SnowflakeResourceEventHandler Disposed;
+
+            public event SnowflakeResourceEventHandler BeforeDispose;
+
+            public List<(ISnowflakeResource, EventArgs)> DispoedEvents { get; } = new List<(ISnowflakeResource, EventArgs)>();
+
+            public TestResource()
+            {
+                Disposed += (sender, e) => this.DispoedEvents.Add((sender, e));
+            }
+
+            public TestResource(SnowflakeResourceReferences refs) : this()
+            {
+                refs.Add(this);
+            }
+
+            public void Dispose()
+            {
+                if (BeforeDispose != null)
+                {
+                    BeforeDispose(this, EventArgs.Empty);
+                }
+                Disposed(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/Snowflake.Data/Util/ISnowflakeResource.cs
+++ b/Snowflake.Data/Util/ISnowflakeResource.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Snowflake.Data.Util
+{
+    public delegate void SnowflakeResourceEventHandler(ISnowflakeResource sender, EventArgs e);
+
+    public interface ISnowflakeResource : IDisposable
+    {
+        event SnowflakeResourceEventHandler Disposed;
+
+        string ResourceID { get; }
+    }
+}

--- a/Snowflake.Data/Util/SnowflakeResourceReferences.cs
+++ b/Snowflake.Data/Util/SnowflakeResourceReferences.cs
@@ -1,0 +1,178 @@
+﻿using Snowflake.Data.Log;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Snowflake.Data.Util
+{
+    public class SnowflakeResourceReferences : IDisposable
+    {
+        private static readonly SFLogger logger = SFLoggerFactory.GetLogger<SnowflakeResourceReferences>();
+
+        private bool disposedValue;
+
+        private readonly OrderedDictionary _items = new OrderedDictionary();
+
+        public int Count
+        {
+            get
+            {
+                lock (_items)
+                {
+                    return _items.Count;
+                }
+            }
+        }
+
+        public string Name { get; }
+
+        public bool IsDisposed { get => this.disposedValue; }
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                lock (_items)
+                {
+                    return this._items.Keys.Cast<string>().ToList();
+                }
+            }
+        }
+
+        public SnowflakeResourceReferences()
+        {
+            Name = "global-" + Guid.NewGuid().ToString();
+        }
+
+        public SnowflakeResourceReferences(string name)
+        {
+            Name = name;
+        }
+
+        private void Trace(string message)
+        {
+#if DEBUG
+            logger.Debug(message);
+#endif
+        }
+
+        public void Add(ISnowflakeResource resource)
+        {
+            Debug.Assert(resource != null);
+
+            disposedValue = false;
+            var resourceRef = new WeakReference<ISnowflakeResource>(resource);
+            lock (_items)
+            {
+                _items.Add(resource.ResourceID, resourceRef);
+                resource.Disposed += this.OnResourceDisposed;
+                Trace($"Added. name={Name} size={Count}");
+            }
+        }
+
+        public void Remove(ISnowflakeResource resource)
+        {
+            Debug.Assert(resource != null);
+
+            lock (_items)
+            {
+                this.Remove(resource.ResourceID);
+            }
+        }
+
+        private void Remove(string id)
+        {
+            Debug.Assert(id != null);
+
+            lock (_items)
+            {
+                _items.Remove(id);
+                Trace($"Removed. name={Name}, size={Count}");
+            }
+        }
+
+        public bool TryGetValue<T>(string id, out T value) where T : class
+        {
+            Debug.Assert(id != null);
+
+            WeakReference<ISnowflakeResource> itemRef;
+            lock (_items)
+            {
+                if (!_items.Contains(id))
+                {
+                    value = null;
+                    return false;
+                }
+                itemRef = _items[id] as WeakReference<ISnowflakeResource>;
+            }
+
+            if (!itemRef.TryGetTarget(out var o))
+            {
+                value = null;
+                return false;
+            }
+
+            value = (T)o;
+            return true;
+        }
+
+        public void OnResourceDisposed(ISnowflakeResource resource, EventArgs e)
+        {
+            this.Remove(resource);
+        }
+
+        /// <summary>
+        /// Dispose all resources. If empty, do nothing.
+        /// </summary>
+        public void DisposeAll()
+        {
+            lock (_items)
+            {
+                Stack<string> keyStack = new Stack<string>(this.Keys);
+                while (keyStack.Any())
+                {
+                    var key = keyStack.Pop();
+                    if (this.TryGetValue<ISnowflakeResource>(key, out var resource))
+                    {
+                        Trace($"try dispose. name={Name}, resource={resource.ResourceID}");
+                        resource.Dispose();
+                    }
+                }
+                disposedValue = true;
+            }
+        }
+
+        public bool DisposeAllSilently()
+        {
+            try
+            {
+                DisposeAll();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Warn($"An error occurred during dispose, but the exception was suppressed. name={Name}", ex);
+                return false;
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    DisposeAllSilently();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
If Close or Dispose is called for a Connection with an uncomplete transaction and this Connection is reused from the ConnectionPool, SQL commands will be executed in the old transaction scope. 
Uncompleted transaction should be rolled back before Close. In addition, if there is any chance of a transaction surviving, it should not be added to the Pool. 
In other cases, an explicit BEGIN may be unknowingly returned to the pool, so connections should be checked before they are reused.