### PR TITLE
Default C# version in the IDE to match with github build matrix for supported .net versions

### DIFF
--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -9,6 +9,7 @@
     <Product>Snowflake Connector for .NET</Product>
     <Copyright>Copyright (c) 2012-2018 Snowflake Computing Inc. All rights reserved.</Copyright>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -15,6 +15,7 @@
     <Copyright>Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.</Copyright>
     <Version>2.0.25</Version>
     <DebugType>Full</DebugType>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Right now github actions build .NET driver for multiple .NET versions out of which 4.7.1 is still supported and enforces c# 7.3.
To spot syntax problems at local env within IDE before submitting a PR we need to default language version to 7.3. 