### PR TITLE
add max retry on http request to prevent infinite retry

### DIFF
--- a/Snowflake.Data.Tests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/HttpUtilTest.cs
@@ -51,7 +51,8 @@ namespace Snowflake.Data.Tests
                 "proxyPassword",
                 "localhost", 
                 false,
-                false
+                false,
+                7
             );
             
             // when
@@ -74,7 +75,8 @@ namespace Snowflake.Data.Tests
                 null,
                 null, 
                 false,
-                false
+                false,
+                0
             );
             
             // when

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1617,7 +1617,7 @@ namespace Snowflake.Data.Tests
             {
                 // No timeout
                 int timeoutSec = 0;
-                string infiniteLoginTimeOut = String.Format(ConnectionString + ";connection_timeout={0};maxHttpRetries={0}",
+                string infiniteLoginTimeOut = String.Format(ConnectionString + ";connection_timeout={0};maxHttpRetries=0",
                     timeoutSec);
 
                 conn.ConnectionString = infiniteLoginTimeOut;
@@ -1705,7 +1705,7 @@ namespace Snowflake.Data.Tests
             using (var conn = new MockSnowflakeDbConnection())
             {
                 // unlimited retry count to trigger the timeout
-                conn.ConnectionString = ConnectionString + "maxHttpRetries={0}";
+                conn.ConnectionString = ConnectionString + "maxHttpRetries=0";
 
                 Assert.AreEqual(conn.State, ConnectionState.Closed);
 

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -353,6 +353,34 @@ namespace Snowflake.Data.Tests
         }
 
         [Test]
+        public void TestLoginWithMaxRetryReached()
+        {
+            using (IDbConnection conn = new MockSnowflakeDbConnection())
+            {
+                string maxRetryConnStr = ConnectionString + "maxHttpRetries=5";
+
+                conn.ConnectionString = maxRetryConnStr;
+
+                Assert.AreEqual(conn.State, ConnectionState.Closed);
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                try
+                {
+                    conn.Open();
+                    Assert.Fail();
+                }
+                catch
+                {
+                }
+                stopwatch.Stop();
+
+                // retry 5 times with backoff 1, 2, 4, 8, 16 seconds
+                // but should not delay more than another 16 seconds
+                Assert.Less(stopwatch.ElapsedMilliseconds, 51 * 1000);
+                Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 30 * 1000);
+            }
+        }
+
+        [Test]
         [Ignore("Disable unstable test cases for now")]
         public void TestDefaultLoginTimeout()
         {

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -1617,7 +1617,7 @@ namespace Snowflake.Data.Tests
             {
                 // No timeout
                 int timeoutSec = 0;
-                string infiniteLoginTimeOut = String.Format(ConnectionString + ";connection_timeout={0}",
+                string infiniteLoginTimeOut = String.Format(ConnectionString + ";connection_timeout={0};maxHttpRetries={0}",
                     timeoutSec);
 
                 conn.ConnectionString = infiniteLoginTimeOut;
@@ -1704,7 +1704,8 @@ namespace Snowflake.Data.Tests
         {
             using (var conn = new MockSnowflakeDbConnection())
             {
-                conn.ConnectionString = ConnectionString;
+                // unlimited retry count to trigger the timeout
+                conn.ConnectionString = ConnectionString + "maxHttpRetries={0}";
 
                 Assert.AreEqual(conn.State, ConnectionState.Closed);
 

--- a/Snowflake.Data.Tests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/SFReusableChunkTest.cs
@@ -381,7 +381,7 @@ select parse_json('{
         public void testChunkRetry()
         {
             IChunkParserFactory previous = ChunkParserFactory.Instance;
-            ChunkParserFactory.Instance = new TestChunkParserFactory(HttpUtil.MAX_RETRY - 1);
+            ChunkParserFactory.Instance = new TestChunkParserFactory(6); // lower than default retry of 7
 
             using (IDbConnection conn = new SnowflakeDbConnection())
             {
@@ -436,7 +436,7 @@ select parse_json('{
         public void testExceptionThrownWhenChunkDownloadRetryCountExceeded()
         {            
             IChunkParserFactory previous = ChunkParserFactory.Instance;
-            ChunkParserFactory.Instance = new TestChunkParserFactory(HttpUtil.MAX_RETRY + 1);
+            ChunkParserFactory.Instance = new TestChunkParserFactory(8); // larger than default max retry of 7
             using (IDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = ConnectionString;

--- a/Snowflake.Data.Tests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/SFSessionPropertyTest.cs
@@ -39,6 +39,8 @@ namespace Snowflake.Data.Tests
             string defProxyHost = "proxy.com";
             string defProxyPort = "1234";
             string defNonProxyHosts = "localhost";
+
+            string defMaxHttpRetries = "7";
             
             var simpleTestCase = new TestCase()
             {
@@ -60,7 +62,8 @@ namespace Snowflake.Data.Tests
                     { SFSessionProperty.FORCERETRYON404, "false" },
                     { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
                     { SFSessionProperty.FORCEPARSEERROR, "false" },
-                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime }
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
                 }
             };
             var testCaseWithBrowserResponseTimeout = new TestCase()
@@ -83,7 +86,8 @@ namespace Snowflake.Data.Tests
                     { SFSessionProperty.FORCERETRYON404, "false" },
                     { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
                     { SFSessionProperty.FORCEPARSEERROR, "false" },
-                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, "180" }
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, "180" },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
                 }
             };   
             var testCaseWithProxySettings = new TestCase()
@@ -108,7 +112,8 @@ namespace Snowflake.Data.Tests
                     { SFSessionProperty.PROXYHOST, defProxyHost },
                     { SFSessionProperty.PROXYPORT, defProxyPort },
                     { SFSessionProperty.NONPROXYHOSTS, defNonProxyHosts },
-                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime }
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
                 },
                 ConnectionString =
                     $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};useProxy=true;proxyHost=proxy.com;proxyPort=1234;nonProxyHosts=localhost"
@@ -135,7 +140,8 @@ namespace Snowflake.Data.Tests
                     { SFSessionProperty.PROXYHOST, defProxyHost },
                     { SFSessionProperty.PROXYPORT, defProxyPort },
                     { SFSessionProperty.NONPROXYHOSTS, defNonProxyHosts },
-                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime }
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
                 },
                 ConnectionString =
                     $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};proxyHost=proxy.com;proxyPort=1234;nonProxyHosts=localhost"

--- a/Snowflake.Data.Tests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/Session/SFHttpClientPropertiesTest.cs
@@ -35,6 +35,7 @@ namespace Snowflake.Data.Tests.Session
                 insecureMode = false,
                 disableRetry = false,
                 forceRetryOn404 = false,
+                maxHttpRetries = 7,
                 proxyProperties = proxyProperties
             };
             
@@ -67,6 +68,7 @@ namespace Snowflake.Data.Tests.Session
                 insecureMode = TestDataGenarator.NextBool(),
                 disableRetry = TestDataGenarator.NextBool(),
                 forceRetryOn404 = TestDataGenarator.NextBool(),
+                maxHttpRetries = TestDataGenarator.NextInt(0, 15),
                 proxyProperties = proxyProperties
             };
             
