### PR TITLE
SNOW-835635 rollback session on connection pooled

### DIFF
--- a/Snowflake.Data.Tests/App.config
+++ b/Snowflake.Data.Tests/App.config
@@ -21,7 +21,7 @@ Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
       </layout>
       <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
         <layout type="log4net.Layout.PatternLayout">
-          <conversionPattern value="%date [%thread] [%-5level] [%method:%line] - %message%newline" />
+          <conversionPattern value="%date [%thread] [%-5level] [%ClassName:%line] - %message%newline" />
         </layout>
       </appender>
     </appender>
@@ -29,6 +29,9 @@ Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
     <root>
       <level value="ALL" />
       <appender-ref ref="RollingFileAppender" />
+    </root>    
+    <root>
+      <level value="WARN" />
       <appender-ref ref="ConsoleAppender" />
     </root>
   </log4net>

--- a/Snowflake.Data.Tests/App.config
+++ b/Snowflake.Data.Tests/App.config
@@ -8,7 +8,7 @@ Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
   </configSections>
   
   <log4net>
-    <appender name="MyRollingFileAppender" type="log4net.Appender.RollingFileAppender">
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
       <file type="log4net.Util.PatternString" value="test_%property{framework}.log" />
       <appendToFile value="true"/>
       <rollingStyle value="Size" />
@@ -19,11 +19,17 @@ Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
         <!-- <header value="[DateTime]  [Thread]  [Level]  [ClassName] Message&#13;&#10;" /> -->
         <conversionPattern value="[%date] [%t] [%-5level] [%logger] %message%newline" />
       </layout>
+      <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+        <layout type="log4net.Layout.PatternLayout">
+          <conversionPattern value="%date [%thread] [%-5level] [%method:%line] - %message%newline" />
+        </layout>
+      </appender>
     </appender>
 
     <root>
       <level value="ALL" />
-      <appender-ref ref="MyRollingFileAppender" />
+      <appender-ref ref="RollingFileAppender" />
+      <appender-ref ref="ConsoleAppender" />
     </root>
   </log4net>
 

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1800,6 +1800,27 @@ namespace Snowflake.Data.Tests
                 Assert.AreEqual(conn.State, ConnectionState.Open);
             }
         }
+
+        [Test]
+        public void TestExplicitTransactionOperationsTracked()
+        {
+            using (var conn = new SnowflakeDbConnection(ConnectionString))
+            {
+                conn.Open();
+                Assert.AreEqual(false, conn.HasActiveTransaction());
+
+                var trans = conn.BeginTransaction();
+                Assert.AreEqual(true, conn.HasActiveTransaction());
+                trans.Rollback();
+                Assert.AreEqual(false, conn.HasActiveTransaction());
+
+                conn.BeginTransaction().Rollback();
+                Assert.AreEqual(false, conn.HasActiveTransaction());
+                
+                conn.BeginTransaction().Commit();
+                Assert.AreEqual(false, conn.HasActiveTransaction());
+            }
+        }
     }
 }
 

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1807,18 +1807,18 @@ namespace Snowflake.Data.Tests
             using (var conn = new SnowflakeDbConnection(ConnectionString))
             {
                 conn.Open();
-                Assert.AreEqual(false, conn.HasActiveTransaction());
+                Assert.AreEqual(false, conn.HasActiveExplicitTransaction());
 
                 var trans = conn.BeginTransaction();
-                Assert.AreEqual(true, conn.HasActiveTransaction());
+                Assert.AreEqual(true, conn.HasActiveExplicitTransaction());
                 trans.Rollback();
-                Assert.AreEqual(false, conn.HasActiveTransaction());
+                Assert.AreEqual(false, conn.HasActiveExplicitTransaction());
 
                 conn.BeginTransaction().Rollback();
-                Assert.AreEqual(false, conn.HasActiveTransaction());
+                Assert.AreEqual(false, conn.HasActiveExplicitTransaction());
                 
                 conn.BeginTransaction().Commit();
-                Assert.AreEqual(false, conn.HasActiveTransaction());
+                Assert.AreEqual(false, conn.HasActiveExplicitTransaction());
             }
         }
     }

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -551,7 +551,7 @@ namespace Snowflake.Data.Tests
                 connection.Open();
                 firstOpenedSessionId = connection.SfSession.sessionId;
                 connection.BeginTransaction();
