### PR TITLE
SNOW-828681: Fix exceptions in log for longer running queries

### DIFF
--- a/Snowflake.Data.Tests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/SFDbCommandIT.cs
@@ -123,7 +123,7 @@ namespace Snowflake.Data.Tests
                 conn.Open();
 
                 IDbCommand cmd = conn.CreateCommand();
-                cmd.CommandText = "select count(seq4()) from table(generator(timelimit => 60)) v order by 1";
+                cmd.CommandText = "select SYSTEM$WAIT(1, 'MINUTES')";
                 IDataReader reader = cmd.ExecuteReader();
                 // only one result is returned
                 Assert.IsTrue(reader.Read());

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -116,7 +116,11 @@ namespace Snowflake.Data.Core
                     // Enforce tls v1.2
                     SslProtocols = SslProtocols.Tls12,
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    CookieUsePolicy = CookieUsePolicy.IgnoreCookies
+                    CookieUsePolicy = CookieUsePolicy.IgnoreCookies,
+                    // Skip timeouts given by WinHttpHandler, let the HttpClient.Timeout take precedence
+                    ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan,
+                    ReceiveDataTimeout = Timeout.InfiniteTimeSpan,
+                    SendTimeout = Timeout.InfiniteTimeSpan
                 };
             }
             else


### PR DESCRIPTION
Omitting WinHttpHandler timeouts. Standard HttpClient.Timeout takes precedence.