@@ -82,6 +84,7 @@ namespace Snowflake.Data.Tests.Session
             Assert.AreEqual(properties.proxyProperties.nonProxyHosts, config.NoProxyList);
             Assert.AreEqual(properties.disableRetry, config.DisableRetry);
             Assert.AreEqual(properties.forceRetryOn404, config.ForceRetryOn404);
+            Assert.AreEqual(properties.maxHttpRetries, config.MaxHttpRetries);
         }
 
         [Test, TestCaseSource(nameof(PropertiesProvider))]
@@ -106,6 +109,7 @@ namespace Snowflake.Data.Tests.Session
             Assert.AreEqual(testCase.expectedProperties.insecureMode, extractedProperties.insecureMode);
             Assert.AreEqual(testCase.expectedProperties.disableRetry, extractedProperties.disableRetry);
             Assert.AreEqual(testCase.expectedProperties.forceRetryOn404, extractedProperties.forceRetryOn404);
+            Assert.AreEqual(testCase.expectedProperties.maxHttpRetries, extractedProperties.maxHttpRetries);
             Assert.AreEqual(proxyProperties, extractedProperties.proxyProperties);
             proxyExtractorMock.Verify(e => e.ExtractProperties(properties), Times.Once);
         }
@@ -122,7 +126,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = false,
                     disableRetry = false,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithValidateDefaultParametersChanged = new PropertiesTestCase()
@@ -135,7 +140,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = false,
                     disableRetry = false,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithClientSessionKeepAliveChanged = new PropertiesTestCase()
@@ -148,7 +154,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = false,
                     disableRetry = false,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithTimeoutChanged = new PropertiesTestCase()
@@ -161,7 +168,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = 15,
                     insecureMode = false,
                     disableRetry = false,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithInsecureModeChanged = new PropertiesTestCase()
@@ -174,7 +182,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = true,
                     disableRetry = false,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithDisableRetryChanged = new PropertiesTestCase()
@@ -187,7 +196,8 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = false,
                     disableRetry = true,
-                    forceRetryOn404 = false
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 7
                 }
             };
             var propertiesWithForceRetryOn404Changed = new PropertiesTestCase()
@@ -200,9 +210,24 @@ namespace Snowflake.Data.Tests.Session
                     timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
                     insecureMode = false,
                     disableRetry = false,
-                    forceRetryOn404 = true
+                    forceRetryOn404 = true,
+                    maxHttpRetries = 7
                 }
