### PR TITLE
SNOW-898710 use endpoint from stageInfo for azure

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -48,7 +48,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             // Get the Azure SAS token and create the client
             if (stageInfo.stageCredentials.TryGetValue(AZURE_SAS_TOKEN, out string sasToken))
             {
-                string blobEndpoint = string.Format("https://{0}.blob.core.windows.net", stageInfo.storageAccount);
+                string blobEndpoint = string.Format("https://{0}.{1}", stageInfo.storageAccount, stageInfo.endPoint);
                 blobServiceClient = new BlobServiceClient(new Uri(blobEndpoint),
                     new AzureSasCredential(sasToken));
             }


### PR DESCRIPTION
### Description
SDK issue 624. The endpoint used for PUT/GET on azure was hardcoded and could cause issue with gov cloud accounts which a different endpoint should be used.
Use the endpoint returned from server response in stageInfo to fix the issue.
No test case added as the existing test case can confirm using endpoint from stageInfo works already. Choosing different endpoint for gov cloud accounts is server behavior.
Will ask customer to try with the fix if possible though.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name