### PR TITLE
SNOW-736347 [HTAP] add retry reason in query retry request

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -58,7 +58,8 @@ namespace Snowflake.Data.Tests.UnitTests
             string defNonProxyHosts = "localhost";
 
             string defMaxHttpRetries = "7";
-            
+            string defIncludeRetryReason = "true";
+
             var simpleTestCase = new TestCase()
             {
                 ConnectionString = $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};",
@@ -80,7 +81,8 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
                     { SFSessionProperty.FORCEPARSEERROR, "false" },
                     { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
-                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason }
                 }
             };
             var testCaseWithBrowserResponseTimeout = new TestCase()
@@ -103,7 +105,8 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
                     { SFSessionProperty.FORCEPARSEERROR, "false" },
                     { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, "180" },
-                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason }
                 }
             };   
             var testCaseWithProxySettings = new TestCase()
@@ -129,7 +132,8 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.PROXYPORT, defProxyPort },
                     { SFSessionProperty.NONPROXYHOSTS, defNonProxyHosts },
                     { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
-                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason }
                 },
                 ConnectionString =
                     $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};useProxy=true;proxyHost=proxy.com;proxyPort=1234;nonProxyHosts=localhost"
@@ -157,7 +161,8 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.PROXYPORT, defProxyPort },
                     { SFSessionProperty.NONPROXYHOSTS, defNonProxyHosts },
                     { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
-                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries }
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason }
                 },
                 ConnectionString =
                     $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};proxyHost=proxy.com;proxyPort=1234;nonProxyHosts=localhost"
@@ -184,7 +189,33 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.FORCEPARSEERROR, "false" },
                     { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
                     { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
-                    { SFSessionProperty.FILE_TRANSFER_MEMORY_THRESHOLD, "25" }
+                    { SFSessionProperty.FILE_TRANSFER_MEMORY_THRESHOLD, "25" },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason }
+                }
+            };
+            var testCaseWithIncludeRetryReason = new TestCase()
+            {
+                ConnectionString = $"ACCOUNT={defAccount};USER={defUser};PASSWORD={defPassword};IncludeRetryReason=false",
+                ExpectedProperties = new SFSessionProperties()
+                {
+                    { SFSessionProperty.ACCOUNT, defAccount },
+                    { SFSessionProperty.USER, defUser },
+                    { SFSessionProperty.HOST, defHost },
+                    { SFSessionProperty.AUTHENTICATOR, defAuthenticator },
+                    { SFSessionProperty.SCHEME, defScheme },
+                    { SFSessionProperty.CONNECTION_TIMEOUT, defConnectionTimeout },
+                    { SFSessionProperty.PASSWORD, defPassword },
+                    { SFSessionProperty.PORT, defPort },
+                    { SFSessionProperty.VALIDATE_DEFAULT_PARAMETERS, "true" },
+                    { SFSessionProperty.USEPROXY, "false" },
+                    { SFSessionProperty.INSECUREMODE, "false" },
+                    { SFSessionProperty.DISABLERETRY, "false" },
+                    { SFSessionProperty.FORCERETRYON404, "false" },
+                    { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
+                    { SFSessionProperty.FORCEPARSEERROR, "false" },
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, "false" }
                 }
             };
             return new TestCase[]

--- a/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
@@ -34,7 +34,6 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        // Test with Retry reason enabled
         public void TestRetryReasonEnabled()
         {
             Uri uri = new Uri("https://ac.snowflakecomputing.com" + RestPath.SF_QUERY_PATH);
@@ -47,7 +46,6 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        // Test with Retry reason enabled
         public void TestRetryReasonDisabled()
         {
             Uri uri = new Uri("https://ac.snowflakecomputing.com" + RestPath.SF_QUERY_PATH);

--- a/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
@@ -34,6 +34,32 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
+        // Test with Retry reason enabled
+        public void TestRetryReasonEnabled()
+        {
+            Uri uri = new Uri("https://ac.snowflakecomputing.com" + RestPath.SF_QUERY_PATH);
+
+            HttpUtil.UriUpdater updater = new HttpUtil.UriUpdater(uri, true);
+
+            Uri newUri = updater.Update(429);
+
+            Assert.IsTrue(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_REASON + "=" + 429));
+        }
+
+        [Test]
+        // Test with Retry reason enabled
+        public void TestRetryReasonDisabled()
+        {
+            Uri uri = new Uri("https://ac.snowflakecomputing.com" + RestPath.SF_QUERY_PATH);
+
+            HttpUtil.UriUpdater updater = new HttpUtil.UriUpdater(uri, false);
+
+            Uri newUri = updater.Update(429);
+
+            Assert.IsFalse(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_REASON));
+        }
+
+        [Test]
         /// This uri with query path other than query request should not have a retry counter
         public void TestRetryCountNoneQueryPath()
         {

--- a/Snowflake.Data/Core/RestParams.cs
+++ b/Snowflake.Data/Core/RestParams.cs
@@ -22,6 +22,8 @@ namespace Snowflake.Data.Core
 
         internal const string SF_QUERY_RETRY_COUNT = "retryCount";
 
+        internal const string SF_QUERY_RETRY_REASON = "retryReason";
+
         internal const string SF_QUERY_SESSION_DELETE = "delete";
     }
 

--- a/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
+++ b/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
@@ -18,6 +18,7 @@ namespace Snowflake.Data.Core
         internal bool disableRetry;
         internal bool forceRetryOn404;
         internal int maxHttpRetries;
+        internal bool includeRetryReason;
         internal SFSessionHttpClientProxyProperties proxyProperties;
 
         internal void WarnOnTimeout()
@@ -50,7 +51,8 @@ namespace Snowflake.Data.Core
                 proxyProperties.nonProxyHosts,
                 disableRetry,
                 forceRetryOn404,
-                maxHttpRetries);
+                maxHttpRetries,
+                includeRetryReason);
         }
 
         internal Dictionary<SFSessionParameter, object> ToParameterMap()
@@ -86,6 +88,7 @@ namespace Snowflake.Data.Core
                     disableRetry = Boolean.Parse(propertiesDictionary[SFSessionProperty.DISABLERETRY]),
                     forceRetryOn404 = Boolean.Parse(propertiesDictionary[SFSessionProperty.FORCERETRYON404]),
                     maxHttpRetries = int.Parse(propertiesDictionary[SFSessionProperty.MAXHTTPRETRIES]),
+                    includeRetryReason = Boolean.Parse(propertiesDictionary[SFSessionProperty.INCLUDERETRYREASON]),
                     proxyProperties = proxyPropertiesExtractor.ExtractProperties(propertiesDictionary)
                 };
             }

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -81,7 +81,9 @@ namespace Snowflake.Data.Core
         [SFSessionPropertyAttr(required = false, defaultValue = "7")]
         MAXHTTPRETRIES,
         [SFSessionPropertyAttr(required = false)]
-        FILE_TRANSFER_MEMORY_THRESHOLD
+        FILE_TRANSFER_MEMORY_THRESHOLD,
+        [SFSessionPropertyAttr(required = false, defaultValue = "true")]
+        INCLUDERETRYREASON,
     }
 
     class SFSessionPropertyAttr : Attribute


### PR DESCRIPTION
### Description
sdk issue156
Add retry reason as http error code in query retry request. 0 when no response received.
Hidden connection parameter `INCLUDERETRYREASON` to allow disable retry reason in retry request, true by default.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name