-            }; 
+            };
+            var propertiesWithMaxHttpRetiesChanged = new PropertiesTestCase()
+            {
+                conectionString = "account=test;user=test;password=test;maxHttpRetries=10",
+                expectedProperties = new SFSessionHttpClientProperties()
+                {
+                    validateDefaultParameters = true,
+                    clientSessionKeepAlive = false,
+                    timeoutInSec = BaseRestRequest.DEFAULT_REST_RETRY_SECONDS_TIMEOUT,
+                    insecureMode = false,
+                    disableRetry = false,
+                    forceRetryOn404 = false,
+                    maxHttpRetries = 10
+                }
+            };
             return new []
             {
                 defaultProperties,
@@ -211,7 +236,8 @@ namespace Snowflake.Data.Tests.Session
                 propertiesWithTimeoutChanged,
                 propertiesWithInsecureModeChanged,
                 propertiesWithDisableRetryChanged,
-                propertiesWithForceRetryOn404Changed
+                propertiesWithForceRetryOn404Changed,
+                propertiesWithMaxHttpRetiesChanged
             };
         }
 

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -379,7 +379,11 @@ namespace Snowflake.Data.Core
                     if (retryCount > maxRetry)
                     {
                         logger.Debug($"stop retry as maxHttpRetries {maxRetry} reached");
-                        return response;
+                        if (response != null)
+                        {
+                            return response;
+                        }
+                        throw new OperationCanceledException("http request failed and max retry reached");
                     }
 
                     // Disposing of the response if not null now that we don't need it anymore

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -376,7 +376,7 @@ namespace Snowflake.Data.Core
                     }
 
                     retryCount++;
-                    if (retryCount > maxRetry)
+                    if ((maxRetry > 0) && (retryCount > maxRetry))
                     {
                         logger.Debug($"stop retry as maxHttpRetries {maxRetry} reached");
                         if (response != null)

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -383,7 +383,7 @@ namespace Snowflake.Data.Core
                         {
                             return response;
                         }
-                        throw new OperationCanceledException("http request failed and max retry reached");
+                        throw new OperationCanceledException($"http request failed and max retry {maxRetry} reached");
                     }
 
                     // Disposing of the response if not null now that we don't need it anymore

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -136,7 +136,8 @@ namespace Snowflake.Data.Core
             int backOffInSec = 1;
             bool retry = false;
             int retryCount = 0;
-            
+            int maxRetry = int.Parse(sessionProperies[SFSessionProperty.MAXHTTPRETRIES]);
+
             do
             {
                 retry = false;
@@ -184,7 +185,7 @@ namespace Snowflake.Data.Core
                     }
                     catch (Exception e)
                     {
-                        if (retryCount < HttpUtil.MAX_RETRY)
+                        if (retryCount < maxRetry)
                         {
                             retry = true;
                             // reset the chunk before retry in case there could be garbage

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -185,7 +185,7 @@ namespace Snowflake.Data.Core
                     }
                     catch (Exception e)
                     {
-                        if (retryCount < maxRetry)
+                        if ((maxRetry <= 0) || (retryCount < maxRetry))
                         {
                             retry = true;
                             // reset the chunk before retry in case there could be garbage

--- a/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
+++ b/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
@@ -17,6 +17,7 @@ namespace Snowflake.Data.Core
         internal bool insecureMode;
         internal bool disableRetry;
         internal bool forceRetryOn404;
+        internal int maxHttpRetries;
         internal SFSessionHttpClientProxyProperties proxyProperties;
 
         internal void WarnOnTimeout()
@@ -48,7 +49,8 @@ namespace Snowflake.Data.Core
                 proxyProperties.proxyPassword,
                 proxyProperties.nonProxyHosts,
                 disableRetry,
-                forceRetryOn404);
+                forceRetryOn404,
+                maxHttpRetries);
         }
 
         internal Dictionary<SFSessionParameter, object> ToParameterMap()
@@ -83,6 +85,7 @@ namespace Snowflake.Data.Core
                     insecureMode = Boolean.Parse(propertiesDictionary[SFSessionProperty.INSECUREMODE]),
                     disableRetry = Boolean.Parse(propertiesDictionary[SFSessionProperty.DISABLERETRY]),
                     forceRetryOn404 = Boolean.Parse(propertiesDictionary[SFSessionProperty.FORCERETRYON404]),
+                    maxHttpRetries = int.Parse(propertiesDictionary[SFSessionProperty.MAXHTTPRETRIES]),
                     proxyProperties = proxyPropertiesExtractor.ExtractProperties(propertiesDictionary)
                 };
             }

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -78,6 +78,8 @@ namespace Snowflake.Data.Core
         FORCEPARSEERROR,
         [SFSessionPropertyAttr(required = false, defaultValue = "120")]
         BROWSER_RESPONSE_TIMEOUT,
+        [SFSessionPropertyAttr(required = false, defaultValue = "7")]
+        MAXHTTPRETRIES,
     }
 
     class SFSessionPropertyAttr : Attribute


### PR DESCRIPTION
sdk issue 457

add new connection parameter `maxHttpRetries` to limit the number of retry attempts.
