### PR TITLE
Snow 840115 - Set None value for TypeNameHandling in local JsonSerializerSettings

### DIFF
--- a/Snowflake.Data/Core/JsonUtils.cs
+++ b/Snowflake.Data/Core/JsonUtils.cs
@@ -19,8 +19,8 @@ namespace Snowflake.Data.Core
             ContractResolver = new DefaultContractResolver()
             {
                 NamingStrategy = new DefaultNamingStrategy()
-            }
+            },
+            TypeNameHandling = TypeNameHandling.None
         };
-  
     }
 }


### PR DESCRIPTION
When client tried execute command using .net driver then  JSONSerializer can use customer global configuration. If he had set TypeNameHandling=Auto then operation on snowflake was finished with error "SQL compilation error: Unsupported data type 'java.util.LinkedHashMap'". 