### PR TITLE
SNOW-903956: Add support for CloseAsync() on IDbConnection in .NET 6

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -167,6 +167,15 @@ namespace Snowflake.Data.Client
             _connectionState = ConnectionState.Closed;
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        // CloseAsync was added to IDbConnection as part of .NET Standard 2.1, first supported by .NET Core 3.0.
+        // Adding an override for CloseAsync will prevent the need for casting to SnowflakeDbConnection to call CloseAsync(CancellationToken).
+        public override async Task CloseAsync()
+        {
+            await CloseAsync(CancellationToken.None);
+        }
+#endif
+
         public Task CloseAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Close Connection.");


### PR DESCRIPTION
### Description
As mentioned in #762, `IDbConnection` in .NET Standard 2.1 added a new `CloseAsync()` method.

This Pull Request adds functionality targeted at .NET Standard 2.1 (designated by the `NETCOREAPP3_0_OR_GREATER` compiler flag) to add an override for `CloseAsync()`. The compiler flag is required because the codebase also targets .NET Framework 4.7.2, which only supports .NET Standard 2.0 that doesn't have `CloseAsync()`.

This Pull Request negates the need to cast to `SnowflakeDbConnection` to call `CloseAsync(CancellationToken)` in .NET 6 by having `CloseAsync()` call `CloseAsync(CancellationToken.None)`.

This is the code from #538 that was automatically closed when I rebased my fork to resolve merge conflicts.

### Checklist
- [X] Code compiles correctly
- [X] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`dotnet test`)
- [X] Extended the README / documentation, if necessary
- [X] Provide JIRA issue id (if possible) or GitHub issue id in PR name