### PR TITLE
Bug fix for 401 error with empty session token

### DIFF
--- a/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
+++ b/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
@@ -27,7 +27,8 @@ namespace Snowflake.Data.Tests.Mock
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message,
                                                               TimeSpan restTimeout,
-                                                              CancellationToken externalCancellationToken)
+                                                              CancellationToken externalCancellationToken,
+                                                              string sid = "")
         {
             // Override the http timeout and set to 1ms to force all http request to timeout and retry
             message.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY] = TimeSpan.FromMilliseconds(1);

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -104,6 +104,7 @@ namespace Snowflake.Data.Client
                         }
                         else
                         {
+                            logger.Debug($"reuse pooled connection with sid {conn.SfSession.sessionId}");
                             return conn;
                         }
                     }
@@ -138,6 +139,7 @@ namespace Snowflake.Data.Client
                 {
                     conn._poolTimeout = timeNow + timeout;
                 }
+                logger.Debug($"pool connection with sid {conn.SfSession.sessionId}");
                 connectionPool.Add(conn);
                 return true;
             }

--- a/Snowflake.Data/Core/RestRequest.cs
+++ b/Snowflake.Data/Core/RestRequest.cs
@@ -15,6 +15,7 @@ namespace Snowflake.Data.Core
     {
         HttpRequestMessage ToRequestMessage(HttpMethod method);
         TimeSpan GetRestTimeout();
+        string getSid();
     }
 
     /// <summary>
@@ -35,6 +36,8 @@ namespace Snowflake.Data.Core
         /// Timeout of the overall rest request
         /// </summary>
         internal TimeSpan RestTimeout { get; set; }
+
+        internal String sid { get; set; }
 
         /// <summary>
         /// Timeout for every single HTTP request
@@ -57,6 +60,11 @@ namespace Snowflake.Data.Core
         TimeSpan IRestRequest.GetRestTimeout()
         {
             return RestTimeout;
+        }
+
+        string IRestRequest.getSid()
+        {
+            return sid;
         }
     }
 

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -161,12 +161,13 @@ namespace Snowflake.Data.Core
                                                           CancellationToken externalCancellationToken)
         {
             HttpRequestMessage message = request.ToRequestMessage(method);
-            return await SendAsync(message, request.GetRestTimeout(), externalCancellationToken).ConfigureAwait(false);
+            return await SendAsync(message, request.GetRestTimeout(), externalCancellationToken, request.getSid()).ConfigureAwait(false);
         }
 
         protected virtual async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message,
                                                               TimeSpan restTimeout,
-                                                              CancellationToken externalCancellationToken)
+                                                              CancellationToken externalCancellationToken,
+                                                              string sid="")
         {
             // merge multiple cancellation token
             using (CancellationTokenSource restRequestTimeout = new CancellationTokenSource(restTimeout))
@@ -177,11 +178,19 @@ namespace Snowflake.Data.Core
                     HttpResponseMessage response = null;
                     try
                     {
-                        logger.Debug($"Executing: {message.Method} {message.RequestUri} HTTP/{message.Version}");
+                        logger.Debug($"Executing: {sid} {message.Method} {message.RequestUri} HTTP/{message.Version}");
 
                         response = await _HttpClient
                             .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token)
                             .ConfigureAwait(false);
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            logger.Debug($"Failed Response: {sid} {message.Method} {message.RequestUri} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
+                        }
+                        else
+                        {
+                            logger.Debug($"Succeeded Response: {sid} {message.Method} {message.RequestUri}");
+                        }
                         response.EnsureSuccessStatusCode();
 
                         return response;

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -153,7 +153,8 @@ namespace Snowflake.Data.Core
                         // s3 download request timeout to one hour
                         RestTimeout = TimeSpan.FromHours(1),
                         HttpTimeout = Timeout.InfiniteTimeSpan, // Disable timeout for each request
-                        chunkHeaders = downloadContext.chunkHeaders
+                        chunkHeaders = downloadContext.chunkHeaders,
+                        sid = ResultSet.sfStatement.SfSession.sessionId
                     };
 
                 using (var httpResponse = await _RestRequester.GetAsync(downloadRequest, downloadContext.cancellationToken)

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -268,7 +268,8 @@ namespace Snowflake.Data.Core
             SFRestRequest closeSessionRequest = new SFRestRequest
             {
                 Url = BuildUri(RestPath.SF_SESSION_PATH, queryParams),
-                authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken)
+                authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken),
+                sid = sessionId
             };
 
             logger.Debug($"Send closeSessionRequest");
@@ -299,7 +300,8 @@ namespace Snowflake.Data.Core
             SFRestRequest closeSessionRequest = new SFRestRequest()
             {
                 Url = BuildUri(RestPath.SF_SESSION_PATH, queryParams),
-                authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken)
+                authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, sessionToken),
+                sid = sessionId
             };
 
             logger.Debug($"Send async closeSessionRequest");

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -138,7 +138,8 @@ namespace Snowflake.Data.Core
                 jsonBody = postBody,
                 HttpTimeout = Timeout.InfiniteTimeSpan,
                 RestTimeout = Timeout.InfiniteTimeSpan,
-                isPutGet = isPutGetQuery
+                isPutGet = isPutGetQuery,
+                sid = SfSession.sessionId
             };
         }
 
@@ -150,7 +151,8 @@ namespace Snowflake.Data.Core
                 Url = uri,
                 authorizationToken = String.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, SfSession.sessionToken),
                 HttpTimeout = Timeout.InfiniteTimeSpan,
-                RestTimeout = Timeout.InfiniteTimeSpan
+                RestTimeout = Timeout.InfiniteTimeSpan,
+                sid = SfSession.sessionId
             };
         }
 
@@ -435,7 +437,8 @@ namespace Snowflake.Data.Core
                 {
                     Url = uri,
                     authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, SfSession.sessionToken),
-                    jsonBody = postBody
+                    jsonBody = postBody,
+                    sid = SfSession.sessionId
                 };
             }
         }


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/362

The root cause was that when OpenAsync() not finish the login process the application close the connection already. In such case the driver pool the invalid connection (session is empty) without any validation, and when it get reused by other connection, the query request failed with 401 error because the session token is empty.

Fix it by adding check of whether the session token is empty before pooling the connection.
Also added logging for session id to get better tracking of the activity for each session in case of using multiple connections in parallel.