### PR TITLE
Bug fix for "Session no longer exists" issue with connection pooling

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -15,6 +15,7 @@ namespace Snowflake.Data.Tests
     using System.Diagnostics;
     using Snowflake.Data.Tests.Mock;
     using System.Runtime.InteropServices;
+    using System.Data.Common;
 
     [TestFixture]
     class SFConnectionPoolT : SFBaseTest
@@ -22,10 +23,94 @@ namespace Snowflake.Data.Tests
         private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionPoolT>();
 
         [Test]
-        [Ignore("Disable test case to prevent the static variable changed at the same time.")]
+        [Ignore("dummy test case for showing test progress.")]
         public void ConnectionPoolTDone()
         {
             // Do nothing;
+        }
+
+        [Test]
+        // test connection pooling with concurrent connection
+        public void TestConcurrentConnectionPooling()
+        {
+            // add test case name in connection string to make in unique for each test case
+            string connStr = ConnectionString + ";application=TestConcurrentConnectionPooling";
+            ConcurrentPoolingHelper(connStr, true);
+        }
+
+        [Test]
+        // test connection pooling with concurrent connection and no close
+        // call for connection. Connection is closed when Dispose() is called
+        // by framework.
+        public void TestConcurrentConnectionPoolingDispose()
+        {
+            // add test case name in connection string to make in unique for each test case
+            string connStr = ConnectionString + ";application=TestConcurrentConnectionPoolingNoClose";
+            ConcurrentPoolingHelper(connStr, false);
+        }
+
+        static void ConcurrentPoolingHelper(string connectionString, bool closeConnection)
+        {
+            // thread number a bit larger than pool size so some connections
+            // would fail on pooling while some connections could success
+            const int threadNum = 12;
+            // set short pooling timeout to cover the case that connection expired
+            const int poolTimeout = 3;
+
+            // reset to default settings in case it changed by other test cases
+            SnowflakeDbConnectionPool.SetPooling(true);
+            SnowflakeDbConnectionPool.SetMaxPoolSize(10);
+            SnowflakeDbConnectionPool.ClearAllPools();
+            SnowflakeDbConnectionPool.SetTimeout(poolTimeout);
+
+            var threads = new Task[threadNum];
+            for (int i = 0; i < threadNum; i++)
+            {
+                threads[i] = Task.Factory.StartNew(() =>
+                {
+                    QueryExecutionThread(connectionString, closeConnection);
+                });
+            }
+            Task.WaitAll(threads);
+        }
+
+        // thead to execute query with new connection in a loop
+        static void QueryExecutionThread(string connectionString, bool closeConnection)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (DbConnection conn = new SnowflakeDbConnection(connectionString))
+                {
+                    conn.Open();
+                    using (DbCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "select 1, 2, 3";
+                        try
+                        {
+                            using (var reader = cmd.ExecuteReader())
+                            {
+                                while (reader.Read())
+                                {
+                                    for (int j = 0; j < reader.FieldCount; j++)
+                                    {
+                                        // Process each column as appropriate
+                                        object obj = reader.GetFieldValue<object>(j);
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Assert.Fail("Caught unexpected exception: " + e);
+                        }
+                    }
+
+                    if (closeConnection)
+                    {
+                        conn.Close();
+                    }
+                };
+            }
         }
 
         [Test]
@@ -402,6 +487,107 @@ namespace Snowflake.Data.Tests
                     // fail the test case if anything wrong.
                     Assert.Fail();
                 }
