### PR TITLE
SNOW-828646: Test connection is not reused when not created successfully

### DIFF
--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -67,6 +67,11 @@ namespace Snowflake.Data.Tests
                                              string.Format(ConnectionStringSnowflakeAuthFmt,
                                                  testConfig.user,
                                                  testConfig.password);
+        
+        protected string ConnectionStringWithInvalidUserName => ConnectionStringWithoutAuth +
+                                             string.Format(ConnectionStringSnowflakeAuthFmt,
+                                                 "unknown",
+                                                 testConfig.password);
 
         protected TestConfig testConfig { get; }
     }

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -23,8 +23,6 @@ namespace Snowflake.Data.Tests
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SFConnectionIT>();
 
-        private const string ConnectionFailureErrorCode = "08006";
-
         [Test]
         [Ignore("ConnectionIT")]
         public void ConnectionITDone()
@@ -97,7 +95,7 @@ namespace Snowflake.Data.Tests
                     {
                         // Expected
                         s_logger.Debug("Failed opening connection ", e);
-                        Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
+                        AssertIsConnectionFailure(e);
                     }
 
                     Assert.AreEqual(ConnectionState.Closed, conn.State);
@@ -134,7 +132,7 @@ namespace Snowflake.Data.Tests
                 {
                     // Expected
                     s_logger.Debug("Failed opening connection ", e);
-                    Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
+                    AssertIsConnectionFailure(e);
                 }
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
@@ -159,7 +157,7 @@ namespace Snowflake.Data.Tests
                 }
                 catch (SnowflakeDbException e)
                 {
-                    Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
+                    AssertIsConnectionFailure(e);
                     AssertConnectionIsNotOpen(snowflakeConnection);
                     if (explicitClose)
                     {
@@ -188,7 +186,7 @@ namespace Snowflake.Data.Tests
                 }
                 catch (SnowflakeDbException e)
                 {
-                    Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
+                    AssertIsConnectionFailure(e);
                     AssertConnectionIsNotOpen(snowflakeConnection);
                     snowflakeConnection = null;
                 }
@@ -200,6 +198,11 @@ namespace Snowflake.Data.Tests
             Assert.NotNull(snowflakeDbConnection);
             Assert.IsFalse(snowflakeDbConnection.IsOpen()); // check via public method
             Assert.AreEqual(snowflakeDbConnection.State, ConnectionState.Closed); // ensure internal state is expected
+        }
+
+        private static void AssertIsConnectionFailure(SnowflakeDbException e)
+        {
+            Assert.AreEqual(SnowflakeDbException.CONNECTION_FAILURE_SSTATE, e.SqlState);
         }
 
         [Test]
@@ -1411,7 +1414,7 @@ namespace Snowflake.Data.Tests
                     // Expected
                     s_logger.Debug("Failed opening connection ", e);
                     Assert.AreEqual(270001, e.ErrorCode); //Internal error
