### PR TITLE
SNOW-870776: Remove minicover and update dotnet patch version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,14 +160,9 @@ jobs:
         run: |
           dotnet restore
           dotnet build
-      - name: Run minicover
+      - name: Run Tests
         run: |
-          dotnet new tool-manifest
-          dotnet tool install --local MiniCover --version 3.4.7
-          dotnet minicover instrument --workdir ./ --assemblies 'Snowflake.Data.Tests/**/bin/**/Snowflake.Data.dll' --sources 'Snowflake.Data/**/*.cs'
-          dotnet minicover reset
           dotnet test --no-build
-          dotnet minicover uninstrument
         env:
           snowflake_cloud_env: ${{ matrix.cloud_env }}
           net_version: ${{ matrix.dotnet }}
@@ -207,14 +202,9 @@ jobs:
         run: |
           dotnet restore
           dotnet build
-      - name: Run minicover
+      - name: Run Tests
         run: |
-          dotnet new tool-manifest
-          dotnet tool install --local MiniCover --version 3.4.7
-          dotnet minicover instrument --workdir ./ --assemblies 'Snowflake.Data.Tests/**/bin/**/Snowflake.Data.dll' --sources 'Snowflake.Data/**/*.cs'
-          dotnet minicover reset
           dotnet test --no-build
-          dotnet minicover uninstrument
         env:
           snowflake_cloud_env: ${{ matrix.cloud_env }}
           net_version: ${{ matrix.dotnet }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.100']
+        dotnet: ['6.0.412']
         cloud_env: ['AZURE', 'GCP', 'AWS']
     steps:
       - uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.412
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.412
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -186,7 +186,7 @@ jobs:
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.412
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Remove the minicover which causes some tests to take very long time (e.g. `TestSimpleLargeResultSet` took almost 40 minutes on Linux and MacOs, whereas it took 5 seconds on Windows) and also update .NET patch to the newest version.