-                Assert.AreEqual(true, connection.HasActiveTransaction());
+                Assert.AreEqual(true, connection.HasActiveExplicitTransaction());
                 Assert.Throws<SnowflakeDbException>(() =>
                 {
                     using (var command = connection.CreateCommand())
@@ -568,7 +568,7 @@ namespace Snowflake.Data.Tests
                 connectionWithSessionReused.Open();
                 
                 Assert.AreEqual(firstOpenedSessionId, connectionWithSessionReused.SfSession.sessionId);
-                Assert.AreEqual(false, connectionWithSessionReused.HasActiveTransaction());
+                Assert.AreEqual(false, connectionWithSessionReused.HasActiveExplicitTransaction());
                 using (var cmd = connectionWithSessionReused.CreateCommand())
                 {
                     cmd.CommandText = "SELECT CURRENT_TRANSACTION()";
@@ -591,7 +591,7 @@ namespace Snowflake.Data.Tests
                 {
                     command.CommandText = "BEGIN"; // in general can be put as a part of a multi statement call and mixed with commit as well 
                     command.ExecuteNonQuery();
-                    Assert.AreEqual(false, connection.HasActiveTransaction()); 
+                    Assert.AreEqual(false, connection.HasActiveExplicitTransaction()); 
                 }
             }
         }
@@ -609,7 +609,7 @@ namespace Snowflake.Data.Tests
                 connection1.Open();
                 Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize(), "Connection session is added to the pool after close connection");
                 connection1.BeginTransaction();
-                Assert.AreEqual(true, connection1.HasActiveTransaction());
+                Assert.AreEqual(true, connection1.HasActiveExplicitTransaction());
                 using (var command = connection1.CreateCommand())
                 {
                     firstOpenedSessionId = connection1.SfSession.sessionId;
@@ -624,7 +624,7 @@ namespace Snowflake.Data.Tests
                 connection2.ConnectionString = ConnectionString;
                 connection2.Open();
                 Assert.AreEqual(0, SnowflakeDbConnectionPool.GetCurrentPoolSize(), "Connection session should be now removed from the pool");
-                Assert.AreEqual(false, connection2.HasActiveTransaction());
+                Assert.AreEqual(false, connection2.HasActiveExplicitTransaction());
                 using (var command = connection2.CreateCommand())
                 {
                     Assert.AreEqual(firstOpenedSessionId, connection2.SfSession.sessionId);
@@ -653,7 +653,7 @@ namespace Snowflake.Data.Tests
                 connection.ConnectionString = ConnectionString;
                 connection.Open();
                 connection.BeginTransaction();
-                Assert.AreEqual(true, connection.HasActiveTransaction());
+                Assert.AreEqual(true, connection.HasActiveExplicitTransaction());
                 // no Rollback or Commit; during internal Rollback while closing a connection a mocked exception will be thrown
             }
             

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -433,7 +433,7 @@ namespace Snowflake.Data.Tests
     class SFConnectionPoolITAsync : SFBaseTestAsync
     {
         private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionPoolITAsync>();
-        private static readonly PoolConfig previousPoolConfig = new();
+        private static readonly PoolConfig previousPoolConfig = new PoolConfig();
 
         [SetUp]
         public void BeforeTest()
@@ -734,13 +734,13 @@ namespace Snowflake.Data.Tests
         
         private class TestSnowflakeDbFactory : DbProviderFactory 
         {
-            public override SnowflakeDbCommand CreateCommand()
+            public override DbCommand CreateCommand()
             {
                 var commandThrowingExceptionOnlyForRollback = new Mock<SnowflakeDbCommand>().As<IDbCommand>();
                 commandThrowingExceptionOnlyForRollback.CallBase = true;
                 commandThrowingExceptionOnlyForRollback.SetupSet(it => it.CommandText = "ROLLBACK")
                     .Throws(new SnowflakeDbException(SFError.INTERNAL_ERROR, "Unexpected failure on transaction rollback when connection is returned to the pool with pending transaction"));
-                return (SnowflakeDbCommand)commandThrowingExceptionOnlyForRollback.Object;
+                return (DbCommand)commandThrowingExceptionOnlyForRollback.Object;
             }
         }
     }

--- a/Snowflake.Data.Tests/SFConnectionPoolT.cs
+++ b/Snowflake.Data.Tests/SFConnectionPoolT.cs
@@ -571,7 +571,6 @@ namespace Snowflake.Data.Tests
                 {
                     cmd.CommandText = "SELECT CURRENT_TRANSACTION()";
                     Assert.AreEqual(DBNull.Value, cmd.ExecuteScalar());
-                    Assert.AreEqual(false, connectionWithSessionReused.HasActiveTransaction());
                 }
             } 
             
