### PR TITLE
remove winhttphandler

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -107,6 +107,7 @@ namespace Snowflake.Data.Core
         private HttpMessageHandler setupCustomHttpHandler(HttpClientConfig config)
         {
             HttpMessageHandler httpHandler;
+/*
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && SFEnvironment.ClientEnv.IsNetFramework)
             {
                 httpHandler = new WinHttpHandler()
@@ -120,6 +121,7 @@ namespace Snowflake.Data.Core
                 };
             }
             else
+*/
             {
                 httpHandler = new HttpClientHandler()
                 {
@@ -168,6 +170,7 @@ namespace Snowflake.Data.Core
                     }
                     proxy.BypassList = bypassList;
                 }
+/*
                 if (httpHandler is WinHttpHandler && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     WinHttpHandler httpHandlerWithProxy = (WinHttpHandler)httpHandler;
@@ -177,6 +180,7 @@ namespace Snowflake.Data.Core
                     return httpHandlerWithProxy;
                 }
                 else if (httpHandler is HttpClientHandler)
+*/
                 {
                     HttpClientHandler httpHandlerWithProxy = (HttpClientHandler)httpHandler;
                     httpHandlerWithProxy.Proxy = proxy;

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -125,7 +125,6 @@ namespace Snowflake.Data.Core
             {
                 httpHandler = new HttpClientHandler()
                 {
-                    // Enforce tls v1.2
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
                     UseCookies = false // Disable cookies
                 };

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -123,15 +123,29 @@ namespace Snowflake.Data.Core
             else
 */
             {
-                httpHandler = new HttpClientHandler()
+                try
                 {
-                    // Verify no certificates have been revoked
-                    CheckCertificateRevocationList = config.CrlCheckEnabled,
-                    // Enforce tls v1.2
-                    SslProtocols = SslProtocols.Tls12,
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    UseCookies = false // Disable cookies
-                };
+                    httpHandler = new HttpClientHandler()
+                    {
+                        // Verify no certificates have been revoked
+                        CheckCertificateRevocationList = config.CrlCheckEnabled,
+                        // Enforce tls v1.2
+                        SslProtocols = SslProtocols.Tls12,
+                        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                        UseCookies = false // Disable cookies
+                    };
+                }
+                // special logic for .NET framework 4.7.1 that
+                // CheckCertificateRevocationList and SslProtocols are not supported
+                catch (PlatformNotSupportedException)
+                {
+                    httpHandler = new HttpClientHandler()
+                    {
+                        // Enforce tls v1.2
+                        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                        UseCookies = false // Disable cookies
+                    };
+                }
             }
 
             // Add a proxy if necessary

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.2" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
+    <!--PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.1" /-->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.2" />
-    <!--PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.1" /-->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   


### PR DESCRIPTION
Bug fix for issue#365

The issue was introduced by using WinHttpHandler as a replacement for HttpClientHandler, which was found not a good replacement due to some unexpected behavior changes.
.e.g the root cause of issue#365 likely is the same as issue#404, that WinHttpHandler needs different time out settings.
The purpose of using WinHttpHandler is to fix an issue that when using proxy and set INSECURE_MODE=false, the connection could fail with SSL error.
Per discussion in the issue#365 that actually could be customer proxy setting issue, also using WinHttpHandler doesn't really fix the issue as it's been reported on Linux as well.

The decision here is to remove WinHttpHandler, to remove all unexpected behavior changes with it. For the proxy issue if customer raise it again we can check whether it's customer setting issue. In case we do need a fix on driver side we could find a solution that fix in on all platforms.