### PR TITLE
SNOW-896750: Check and enable TestSimpleLargeResultSet on GCP

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -235,10 +235,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
-        // Skip SimpleLargeResultSet test on GCP as it will fail
-        // on row 8192 consistently on Appveyor.
-        [IgnoreOnEnvIs("snowflake_cloud_env",
-                       new string[] { "GCP" })]
         public void TestSimpleLargeResultSet()
         {
             using (IDbConnection conn = new SnowflakeDbConnection())


### PR DESCRIPTION
### Description
The test is ignored on GCP environment. Check and confirm that it is working on GCP. If not, see if it is possible to fix it.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name