+            }
+        }
+
+        [Test]
+        // test connection pooling with concurrent connection using async calls
+        public void TestConcurrentConnectionPoolingAsync()
+        {
+            // add test case name in connection string to make in unique for each test case
+            string connStr = ConnectionString + ";application=TestConcurrentConnectionPoolingAsync";
+            ConcurrentPoolingAsyncHelper(connStr, true);
+        }
+
+        [Test]
+        // test connection pooling with concurrent connection and using async calls no close
+        // call for connection. Connection is closed when Dispose() is called
+        // by framework.
+        public void TestConcurrentConnectionPoolingDisposeAsync()
+        {
+            // add test case name in connection string to make in unique for each test case
+            string connStr = ConnectionString + ";application=TestConcurrentConnectionPoolingDisposeAsync";
+            ConcurrentPoolingAsyncHelper(connStr, false);
+        }
+
+        static void ConcurrentPoolingAsyncHelper(string connectionString, bool closeConnection)
+        {
+            // task number a bit larger than pool size so some connections
+            // would fail on pooling while some connections could success
+            const int taskNum = 12;
+            // set short pooling timeout to cover the case that connection expired
+            const int poolTimeout = 3;
+
+            // reset to default settings in case it changed by other test cases
+            SnowflakeDbConnectionPool.SetPooling(true);
+            SnowflakeDbConnectionPool.SetMaxPoolSize(10);
+            SnowflakeDbConnectionPool.ClearAllPools();
+            SnowflakeDbConnectionPool.SetTimeout(poolTimeout);
+
+            var tasks = new Task[taskNum + 1];
+            for (int i = 0; i < taskNum; i++)
+            {
+                tasks[i] = QueryExecutionTaskAsync(connectionString, closeConnection);
+            }
+            // cover the case of invalid sessions to ensure that won't
+            // break connection pooling
+            tasks[taskNum] = InvalidConnectionTaskAsync(connectionString);
+            Task.WaitAll(tasks);
+        }
+
+        // task to execute query with new connection in a loop
+        static async Task QueryExecutionTaskAsync(string connectionString, bool closeConnection)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (var conn = new SnowflakeDbConnection(connectionString))
+                {
+                    await conn.OpenAsync();
+                    using (DbCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "select 1, 2, 3";
+                        try
+                        {
+                            using (DbDataReader reader = await cmd.ExecuteReaderAsync())
+                            {
+                                while (await reader.ReadAsync())
+                                {
+                                    for (int j = 0; j < reader.FieldCount; j++)
+                                    {
+                                        // Process each column as appropriate
+                                        object obj = await reader.GetFieldValueAsync<object>(j);
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Assert.Fail("Caught unexpected exception: " + e);
+                        }
+                    }
+
+                    if (closeConnection)
+                    {
+                        await conn.CloseAsync(new CancellationTokenSource().Token);
+                    }
+                };
+            }
+        }
+
+        // task to generate invalid(not finish open) connections in a loop
+        static async Task InvalidConnectionTaskAsync(string connectionString)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (var conn = new SnowflakeDbConnection(connectionString))
+                {
+                    // intentially not using await so the connection
+                    // will be disposed with invalid underlying session
+                    conn.OpenAsync();
+                };
+                // wait 100ms each time so the invalid sessions are generated
+                // roughly at the same speed as connections for query tasks
+                await Task.Delay(100);
             }
         }
     }

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -72,6 +72,8 @@ namespace Snowflake.Data.Tests
                 });
             }
             Task.WaitAll(threads);
+            // set pooling timeout back to default to avoid impact on other test cases
+            SnowflakeDbConnectionPool.SetTimeout(3600);
         }
 
         // thead to execute query with new connection in a loop
@@ -533,6 +535,9 @@ namespace Snowflake.Data.Tests
             // break connection pooling
             tasks[taskNum] = InvalidConnectionTaskAsync(connectionString);
             Task.WaitAll(tasks);
+
+            // set pooling timeout back to default to avoid impact on other test cases
+            SnowflakeDbConnectionPool.SetTimeout(3600);
         }
 
         // task to execute query with new connection in a loop

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -219,7 +219,10 @@ namespace Snowflake.Data.Tests
             conn3.Open();
             conn3.Close();
 
-            Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
+            // The pooling timeout should apply to all connections being pooled,
+            // not just the connections created after the new setting,
+            // so expected result should be 0
+            Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             SnowflakeDbConnectionPool.SetPooling(false);
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -151,7 +151,7 @@ namespace Snowflake.Data.Client
                                 {
                                     // Exception from SfSession.CloseAsync
                                     logger.Error("Error closing the session", previousTask.Exception);
-                                    taskCompletionSource.SetException(previousTask.Exception.InnerException);
+                                    taskCompletionSource.SetException(previousTask.Exception);
                                 }
                                 else if (previousTask.IsCanceled)
                                 {

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -24,14 +24,15 @@ namespace Snowflake.Data.Client
 
         internal int _connectionTimeout;
 
-        internal long _poolTimeout = 0;
-
         private bool disposed = false;
-
-        private bool pooled = false;
 
         private static Mutex _arraybindingMutex = new Mutex();
 
+        // TBD this doesn't make sense to have a static flag while reset it
+        // in each instance.
+        // Likely this should be a non-static one and the Mutex as well (if
+        // it's needed) since the stage is created per session
+        // Will fix that in a separated PR though as it's a different issue
         private static Boolean _isArrayBindStageCreated;
 
         public SnowflakeDbConnection()
@@ -41,17 +42,6 @@ namespace Snowflake.Data.Client
                 int.Parse(SFSessionProperty.CONNECTION_TIMEOUT.GetAttribute<SFSessionPropertyAttr>().
                     defaultValue);
             _isArrayBindStageCreated = false;
-        }
-
-        private void copy(SnowflakeDbConnection conn)
-        {
-            this.logger = conn.logger;
-            this.SfSession = conn.SfSession;
-            this._connectionState = conn._connectionState;
-            this._connectionTimeout = conn._connectionTimeout;
-            this.disposed = conn.disposed;
-            this.ConnectionString = conn.ConnectionString;
-            this.Password = conn.Password;
         }
 
         public SnowflakeDbConnection(string connectionString) : this()