-                    Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
+                    AssertIsConnectionFailure(e);
                 }
             }
         }

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -21,9 +21,9 @@ namespace Snowflake.Data.Tests
     [TestFixture]
     class SFConnectionIT : SFBaseTest
     {
-        private static SFLogger logger = SFLoggerFactory.GetLogger<SFConnectionIT>();
+        private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SFConnectionIT>();
 
-        private static readonly string ConnectionFailureErrorCode = "08006";
+        private const string ConnectionFailureErrorCode = "08006";
 
         [Test]
         [Ignore("ConnectionIT")]
@@ -89,14 +89,14 @@ namespace Snowflake.Data.Tests
                     try
                     {
                         conn.Open();
-                        logger.Debug("{appName}");
+                        s_logger.Debug("{appName}");
                         Assert.Fail();
 
                     }
                     catch (SnowflakeDbException e)
                     {
                         // Expected
-                        logger.Debug("Failed opening connection ", e);
+                        s_logger.Debug("Failed opening connection ", e);
                         Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
                     }
 
@@ -133,7 +133,7 @@ namespace Snowflake.Data.Tests
                 catch (SnowflakeDbException e)
                 {
                     // Expected
-                    logger.Debug("Failed opening connection ", e);
+                    s_logger.Debug("Failed opening connection ", e);
                     Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
                 }
 
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Tests
             SnowflakeDbConnection snowflakeConnection = null;
             for (var i = 0; i < 2; ++i)
             {
-                logger.Debug($"Running try #{i}");
+                s_logger.Debug($"Running try #{i}");
                 try
                 {
                     snowflakeConnection = new SnowflakeDbConnection(ConnectionStringWithInvalidUserName);
@@ -178,7 +178,7 @@ namespace Snowflake.Data.Tests
             SnowflakeDbConnection snowflakeConnection = null;
             for (var i = 0; i < 2; ++i)
             {
-                logger.Debug($"Running try #{i}");
+                s_logger.Debug($"Running try #{i}");
                 try
                 {
                     using (snowflakeConnection = new SnowflakeDbConnection(ConnectionStringWithInvalidUserName))
@@ -1409,7 +1409,7 @@ namespace Snowflake.Data.Tests
                 catch (SnowflakeDbException e)
                 {
                     // Expected
-                    logger.Debug("Failed opening connection ", e);
+                    s_logger.Debug("Failed opening connection ", e);
                     Assert.AreEqual(270001, e.ErrorCode); //Internal error
                     Assert.AreEqual(ConnectionFailureErrorCode, e.SqlState);
                 }

--- a/Snowflake.Data.Tests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/SFConnectionIT.cs
@@ -145,10 +145,10 @@ namespace Snowflake.Data.Tests
         public void TestConnectionIsNotMarkedAsOpenWhenWasNotCorrectlyOpenedBefore(bool explicitClose)
         {
             SnowflakeDbConnectionPool.SetPooling(true);
-            SnowflakeDbConnection snowflakeConnection = null;
-            for (var i = 0; i < 2; ++i)
+            for (int i = 0; i < 2; ++i)
             {
                 s_logger.Debug($"Running try #{i}");
+                SnowflakeDbConnection snowflakeConnection = null;
                 try
                 {
                     snowflakeConnection = new SnowflakeDbConnection(ConnectionStringWithInvalidUserName);
@@ -164,19 +164,18 @@ namespace Snowflake.Data.Tests
                         snowflakeConnection.Close();
                         AssertConnectionIsNotOpen(snowflakeConnection);
                     }
-                    snowflakeConnection = null;
                 }
             }
         }
 
         [Test]
-        public void TestConnectionIsNotMarkedAsOpenWhenWasNotCorrectlyOpenedWithUsing()
+        public void TestConnectionIsNotMarkedAsOpenWhenWasNotCorrectlyOpenedWithUsingClause()
         {
             SnowflakeDbConnectionPool.SetPooling(true);
-            SnowflakeDbConnection snowflakeConnection = null;
-            for (var i = 0; i < 2; ++i)
+            for (int i = 0; i < 2; ++i)
             {
                 s_logger.Debug($"Running try #{i}");
+                SnowflakeDbConnection snowflakeConnection = null;
                 try
                 {
                     using (snowflakeConnection = new SnowflakeDbConnection(ConnectionStringWithInvalidUserName))
@@ -188,7 +187,6 @@ namespace Snowflake.Data.Tests
                 {
                     AssertIsConnectionFailure(e);
                     AssertConnectionIsNotOpen(snowflakeConnection);
-                    snowflakeConnection = null;
                 }
             }
         }
@@ -197,7 +195,7 @@ namespace Snowflake.Data.Tests
         {
             Assert.NotNull(snowflakeDbConnection);
             Assert.IsFalse(snowflakeDbConnection.IsOpen()); // check via public method
-            Assert.AreEqual(snowflakeDbConnection.State, ConnectionState.Closed); // ensure internal state is expected
+            Assert.AreEqual(ConnectionState.Closed, snowflakeDbConnection.State); // ensure internal state is expected
         }
 
         private static void AssertIsConnectionFailure(SnowflakeDbException e)


### PR DESCRIPTION
- Add tests to verify that connection is not marked as open (and taken from the pool) when before was unsuccessfully opened because of e.g. invalid user name 