### PR TITLE
SNOW-828158: Set Culture explicitly for tests

### DIFF
--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -47,6 +47,7 @@ namespace Snowflake.Data.Tests
      */
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [SetCulture("en-US")]
     public class SFBaseTestAsync
     {
         private const string ConnectionStringWithoutAuthFmt = "scheme={0};host={1};port={2};" +

--- a/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
@@ -11,6 +11,7 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Text;
 
     [TestFixture]
+    [SetCulture("en-US")]
     class FastParserTest
     {
         byte[] _byte;

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -13,6 +13,7 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Globalization;
 
     [TestFixture]
+    [SetCulture("en-US")]
     class SFDataConverterTest
     {
         [Test]


### PR DESCRIPTION
### Description
Setting the culture explicitly allows to run the tests in any locale on a local machine without changing it to `en-US`.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name