### PR TITLE
Bug fix for retry on chunk downloading

### DIFF
--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1600,10 +1600,10 @@ namespace Snowflake.Data.Tests
                     stopwatch.Stop();
                     int detla = 10; //in case server time slower.
 
-                    // Should timeout after 5sec + 3 retry 20 sec
-                    Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 35 * 1000 - detla);
+                    // Should timeout after 5sec
+                    Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 5 * 1000 - detla);
                     // But never more than 1 sec (max backoff) after the default timeout
-                    Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (66) * 1000);
+                    Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (6) * 1000);
 
                     Assert.AreEqual(ConnectionState.Closed, conn.State);
                     Assert.AreEqual(5, conn.ConnectionTimeout);
@@ -1635,10 +1635,10 @@ namespace Snowflake.Data.Tests
                 stopwatch.Stop();
                 int detla = 10; //in case server time slower.
 
-                // Should timeout after the default timeout (120 sec * 6 retries = 840 sec)
-                Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 840 * 1000 - detla);
+                // Should timeout after the default timeout (120 sec)
+                Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 120 * 1000 - detla);
                 // But never more than 16 sec (max backoff) after the default timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (840 + 16) * 1000);
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (120 + 16) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(120, conn.ConnectionTimeout);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -162,8 +162,8 @@ namespace Snowflake.Data.Client
                                 else
                                 {
                                     logger.Debug("Session closed successfully");
-                                    taskCompletionSource.SetResult(null);
                                     _connectionState = ConnectionState.Closed;
+                                    taskCompletionSource.SetResult(null);
                                 }
                             }, cancellationToken);
                     }

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -65,6 +65,7 @@ namespace Snowflake.Data.Core
     public sealed class HttpUtil
     {
         static internal readonly int MAX_RETRY = 6;
+        static internal readonly int MAX_BACKOFF = 16;
         private static readonly SFLogger logger = SFLoggerFactory.GetLogger<HttpUtil>();
 
         private HttpUtil() { }
@@ -295,7 +296,6 @@ namespace Snowflake.Data.Core
                 HttpResponseMessage response = null;
                 int backOffInSec = 1;
                 int totalRetryTime = 0;
-                int maxDefaultBackoff = 16;
 
                 ServicePoint p = ServicePointManager.FindServicePoint(requestMessage.RequestUri);
                 p.Expect100Continue = false; // Saves about 100 ms per request
@@ -387,8 +387,8 @@ namespace Snowflake.Data.Core
                     await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
                     totalRetryTime += backOffInSec;
                     // Set next backoff time
-                    backOffInSec = backOffInSec >= maxDefaultBackoff ?
-                            maxDefaultBackoff : backOffInSec * 2;
+                    backOffInSec = backOffInSec >= MAX_BACKOFF ?
+                            MAX_BACKOFF : backOffInSec * 2;
 
                     if ((restTimeout.TotalSeconds > 0) && (totalRetryTime + backOffInSec > restTimeout.TotalSeconds))
                     {

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -55,45 +55,11 @@ namespace Snowflake.Data.Core
 
         public async Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            bool retry = false;
-            int retryCount = 0;
-            var result = default(T);
-            
-            do
+            using (var response = await SendAsync(HttpMethod.Post, request, cancellationToken).ConfigureAwait(false))
             {
-                int backOffInSec = 1;
-                retry = false;
-                try
-                {
-                    //use it for testing only
-                    //bool forceParseError = true;
-                    //if (forceParseError)
-                    //{
-                    //    throw new Exception("json parsing error.");
-                    //}
-                    using (var response = await SendAsync(HttpMethod.Post, request, cancellationToken).ConfigureAwait(false))
-                    {
-                        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        result = JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (retryCount < HttpUtil.MAX_RETRY)
-                    {
-                        logger.Debug($"PostAsync Exception, retry="+ retryCount);
-                        retry = true;
-                        await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
-                        ++retryCount;
-                        backOffInSec = backOffInSec * 2;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-            } while (retry);
-            return result;
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
+            }
         }
 
         public T Get<T>(IRestRequest request)
@@ -104,45 +70,11 @@ namespace Snowflake.Data.Core
 
         public async Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            bool retry = false;
-            int retryCount = 0;
-            var result = default(T);
-
-            do
+            using (HttpResponseMessage response = await GetAsync(request, cancellationToken).ConfigureAwait(false))
             {
-                int backOffInSec = 1;
-                retry = false;
-                try
-                {
-                    //use it for testing only
-                    //bool forceParseError = true;
-                    //if (forceParseError)
-                    //{
-                    //    throw new Exception("json parsing error.");
-                    //}
-                    using (HttpResponseMessage response = await GetAsync(request, cancellationToken).ConfigureAwait(false))
-                    {
-                        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        result = JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (retryCount < HttpUtil.MAX_RETRY)
-                    {
-                        logger.Debug($"GetAsync Exception, retry=" + retryCount);
-                        retry = true;
-                        await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
-                        ++retryCount;
-                        backOffInSec = backOffInSec * 2;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-            } while (retry);
-            return result;
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
+            }
         }
 
         public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -14,6 +14,7 @@ namespace Snowflake.Data.Core
 {
     /// <summary>
     /// The RestRequester is responsible to send out a rest request and receive response
+    /// No retry needed here since retry is made in HttpClient.RetryHandler (HttpUtil.cs)
     /// </summary>
     internal interface IRestRequester
     {

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -161,7 +161,10 @@ namespace Snowflake.Data.Core
                 using (Stream stream = await httpResponse.Content.ReadAsStreamAsync()
                     .ConfigureAwait(continueOnCapturedContext: false))
                 {
-                    //TODO this shouldn't be required.
+                    // retry on chunk downloading since the retry logic in HttpClient.RetryHandler
+                    // doesn't cover this. The GET request could be succeeded but network error
+                    // still could happen during reading chunk data from stream and that needs
+                    // retry as well.
                     try
                     {
                         IEnumerable<string> encoding;

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -132,7 +132,8 @@ namespace Snowflake.Data.Core
         private async Task<IResultChunk> DownloadChunkAsync(DownloadContextV3 downloadContext)
         {
             //logger.Info($"Start downloading chunk #{downloadContext.chunkIndex}");
-            SFReusableChunk chunk;
+            SFReusableChunk chunk = downloadContext.chunk;
+            int backOffInSec = 1;
             bool retry = false;
             int retryCount = 0;
 
@@ -141,9 +142,7 @@ namespace Snowflake.Data.Core
 
             do
             {
-                int backOffInSec = 1;
                 retry = false;
-                chunk = downloadContext.chunk;
 
                 S3DownloadRequest downloadRequest =
                     new S3DownloadRequest()
@@ -165,10 +164,6 @@ namespace Snowflake.Data.Core
                     //TODO this shouldn't be required.
                     try
                     {
-                        if(forceParseError)
-                        {
-                            throw new Exception("json parsing error.");
-                        }
                         IEnumerable<string> encoding;
                         if (httpResponse.Content.Headers.TryGetValues("Content-Encoding", out encoding))
                         {
@@ -186,6 +181,10 @@ namespace Snowflake.Data.Core
                         {
                             await ParseStreamIntoChunk(stream, chunk);
                         }
+                        if (forceParseError)
+                        {
+                            throw new Exception("json parsing error.");
+                        }
                     }
                     catch (Exception e)
                     {
@@ -193,9 +192,22 @@ namespace Snowflake.Data.Core
                         if (retryCount < HttpUtil.MAX_RETRY)
                         {
                             retry = true;
+                            // reset the chunk before retry in case there could be garbage
+                            // data left from last attempt
+                            ExecResponseChunk chunkInfo = new ExecResponseChunk()
+                            {
+                                rowCount = chunk.RowCount,
+                                url = chunk.Url
+                            };
+                            chunk.Reset(chunkInfo, chunk.chunkIndexToDownload);
                             await Task.Delay(TimeSpan.FromSeconds(backOffInSec), downloadContext.cancellationToken).ConfigureAwait(false);
                             ++retryCount;
+                            // Set next backoff time
                             backOffInSec = backOffInSec * 2;
+                            if (backOffInSec > HttpUtil.MAX_BACKOFF)
+                            {
+                                backOffInSec = HttpUtil.MAX_BACKOFF;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Revise the fix for issue#52 to fix bugs there
https://github.com/snowflakedb/snowflake-connector-net/pull/610
https://github.com/snowflakedb/snowflake-connector-net/pull/619
https://github.com/snowflakedb/snowflake-connector-net/pull/631

- rollback the retry added for request sending (in requester.cs) since we have retry on request sending in HttpClient.RetryHandler already. Extra retry here is unnecessary
- Reset chunk before retry on chunk downloading in case there could be garbage data left from previous attempt which could fail the chunk parsing
- Fix the bug that backoff time is not set correctly