### PR TITLE
SNOW-933246: adding missed fix for HTAP parameter removal

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -182,21 +182,26 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
-                IDbCommand cmd = conn.CreateCommand();
-                cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='MM/DD/YYYY'";
-                cmd.ExecuteNonQuery();
+                try
+                {
+                    IDbCommand cmd = conn.CreateCommand();
+                    cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='MM/DD/YYYY'";
+                    cmd.ExecuteNonQuery();
 
-                cmd.CommandText = $"select TO_DATE('2013-05-17')";
-                IDataReader reader = cmd.ExecuteReader();
+                    cmd.CommandText = $"select TO_DATE('2013-05-17')";
+                    IDataReader reader = cmd.ExecuteReader();
 
-                Assert.IsTrue(reader.Read());
-                Assert.AreEqual("05/17/2013", reader.GetString(0));
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual("05/17/2013", reader.GetString(0));
 
-                reader.Close();
-
-                // set format back to default to avoid impact other test cases
-                cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='YYYY-MM-DD'";
-                cmd.ExecuteNonQuery();
+                    reader.Close();
+                }
+                finally
+                {
+                    // set format back to default to avoid impact other test cases
+                    cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='YYYY-MM-DD'";
+                    cmd.ExecuteNonQuery();
+                }
 
                 conn.Close();
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -174,6 +174,28 @@ namespace Snowflake.Data.Tests.IntegrationTests
             testGetDateAndOrTime(inputTimeStr, null, SFDataType.DATE);
         }
 
+        [Test]
+        public void TestDateOutputFormat()
+        {
+            using (IDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                IDbCommand cmd = conn.CreateCommand();
+                cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='MM/DD/YYYY'";
+                cmd.ExecuteNonQuery();
+
+                cmd.CommandText = $"select TO_DATE('2013-05-17')";
+                IDataReader reader = cmd.ExecuteReader();
+
+                Assert.IsTrue(reader.Read());
+                Assert.AreEqual("05/17/2013", reader.GetString(0));
+
+                reader.Close();
+                conn.Close();
+            }
+        }
 
         [Test]
         [TestCase(null, null)]

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -193,6 +193,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.AreEqual("05/17/2013", reader.GetString(0));
 
                 reader.Close();
+
+                // set format back to default to avoid impact other test cases
+                cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='YYYY-MM-DD'";
+                cmd.ExecuteNonQuery();
+
                 conn.Close();
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -181,10 +181,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
+                IDbCommand cmd = conn.CreateCommand();
 
                 try
                 {
-                    IDbCommand cmd = conn.CreateCommand();
                     cmd.CommandText = "alter session set DATE_OUTPUT_FORMAT='MM/DD/YYYY'";
                     cmd.ExecuteNonQuery();
 

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -34,6 +34,12 @@ namespace Snowflake.Data.Tests.UnitTests
 
             Assert.AreEqual(databaseName, sfSession.database);
             Assert.AreEqual(schemaName, sfSession.schema);
+
+            // when database or schema name is missing in the response,
+            // the cached value should keep unchanged
+            sfSession.UpdateDatabaseAndSchema(null, null);
+            Assert.AreEqual(databaseName, sfSession.database);
+            Assert.AreEqual(schemaName, sfSession.schema);
         }
 
         [Test]

--- a/Snowflake.Data/Core/ArrowResultSet.cs
+++ b/Snowflake.Data/Core/ArrowResultSet.cs
@@ -45,7 +45,7 @@ namespace Snowflake.Data.Core
 
                 responseData.rowSet = null;
 
-                sfResultSetMetaData = new SFResultSetMetaData(responseData);
+                sfResultSetMetaData = new SFResultSetMetaData(responseData, this.sfStatement.SfSession);
 
                 isClosed = false;
 

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -39,7 +39,7 @@ namespace Snowflake.Data.Core
                 _currentChunk = new SFResultChunk(responseData.rowSet);
                 responseData.rowSet = null;
 
-                sfResultSetMetaData = new SFResultSetMetaData(responseData);
+                sfResultSetMetaData = new SFResultSetMetaData(responseData, this.sfStatement.SfSession);
 
                 isClosed = false;
 

--- a/Snowflake.Data/Core/SFResultSetMetaData.cs
+++ b/Snowflake.Data/Core/SFResultSetMetaData.cs
@@ -37,25 +37,15 @@ namespace Snowflake.Data.Core
         /// </summary>
         private Dictionary<string, int> columnNameToIndexCache = new Dictionary<string, int>();
 
