### PR TITLE
SNOW-845774 - Add Jenkins user to allow list for cla assistant check

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -24,6 +24,6 @@ jobs:
           path-to-signatures: 'signatures/version1.json'
           path-to-document: 'https://github.com/snowflakedb/CLA/blob/main/README.md'
           branch: 'main'
-          allowlist: 'dependabot[bot],github-actions'
+          allowlist: 'dependabot[bot],github-actions,Jenkins User,_jenkins'
           remote-organization-name: 'snowflakedb'
           remote-repository-name: 'cla-db'


### PR DESCRIPTION
CLA Assistant check has been failing for release branches. The failure is due the jenkins user used to create the branch and do the commit is not in the allow list in that check.
The fix is to add it.