### PR TITLE
SNOW-828572 Set UseProxy on HttpClientHandler

### DIFF
--- a/Snowflake.Data.Tests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/HttpUtilTest.cs
@@ -47,7 +47,7 @@ namespace Snowflake.Data.Tests
                 true,
                 "snowflake.com",
                 "123",
-                "Bartek",
+                "testUser",
                 "proxyPassword",
                 "localhost", 
                 false,

--- a/Snowflake.Data.Tests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/HttpUtilTest.cs
@@ -2,6 +2,8 @@
  * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
  */
 
+using System.Net.Http;
+
 namespace Snowflake.Data.Tests
 {
     using NUnit.Framework;
@@ -35,6 +37,52 @@ namespace Snowflake.Data.Tests
             bool actualIsRetryable = HttpUtil.isRetryableHTTPCode((int)response.StatusCode, forceRetryOn404);
 
             Assert.AreEqual(expectedIsRetryable, actualIsRetryable);
+        }
+
+        [Test]
+        public void ShouldCreateHttpClientHandlerWithProxy()
+        {
+            // given
+            var config = new HttpClientConfig(
+                true,
+                "snowflake.com",
+                "123",
+                "Bartek",
+                "proxyPassword",
+                "localhost", 
+                false,
+                false
+            );
+            
+            // when
+            var handler = (HttpClientHandler) HttpUtil.Instance.SetupCustomHttpHandler(config);
+            
+            // then
+            Assert.IsTrue(handler.UseProxy);
+            Assert.IsNotNull(handler.Proxy);
+        }
+
+        [Test]
+        public void ShouldCreateHttpClientHandlerWithoutProxy()
+        {
+            // given
+            var config = new HttpClientConfig(
+                true,
+                null,
+                null,
+                null,
+                null,
+                null, 
+                false,
+                false
+            );
+            
+            // when
+            var handler = (HttpClientHandler) HttpUtil.Instance.SetupCustomHttpHandler(config);
+            
+            // then
+            Assert.IsFalse(handler.UseProxy);
+            Assert.IsNull(handler.Proxy);
         }
     }
 }

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -93,7 +93,7 @@ namespace Snowflake.Data.Core
                 logger.Debug("Http client not registered. Adding.");
 
                 var httpClient = new HttpClient(
-                    new RetryHandler(setupCustomHttpHandler(config), config.DisableRetry, config.ForceRetryOn404))
+                    new RetryHandler(SetupCustomHttpHandler(config), config.DisableRetry, config.ForceRetryOn404))
                 {
                     Timeout = Timeout.InfiniteTimeSpan
                 };
@@ -105,7 +105,7 @@ namespace Snowflake.Data.Core
             return _HttpClients[name];
         }
 
-        private HttpMessageHandler setupCustomHttpHandler(HttpClientConfig config)
+        internal HttpMessageHandler SetupCustomHttpHandler(HttpClientConfig config)
         {
             HttpMessageHandler httpHandler;
             try
@@ -117,7 +117,8 @@ namespace Snowflake.Data.Core
                     // Enforce tls v1.2
                     SslProtocols = SslProtocols.Tls12,
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    UseCookies = false // Disable cookies
+                    UseCookies = false, // Disable cookies
+                    UseProxy = false
                 };
             }
             // special logic for .NET framework 4.7.1 that
@@ -127,7 +128,8 @@ namespace Snowflake.Data.Core
                 httpHandler = new HttpClientHandler()
                 {
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    UseCookies = false // Disable cookies
+                    UseCookies = false, // Disable cookies
+                    UseProxy = false
                 };
             }
 
@@ -169,6 +171,7 @@ namespace Snowflake.Data.Core
                 }
 
                 HttpClientHandler httpHandlerWithProxy = (HttpClientHandler)httpHandler;
+                httpHandlerWithProxy.UseProxy = true;
                 httpHandlerWithProxy.Proxy = proxy;
                 return httpHandlerWithProxy;
             }


### PR DESCRIPTION
It is a bug fix that resolves the issue: https://github.com/snowflakedb/snowflake-connector-net/issues/653
The fix is about setting properly UseProxy attribute of HttpClientConfig to indicate whether a proxy is being used.