@@ -594,7 +593,8 @@ namespace Snowflake.Data.Tests
                     firstOpenedSessionId = connection1.SfSession.sessionId;
                     command.CommandText = "BEGIN TRANSACTION";
                     command.ExecuteNonQuery();
-                    Assert.AreEqual(true, connection1.HasActiveTransaction());
+                    command.CommandText = "SELECT CURRENT_TRANSACTION()";
+                    Assert.AreNotEqual(DBNull.Value, command.ExecuteScalar());
                 }
             }
             Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize(), "Connection should be returned to the pool");
@@ -608,7 +608,6 @@ namespace Snowflake.Data.Tests
                     Assert.AreEqual(firstOpenedSessionId, connection2.SfSession.sessionId);
                     command.CommandText = "SELECT CURRENT_TRANSACTION()";
                     Assert.AreEqual(DBNull.Value, command.ExecuteScalar());
-                    Assert.AreEqual(false, connection2.HasActiveTransaction());
                 }
             }
             Assert.AreEqual(1, SnowflakeDbConnectionPool.GetCurrentPoolSize(), "Connection should be returned to the pool");

--- a/Snowflake.Data.Tests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/SFDbTransactionIT.cs
@@ -156,5 +156,14 @@ namespace Snowflake.Data.Tests
 
             conn.Close();
         }
+
+        [Test]
+        public void TestThrowsExceptionWhenBeginTransactionWithoutOpen()
+        {
+            using (var conn = new SnowflakeDbConnection(ConnectionString))
+            {
+                Assert.Throws<SnowflakeDbException>(() => conn.BeginTransaction());
+            }
+        }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -129,7 +129,10 @@ namespace Snowflake.Data.Client
                 }
 
                 connection = sfc;
-                sfStatement = new SFStatement(sfc.SfSession);
+                if (sfc.SfSession != null)
+                {
+                    sfStatement = new SFStatement(sfc.SfSession);
+                }
             }
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Data.Client
 
         internal ConnectionState _connectionState;
 
-        protected virtual DbProviderFactory DbProviderFactory => new SnowflakeDbFactory();
+        protected override DbProviderFactory DbProviderFactory => new SnowflakeDbFactory();
         
         internal int _connectionTimeout;
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Data.Client
 
         internal ConnectionState _connectionState;
 
-        protected virtual DbProviderFactory? DbProviderFactory => new SnowflakeDbFactory();
+        protected virtual DbProviderFactory DbProviderFactory => new SnowflakeDbFactory();
         
         internal int _connectionTimeout;
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -106,11 +106,11 @@ namespace Snowflake.Data.Client
         public override ConnectionState State => _connectionState;
         internal SnowflakeDbTransaction ExplicitTransaction { get; set; } // tracks only explicit transaction operations
         