@@ -117,56 +107,20 @@ namespace Snowflake.Data.Client
         {
             logger.Debug("Close Connection.");
             if ((_connectionState != ConnectionState.Closed) &&
-                !(String.IsNullOrEmpty(SfSession.sessionToken)))
+                (SfSession != null))
             {
-                pooled = SnowflakeDbConnectionPool.addConnection(this);
-                _connectionState = ConnectionState.Closed;
-            }
-
-            if(!pooled)
-            {
-                PostClose();
-            }
-        }
-
-        internal void PostClose()
-        {
-            if (SfSession != null)
-            {
-                SfSession.close();
-            }
-        }
-
-        internal void PostCloseAsync(TaskCompletionSource<object> task, CancellationToken cancellationToken)
-        {
-            if (SfSession != null)
-            {
-                SfSession.CloseAsync(cancellationToken).ContinueWith(
-                previousTask =>
+                if (SnowflakeDbConnectionPool.addSession(SfSession))
                 {
-                    if (previousTask.IsFaulted)
-                    {
-                        // Exception from SfSession.CloseAsync
-                        logger.Error("Error closing the session", previousTask.Exception);
-                        task.SetException(previousTask.Exception);
-                    }
-                    else if (previousTask.IsCanceled)
-                    {
-                        logger.Debug("Session close canceled");
-                        task.SetCanceled();
-                    }
-                    else
-                    {
-                        logger.Debug("Session closed successfully");
-                        _connectionState = ConnectionState.Closed;
-                        task.SetResult(null);
-                    }
-                }, cancellationToken);
+                    logger.Debug($"Session pooled: {SfSession.sessionId}");
+                }
+                else
+                {
+                    SfSession.close();
+                }
+                SfSession = null;
             }
-            else
-            {
-                task.SetResult(null);
-            }
+
+            _connectionState = ConnectionState.Closed;
         }
 
         public Task CloseAsync(CancellationToken cancellationToken)
@@ -180,19 +134,44 @@ namespace Snowflake.Data.Client
             }
             else
             {
-                if ((_connectionState != ConnectionState.Closed) &&
-                    !(String.IsNullOrEmpty(SfSession.sessionToken)))
+                if ((_connectionState != ConnectionState.Closed) && SfSession != null)
                 {
-                    pooled = SnowflakeDbConnectionPool.addConnection(this);
-                }
-                if (pooled)
-                {
-                    _connectionState = ConnectionState.Closed;
-                    taskCompletionSource.SetResult(null);
+                    if (SnowflakeDbConnectionPool.addSession(SfSession))
+                    {
+                        logger.Debug($"Session pooled: {SfSession.sessionId}");
+                        _connectionState = ConnectionState.Closed;
+                        taskCompletionSource.SetResult(null);
+                    }
+                    else
+                    {
+                        SfSession.CloseAsync(cancellationToken).ContinueWith(
+                            previousTask =>
+                            {
+                                if (previousTask.IsFaulted)
+                                {
+                                    // Exception from SfSession.CloseAsync
+                                    logger.Error("Error closing the session", previousTask.Exception);
+                                    taskCompletionSource.SetException(previousTask.Exception.InnerException);
+                                }
+                                else if (previousTask.IsCanceled)
+                                {
+                                    _connectionState = ConnectionState.Closed;
+                                    logger.Debug("Session close canceled");
+                                    taskCompletionSource.SetCanceled();
+                                }
+                                else
+                                {
+                                    logger.Debug("Session closed successfully");
+                                    taskCompletionSource.SetResult(null);
+                                    _connectionState = ConnectionState.Closed;
+                                }
+                            }, cancellationToken);
+                    }
                 }
                 else
                 {
-                    PostCloseAsync(taskCompletionSource, cancellationToken);
+                    logger.Debug("Session not opened. Nothing to do.");
+                    taskCompletionSource.SetResult(null);
                 }
             }
             return taskCompletionSource.Task;