-        internal SFResultSetMetaData(QueryExecResponseData queryExecResponseData)
+        internal SFResultSetMetaData(QueryExecResponseData queryExecResponseData, SFSession session)
         {
             rowTypes = queryExecResponseData.rowType;
             columnCount = rowTypes.Count;
             statementType = findStatementTypeById(queryExecResponseData.statementTypeId);
             columnTypes = InitColumnTypes();
-            
-            foreach (NameValueParameter parameter in queryExecResponseData.parameters)
-            {
-                switch(parameter.name)
-                {
-                    case "DATE_OUTPUT_FORMAT":
-                        dateOutputFormat = parameter.value;
-                        break;
-                    case "TIME_OUTPUT_FORMAT":
-                        timeOutputFormat = parameter.value;
-                        break;
-                }
-            }
+
+            dateOutputFormat = session.ParameterMap[SFSessionParameter.DATE_OUTPUT_FORMAT].ToString();
+            timeOutputFormat = session.ParameterMap[SFSessionParameter.TIME_OUTPUT_FORMAT].ToString();
         }
 
         internal SFResultSetMetaData(PutGetResponseData putGetResponseData)

--- a/Snowflake.Data/Core/SFResultSetMetaData.cs
+++ b/Snowflake.Data/Core/SFResultSetMetaData.cs
@@ -44,8 +44,14 @@ namespace Snowflake.Data.Core
             statementType = findStatementTypeById(queryExecResponseData.statementTypeId);
             columnTypes = InitColumnTypes();
 
-            dateOutputFormat = session.ParameterMap[SFSessionParameter.DATE_OUTPUT_FORMAT].ToString();
-            timeOutputFormat = session.ParameterMap[SFSessionParameter.TIME_OUTPUT_FORMAT].ToString();
+            if (session.ParameterMap.ContainsKey(SFSessionParameter.DATE_OUTPUT_FORMAT))
+            {
+                dateOutputFormat = session.ParameterMap[SFSessionParameter.DATE_OUTPUT_FORMAT].ToString();
+            }
+            if (session.ParameterMap.ContainsKey(SFSessionParameter.TIME_OUTPUT_FORMAT))
+            {
+                timeOutputFormat = session.ParameterMap[SFSessionParameter.TIME_OUTPUT_FORMAT].ToString();
+            }
         }
 
         internal SFResultSetMetaData(PutGetResponseData putGetResponseData)

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -380,6 +380,13 @@ namespace Snowflake.Data.Core
         internal void UpdateSessionParameterMap(List<NameValueParameter> parameterList)
         {
             logger.Debug("Update parameter map");
+            // with HTAP parameter removal parameters might not returned
+            // query response
+            if (parameterList is null)
+            {
+                return;
+            }
+
             foreach (NameValueParameter parameter in parameterList)
             {
                 if (Enum.TryParse(parameter.name, out SFSessionParameter parameterName))
@@ -432,8 +439,16 @@ namespace Snowflake.Data.Core
 
         internal void UpdateDatabaseAndSchema(string databaseName, string schemaName)
         {
-            this.database = databaseName;
-            this.schema = schemaName;
+            // with HTAP session metadata removal database/schema
+            // might be not returened in query result
+            if (databaseName != null)
+            {
+                this.database = databaseName;
+            }
+            if (schemaName != null)
+            {
+                this.schema = schemaName;
+            }
         }
         
         internal void startHeartBeatForThisSession()

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -441,11 +441,11 @@ namespace Snowflake.Data.Core
         {
             // with HTAP session metadata removal database/schema
             // might be not returened in query result
-            if (databaseName != null)
+            if (!String.IsNullOrEmpty(databaseName))
             {
                 this.database = databaseName;
             }
-            if (schemaName != null)
+            if (!String.IsNullOrEmpty(schemaName))
             {
                 this.schema = schemaName;
             }

--- a/Snowflake.Data/Core/Session/SFSessionParameter.cs
+++ b/Snowflake.Data/Core/Session/SFSessionParameter.cs
@@ -12,5 +12,7 @@ namespace Snowflake.Data.Core
         CLIENT_STAGE_ARRAY_BINDING_THRESHOLD,
         CLIENT_SESSION_KEEP_ALIVE,
         QUERY_CONTEXT_CACHE_SIZE,
+        DATE_OUTPUT_FORMAT,
+        TIME_OUTPUT_FORMAT,
     }
 }


### PR DESCRIPTION
### Description
sdk issue 693
Some cases for HTAP metadata/parameter removal was missed in September release. Fix them and add test case as well.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name