### PR TITLE
Do not log proxy credentials

### DIFF
--- a/Snowflake.Data.Tests/SecretDetectorTest.cs
+++ b/Snowflake.Data.Tests/SecretDetectorTest.cs
@@ -205,7 +205,10 @@ namespace Snowflake.Data.Tests
         public void TestPassword()
         {
             // password
-            BasicMasking(@"password:aaaaaaaa", @"password:****");                    
+            BasicMasking(@"password:aaaaaaaa", @"password:****");
+
+            // proxypassword
+            BasicMasking(@"proxypassword:aaaaaaaa", @"proxypassword:****");
 
             // pwd
             BasicMasking(@"pwd:aaaaaaaa", @"pwd:****");

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Core
             string name = config.ConfKey;
             if (!_HttpClients.ContainsKey(name))
             {
-                logger.Debug($"Http client for {name} not registered. Adding.");
+                logger.Debug("Http client not registered. Adding.");
 
                 var httpClient = new HttpClient(
                     new RetryHandler(setupCustomHttpHandler(config), config.DisableRetry, config.ForceRetryOn404))

--- a/Snowflake.Data/Core/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/SFSessionProperty.cs
@@ -144,7 +144,7 @@ namespace Snowflake.Data.Core
             }
             catch (ArgumentException e)
             {
-                logger.Warn($"ConnectionString: {connectionString}", e);
+                logger.Warn("Invalid connectionString", e);
                 throw new SnowflakeDbException(e,
                                 SFError.INVALID_CONNECTION_STRING,
                                 e.Message);

--- a/Snowflake.Data/Logger/SecretDetector.cs
+++ b/Snowflake.Data/Logger/SecretDetector.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Log
         private static readonly string PRIVATE_KEY_PATTERN = @"-----BEGIN PRIVATE KEY-----\n([a-z0-9/+=\n]{32,})\n-----END PRIVATE KEY-----";
         private static readonly string PRIVATE_KEY_DATA_PATTERN = @"""privateKeyData"": ""([a-z0-9/+=\n]{10,})""";
         private static readonly string CONNECTION_TOKEN_PATTERN = @"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})";
-        private static readonly string PASSWORD_PATTERN = @"(password|passcode|pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})";
+        private static readonly string PASSWORD_PATTERN = @"(password|passcode|pwd|proxypassword)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})";
 
         private static string MaskAWSKeys(string text)
         {


### PR DESCRIPTION
Bug fix for issue: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/400

Went through source code and removed all logging of proxy password or entire connection string. 
Added proxypassword to SecretDetector as well to prevent it to be logged in the future, but that would only work in case it's logged with "proxypassword" keyword.