@@ -206,11 +185,10 @@ namespace Snowflake.Data.Client
                 logger.Debug($"Open with a connection already opened: {_connectionState}");
                 return;
             }
-            SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString);
-            if (conn != null)
+            SfSession = SnowflakeDbConnectionPool.getSession(this.ConnectionString);
+            if (SfSession != null)
             {
-                logger.Debug($"Connection open with pooled session: {conn.SfSession.sessionId}");
-                this.copy(conn);
+                logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
             }
             else
             {
@@ -244,21 +222,20 @@ namespace Snowflake.Data.Client
 
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
+            logger.Debug("Open Connection Async.");
             if (_connectionState != ConnectionState.Closed)
             {
                 logger.Debug($"Open with a connection already opened: {_connectionState}");
                 return Task.CompletedTask;
             }
-            SnowflakeDbConnection conn = SnowflakeDbConnectionPool.getConnection(this.ConnectionString);
-            if (conn != null)
+            SfSession = SnowflakeDbConnectionPool.getSession(this.ConnectionString);
+            if (SfSession != null)
             {
-                logger.Debug($"Connection open with pooled session: {conn.SfSession.sessionId}");
-                this.copy(conn);
+                logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
                 OnSessionEstablished();
                 return Task.CompletedTask;
             }
 
-            logger.Debug("Open Connection.");
             registerConnectionCancellationCallback(cancellationToken);
             SetSession();
 
@@ -355,13 +332,9 @@ namespace Snowflake.Data.Client
                 logger.Error("Unable to close connection", ex);
             }
 
-            // only dispose the connection when it's not pooled
-            if (!pooled)
-            {
-                disposed = true;
+            disposed = true;
 
-                base.Dispose(disposing);
-            }
+            base.Dispose(disposing);
         }
 
 
@@ -376,13 +349,6 @@ namespace Snowflake.Data.Client
             {
                 externalCancellationToken.Register(() => { _connectionState = ConnectionState.Closed; });
             }
-        }
-
-        // Called by connection pooling when the connection is removed out of pool
-        // could be reused or destroyed when expire
-        internal void Unpool()
-        {
-            pooled = false;
         }
 
         ~SnowflakeDbConnection()

--- a/Snowflake.Data/Core/SFSession.cs
+++ b/Snowflake.Data/Core/SFSession.cs
@@ -59,6 +59,9 @@ namespace Snowflake.Data.Core
         private int arrayBindStageThreshold = 0;
         internal int masterValidityInSeconds = 0;
 
+        internal long startTime = 0;
+        internal string connStr = null;
+
         internal void ProcessLoginResponse(LoginResponse authnResponse)
         {
             if (authnResponse.success)
@@ -72,6 +75,7 @@ namespace Snowflake.Data.Core
                 masterValidityInSeconds = authnResponse.data.masterValidityInSeconds;
                 UpdateSessionParameterMap(authnResponse.data.nameValueParameter);
                 logger.Debug($"Session opened: {sessionId}");
+                startTime = DateTimeOffset.Now.ToUnixTimeSeconds();
             }
             else
             {
@@ -112,6 +116,7 @@ namespace Snowflake.Data.Core
         /// <param name="connectionString">A string in the form of "key1=value1;key2=value2"</param>
         internal SFSession(String connectionString, SecureString password)
         {
+            connStr = connectionString;
             properties = SFSessionProperties.parseConnectionString(connectionString, password);
 
             // If there is an "application" setting, verify that it matches the expect pattern


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/416

The root cause is the improper design of connection pooling feature. It was pooling SnowflakeDBConnection instances and making copy when it's reused from pooling, so it's always possible that the connection hold by different threads could point to the same underlying session.

In the case of issue 416 with `Session no longer exists` error, thread A calls close() to close the connection and the connection get pooled, thread B reuse the connection right after and get the connection out of the pool. Then thread A calls Dispose() on the connection and since it's not pooled, it close the session while it still being used by thread B, and that's why thread B got error of `Session no longer exists`

The error was `Authentication token has expired` in earlier versions I think that's because we made fix for other issues of connection pooling which changed the behavior but the issue still there.

Pool the underlying session instead of the connection instance itself should be able to solve all the timing issue and make the logic more simple and clear. No copy on the session instance and a session should be always either in pool or hold by one thread.

Test cases added for connection pooling with concurrent connections.