-        internal bool HasActiveTransaction() => ExplicitTransaction != null && ExplicitTransaction.IsActive;
+        internal bool HasActiveExplicitTransaction() => ExplicitTransaction != null && ExplicitTransaction.IsActive;
 
         private TransactionRollbackStatus TerminateTransactionForDirtyConnectionReturningToPool()
         {
-            if (!HasActiveTransaction())
+            if (!HasActiveExplicitTransaction())
                 return TransactionRollbackStatus.Success;
             try
             {

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -22,6 +22,14 @@ namespace Snowflake.Data.Client
 
         internal ConnectionState _connectionState;
 
+        private DbProviderFactory _snowflakeDbFactory = new SnowflakeDbFactory();
+
+        internal DbProviderFactory ProviderFactory
+        {
+            get => _snowflakeDbFactory;
+            set => _snowflakeDbFactory = value;
+        }
+        
         internal int _connectionTimeout;
 
         private bool disposed = false;
@@ -101,10 +109,10 @@ namespace Snowflake.Data.Client
             {
                 return DBNull.Value;
             }
-            using (IDbCommand command = CreateDbCommand())
+            using (IDbCommand command = CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_TRANSACTION()";
-                return command.ExecuteScalar(); // TODO: what if exc
+                return command.ExecuteScalar(); 
             }
         }
 
@@ -137,7 +145,7 @@ namespace Snowflake.Data.Client
 
             string alterDbCommand = $"use database {databaseName}";
 
-            using (IDbCommand cmd = this.CreateCommand())
+            using (IDbCommand cmd = CreateCommand())
             {
                 cmd.CommandText = alterDbCommand;
                 cmd.ExecuteNonQuery();
@@ -368,7 +376,9 @@ namespace Snowflake.Data.Client
 
         protected override DbCommand CreateDbCommand()
         {
-            return new SnowflakeDbCommand(this);
+            var command = ProviderFactory.CreateCommand();
+            command.Connection = this;
+            return command;
         }
 
         protected override void Dispose(bool disposing)

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -116,7 +116,7 @@ namespace Snowflake.Data.Client
                 return false;
             try
             {
-                using (IDbCommand command = CreateDbCommand())
+                using (IDbCommand command = CreateCommand())
                 {
                     command.CommandText = "ROLLBACK";
                     command.ExecuteNonQuery(); 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -39,8 +39,7 @@ namespace Snowflake.Data.Client
 
         private enum TransactionRollbackStatus
         {
-            Undefined,
-            NotNeeded,
+            Undefined, // used to indicate ignored transaction status when pool disabled
             Success,
             Failure
         }
@@ -216,9 +215,8 @@ namespace Snowflake.Data.Client
 
         private bool CanReuseSession(TransactionRollbackStatus transactionRollbackStatus)
         {
-            return SnowflakeDbConnectionPool.GetPooling() &&
-                   (transactionRollbackStatus == TransactionRollbackStatus.Success ||
-                    transactionRollbackStatus == TransactionRollbackStatus.NotNeeded);
+            return SnowflakeDbConnectionPool.GetPooling() && 
+                   transactionRollbackStatus == TransactionRollbackStatus.Success;
         }
         
         public override void Open()

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -149,9 +149,19 @@ namespace Snowflake.Data.Client
             maxPoolSize = size;
         }
 
+        public int GetMaxPoolSize()
+        {
+            return maxPoolSize;
+        }
+
         public void SetTimeout(long time)
         {
             timeout = time;
+        }
+
+        public long GetTimeout()
+        {
+            return timeout;
         }
 
         public int GetCurrentPoolSize()
@@ -203,9 +213,19 @@ namespace Snowflake.Data.Client
             SessionPoolSingleton.Instance.SetMaxPoolSize(size);
         }
 
+        public static int GetMaxPoolSize()
+        {
+            return SessionPoolSingleton.Instance.GetMaxPoolSize();
+        }
+
         public static void SetTimeout(long time)
         {
             SessionPoolSingleton.Instance.SetTimeout(time);
+        }
+        
+        public static long GetTimeout()
+        {
+            return SessionPoolSingleton.Instance.GetTimeout();
         }
 
         public static int GetCurrentPoolSize()


### PR DESCRIPTION
This change introduces an automated rollback during connection close and being pooled.
The rollback will be done on condition that a transaction got started with its constructor or BeginTransaction method of a connection (explicit transaction). If an error on such a rollback occurs the connection won't get added back to the pool to ensure that pool does never provide a dirty (with active transaction) connection.
In case of a transaction started with SnowflakeDbCommand the driver won't keep track of it. 