### PR TITLE
pool/SNOW-902608 #2/4 new pool version v2

### DIFF
--- a/CodingConventions.md
+++ b/CodingConventions.md
@@ -85,6 +85,18 @@ public class ExampleClass
 }
 ```
 
+#### Property
+
+Use PascalCase, eg. `SomeProperty`.
+
+```csharp
+public ExampleProperty
+{
+    get;
+    set;
+}
+```
+
 ### Local variables
 
 Use camelCase, eg. `someVariable`.

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
+
+using System.Collections.Generic;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Moq;
+using Snowflake.Data.Client;
+using Snowflake.Data.Tests.Util;
+
+namespace Snowflake.Data.Tests.UnitTests
+{
+    [TestFixture, NonParallelizable]
+    class ConnectionPoolManagerTest
+    {
+        private readonly ConnectionPoolManager _connectionPoolManager = new ConnectionPoolManager();
+        private const string ConnectionString1 = "database=D1;warehouse=W1;account=A1;user=U1;password=P1;role=R1;";
+        private const string ConnectionString2 = "database=D2;warehouse=W2;account=A2;user=U2;password=P2;role=R2;";
+        private readonly SecureString _password = new SecureString();
+        private static PoolConfig s_poolConfig;
+
+        [OneTimeSetUp] 
+        public static void BeforeAllTests()
+        {
+            s_poolConfig = new PoolConfig();
+            SnowflakeDbConnectionPool.SetConnectionPoolVersion(ConnectionPoolType.MultipleConnectionPool);
+            SessionPool.SessionFactory = new MockSessionFactory();
+        }
+        
+        [OneTimeTearDown]
+        public void AfterAllTests()
+        {
+            s_poolConfig.Reset();
+            SessionPool.SessionFactory = new SessionFactory();
+        }
+
+        [Test]
+        public void TestPoolManagerReturnsSessionPoolForGivenConnectionString()
+        {
+            // Act
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            
+            // Assert
+            Assert.AreEqual(ConnectionString1, sessionPool.ConnectionString);
+            Assert.AreEqual(_password, sessionPool.Password);
+        }
+        
+        [Test]
+        public void TestPoolManagerReturnsSamePoolForGivenConnectionString()
+        {
+            // Arrange
+            var anotherConnectionString = ConnectionString1;
+            
+            // Act
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(anotherConnectionString, _password);
+            
+            // Assert
+            Assert.AreEqual(sessionPool1, sessionPool2);
+        }
+        
+        [Test]
+        public void TestDifferentPoolsAreReturnedForDifferentConnectionStrings()
+        {
+            // Arrange
+            Assert.AreNotSame(ConnectionString1, ConnectionString2);
+            
+            // Act
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            
+            // Assert
+            Assert.AreNotSame(sessionPool1, sessionPool2);
+            Assert.AreEqual(ConnectionString1, sessionPool1.ConnectionString);
+            Assert.AreEqual(ConnectionString2, sessionPool2.ConnectionString);
+        }
+        
+                
+        [Test]
+        public void TestGetSessionWorksForSpecifiedConnectionString()
+        {
+            // Act
+            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, _password);
+            
+            // Assert
+            Assert.AreEqual(ConnectionString1, sfSession.ConnectionString);
+            Assert.AreEqual(_password, sfSession.Password);
+        }
+
+        [Test]
+        public async Task TestGetSessionAsyncWorksForSpecifiedConnectionString()
+        {
+            // Act
+            var sfSession = await _connectionPoolManager.GetSessionAsync(ConnectionString1, _password, CancellationToken.None);
+            
+            // Assert
+            Assert.AreEqual(ConnectionString1, sfSession.ConnectionString);
+            Assert.AreEqual(_password, sfSession.Password);
+        }
+
+        [Test]
+        [Ignore("Enable after completion of SNOW-937189")] // TODO: 
+        public void TestCountingOfSessionProvidedByPool()
+        {
+            // Act
+            _connectionPoolManager.GetSession(ConnectionString1, _password);
+            
+            // Assert
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            Assert.AreEqual(1, sessionPool.GetCurrentPoolSize());
+        }
+        
+        [Test]
+        public void TestCountingOfSessionReturnedBackToPool()
+        {
+            // Arrange
+            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, _password);
+            
+            // Act
+            _connectionPoolManager.AddSession(sfSession);
+            
+            // Assert
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            Assert.AreEqual(1, sessionPool.GetCurrentPoolSize());
+        }
+
+        [Test]
+        public void TestSetMaxPoolSizeForAllPools()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+
+            // Act
+            _connectionPoolManager.SetMaxPoolSize(3);
+
+            // Assert
+            Assert.AreEqual(3, sessionPool1.GetMaxPoolSize());
+            Assert.AreEqual(3, sessionPool2.GetMaxPoolSize());
+        }
+         
+        [Test]
+        public void TestSetTimeoutForAllPools()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            
+            // Act
+            _connectionPoolManager.SetTimeout(3000);
+            
+            // Assert
+            Assert.AreEqual(3000, sessionPool1.GetTimeout());
+            Assert.AreEqual(3000, sessionPool2.GetTimeout());
+        }         
+        
+        [Test]
+        public void TestSetPoolingDisabledForAllPools()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+
+            // Act
+            _connectionPoolManager.SetPooling(false);
+            
+            // Assert
+            Assert.AreEqual(false, sessionPool1.GetPooling());
+        }
+        
+        [Test]
+        public void TestSetPoolingEnabledBack()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            _connectionPoolManager.SetPooling(false);
+          
+            // Act
+            _connectionPoolManager.SetPooling(true);
+            
+            // Assert
+            Assert.AreEqual(true, sessionPool1.GetPooling());
+        }
+
+        [Test]
+        public void TestGetPoolingOnManagerLevelWhenNotAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetPooling(true);
+            sessionPool2.SetPooling(false);
+            
+            // Act/Assert
+            var exception = Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetPooling());
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
+            Assert.IsTrue(exception.Message.Contains("Multiple pools have different Pooling values"));
+        }
+
+        [Test]
+        public void TestGetPoolingOnManagerLevelWorksWhenAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetPooling(true);
+            sessionPool2.SetPooling(true);
+            
+            // Act/Assert
+            Assert.AreEqual(true,_connectionPoolManager.GetPooling());
+        }
+
+        [Test]
+        public void TestGetTimeoutOnManagerLevelWhenNotAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetTimeout(299);
+            sessionPool2.SetTimeout(1313);
+            
+            // Act/Assert
+            var exception = Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetTimeout());
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
+            Assert.IsTrue(exception.Message.Contains("Multiple pools have different Timeout values"));
+        }
+
+        [Test]
+        public void TestGetTimeoutOnManagerLevelWhenAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetTimeout(3600);
+            sessionPool2.SetTimeout(3600);
+            
+            // Act/Assert
+            Assert.AreEqual(3600,_connectionPoolManager.GetTimeout());
+        }
+
+        [Test]
+        public void TestGetMaxPoolSizeOnManagerLevelWhenNotAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetMaxPoolSize(1);
+            sessionPool2.SetMaxPoolSize(17);
+            
+            // Act/Assert
+            var exception = Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetMaxPoolSize());
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
+            Assert.IsTrue(exception.Message.Contains("Multiple pools have different Max Pool Size values"));
+        }
+        
+        [Test]
+        public void TestGetMaxPoolSizeOnManagerLevelWhenAllPoolsEqual()
+        {
+            // Arrange
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password);
+            sessionPool1.SetMaxPoolSize(33);
+            sessionPool2.SetMaxPoolSize(33);
+            
+            // Act/Assert
+            Assert.AreEqual(33,_connectionPoolManager.GetMaxPoolSize());
+        }
+
+        [Test]
+        public void TestGetCurrentPoolSizeThrowsExceptionWhenNotAllPoolsEqual()
+        {
+            // Arrange
+            EnsurePoolSize(ConnectionString1, 2);
+            EnsurePoolSize(ConnectionString2, 3);
+            
+            // Act/Assert
+            var exception = Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetCurrentPoolSize());
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
+            Assert.IsTrue(exception.Message.Contains("Multiple pools have different Current Pool Size values"));
+        }
+        
+        private void EnsurePoolSize(string connectionString, int requiredCurrentSize)
+        {
+            var sessionPool = _connectionPoolManager.GetPool(connectionString, _password);
+            sessionPool.SetMaxPoolSize(requiredCurrentSize);
+            var busySessions = new List<SFSession>();
+            for (var i = 0; i < requiredCurrentSize; i++)
+            {
+                var sfSession = _connectionPoolManager.GetSession(connectionString, _password);
+                busySessions.Add(sfSession);
+            }
+
+            foreach (var session in busySessions) // TODO: remove after SNOW-937189 since sessions will be already counted by GetCurrentPool size
+            {
+                session.close();
+                _connectionPoolManager.AddSession(session);
+            }
+            
+            Assert.AreEqual(requiredCurrentSize, sessionPool.GetCurrentPoolSize());
+        }
+    }
+
+    class MockSessionFactory : ISessionFactory
+    {
+        public SFSession NewSession(string connectionString, SecureString password)
+        {
+            var mockSfSession = new Mock<SFSession>(connectionString, password);
+            mockSfSession.Setup(x => x.Open()).Verifiable();
+            mockSfSession.Setup(x => x.OpenAsync(default)).Returns(Task.FromResult(this));
+            mockSfSession.Setup(x => x.IsNotOpen()).Returns(false);
+            mockSfSession.Setup(x => x.IsExpired(It.IsAny<long>(), It.IsAny<long>())).Returns(false);
+            return mockSfSession.Object;
+        }
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionPoolTest.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core.Session;
+
+namespace Snowflake.Data.Tests.UnitTests
+{
+    public class SnowflakeDbConnectionPoolTest
+    {
+        private readonly string _connectionString1 = "database=D1;warehouse=W1;account=A1;user=U1;password=P1;role=R1;";
+        private readonly string _connectionString2 = "database=D2;warehouse=W2;account=A2;user=U2;password=P2;role=R2;";
+
+        [Test]
+        public void TestRevertPoolToPreviousVersion()
+        {
+            // act
+            SnowflakeDbConnectionPool.SetOldConnectionPoolVersion();
+            
+            // assert
+            var sessionPool1 = SnowflakeDbConnectionPool.GetPool(_connectionString1);
+            var sessionPool2 = SnowflakeDbConnectionPool.GetPool(_connectionString2);
+            Assert.AreEqual(ConnectionPoolType.SingleConnectionCache, SnowflakeDbConnectionPool.GetConnectionPoolVersion());
+            Assert.AreEqual(sessionPool1, sessionPool2);
+        }
+    }
+}

--- a/Snowflake.Data.Tests/Util/PoolConfig.cs
+++ b/Snowflake.Data.Tests/Util/PoolConfig.cs
@@ -3,6 +3,7 @@
  */
 
 using Snowflake.Data.Client;
+using Snowflake.Data.Core.Session;
 
 namespace Snowflake.Data.Tests.Util
 {
@@ -11,16 +12,19 @@ namespace Snowflake.Data.Tests.Util
         private readonly bool _pooling;
         private readonly long _timeout;
         private readonly int _maxPoolSize;
+        private readonly ConnectionPoolType _connectionPoolType;
 
         public PoolConfig()
         {
             _maxPoolSize = SnowflakeDbConnectionPool.GetMaxPoolSize();
             _timeout = SnowflakeDbConnectionPool.GetTimeout();
             _pooling = SnowflakeDbConnectionPool.GetPooling();
+            _connectionPoolType = SnowflakeDbConnectionPool.GetConnectionPoolVersion();
         }
 
         public void Reset()
         {
+            SnowflakeDbConnectionPool.SetConnectionPoolVersion(_connectionPoolType);
             SnowflakeDbConnectionPool.SetMaxPoolSize(_maxPoolSize);
             SnowflakeDbConnectionPool.SetTimeout(_timeout);
             SnowflakeDbConnectionPool.SetPooling(_pooling);

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
+using System;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,72 +15,127 @@ namespace Snowflake.Data.Client
     public class SnowflakeDbConnectionPool
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SnowflakeDbConnectionPool>();
-        private static readonly IConnectionManager s_connectionManager = new ConnectionCacheManager();
+        private static readonly Object s_connectionManagerInstanceLock = new Object();
+        private static IConnectionManager s_connectionManager;
+        private const ConnectionPoolType DefaultConnectionPoolType = ConnectionPoolType.SingleConnectionCache; // TODO: set to MultipleConnectionPool once development of entire ConnectionPoolManager epic is complete
+
+        private static IConnectionManager ConnectionManager
+        {
+            get
+            {
+                if (s_connectionManager != null)
+                    return s_connectionManager;
+                SetConnectionPoolVersion(DefaultConnectionPoolType);
+                return s_connectionManager;
+            }
+        }
         
         internal static SFSession GetSession(string connectionString, SecureString password)
         {
-            s_logger.Debug("SnowflakeDbConnectionPool::GetSession");
-            return s_connectionManager.GetSession(connectionString, password);
+            s_logger.Debug($"SnowflakeDbConnectionPool::GetSession");
+            return ConnectionManager.GetSession(connectionString, password);
         }
         
         internal static Task<SFSession> GetSessionAsync(string connectionString, SecureString password, CancellationToken cancellationToken)
         {
-            s_logger.Debug("SnowflakeDbConnectionPool::GetSessionAsync");
-            return s_connectionManager.GetSessionAsync(connectionString, password, cancellationToken);
+            s_logger.Debug($"SnowflakeDbConnectionPool::GetSessionAsync");
+            return ConnectionManager.GetSessionAsync(connectionString, password, cancellationToken);
+        }
+
+        internal static SessionPool GetPool(string connectionString)
+        {
+            s_logger.Debug($"SnowflakeDbConnectionPool::GetPool");
+            return ConnectionManager.GetPool(connectionString);
         }
         
         internal static bool AddSession(SFSession session)
         {
             s_logger.Debug("SnowflakeDbConnectionPool::AddSession");
-            return s_connectionManager.AddSession(session);
+            return ConnectionManager.AddSession(session);
         }
 
         public static void ClearAllPools()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::ClearAllPools");
-            s_connectionManager.ClearAllPools();
+            ConnectionManager.ClearAllPools();
         }
 
         public static void SetMaxPoolSize(int maxPoolSize)
         {
             s_logger.Debug("SnowflakeDbConnectionPool::SetMaxPoolSize");
-            s_connectionManager.SetMaxPoolSize(maxPoolSize);
+            ConnectionManager.SetMaxPoolSize(maxPoolSize);
         }
 
         public static int GetMaxPoolSize()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::GetMaxPoolSize");
-            return s_connectionManager.GetMaxPoolSize();
+            return ConnectionManager.GetMaxPoolSize();
         }
 
         public static void SetTimeout(long connectionTimeout)
         {
             s_logger.Debug("SnowflakeDbConnectionPool::SetTimeout");
-            s_connectionManager.SetTimeout(connectionTimeout);
+            ConnectionManager.SetTimeout(connectionTimeout);
         }
         
         public static long GetTimeout()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::GetTimeout");
-            return s_connectionManager.GetTimeout();
+            return ConnectionManager.GetTimeout();
         }
 
         public static int GetCurrentPoolSize()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::GetCurrentPoolSize");
-            return s_connectionManager.GetCurrentPoolSize();
+            return ConnectionManager.GetCurrentPoolSize();
         }
 
         public static bool SetPooling(bool isEnable)
         {
             s_logger.Debug("SnowflakeDbConnectionPool::SetPooling");
-            return s_connectionManager.SetPooling(isEnable);
+            return ConnectionManager.SetPooling(isEnable);
         }
 
         public static bool GetPooling()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::GetPooling");
-            return s_connectionManager.GetPooling();
+            return ConnectionManager.GetPooling();
+        }
+
+        internal static void SetOldConnectionPoolVersion() // TODO: set to public once development of entire ConnectionPoolManager epic is complete
+        {
+            SetConnectionPoolVersion(ConnectionPoolType.SingleConnectionCache);   
+        }
+
+        internal static void SetConnectionPoolVersion(ConnectionPoolType requestedPoolType)
+        {
+            lock (s_connectionManagerInstanceLock)
+            {
+                s_connectionManager?.ClearAllPools();
+                if (requestedPoolType == ConnectionPoolType.MultipleConnectionPool)
+                {
+                    s_connectionManager = new ConnectionPoolManager();
+                    s_logger.Info("SnowflakeDbConnectionPool - multiple connection pools enabled");
+                }
+                if (requestedPoolType == ConnectionPoolType.SingleConnectionCache)
+                {
+                    s_connectionManager = new ConnectionCacheManager();
+                    s_logger.Warn("SnowflakeDbConnectionPool - connection cache enabled");
+                }
+            }
+        }
+
+        internal static ConnectionPoolType GetConnectionPoolVersion()
+        {
+            if (ConnectionManager != null)
+            {
+                switch (ConnectionManager)
+                {
+                    case ConnectionCacheManager _: return ConnectionPoolType.SingleConnectionCache;
+                    case ConnectionPoolManager _: return ConnectionPoolType.MultipleConnectionPool;
+                }
+            }
+            return DefaultConnectionPoolType;
         }
     }
 }

--- a/Snowflake.Data/Core/ErrorMessages.resx
+++ b/Snowflake.Data/Core/ErrorMessages.resx
@@ -183,4 +183,7 @@
   <data name="BROWSER_RESPONSE_TIMEOUT" xml:space="preserve">
     <value>Browser response timed out after {0} seconds.</value>
   </data>
+  <data name="INCONSISTENT_RESULT_ERROR" xml:space="preserve">
+    <value>Cannot return result set as a scalar value: {0}</value>
+  </data>
 </root>

--- a/Snowflake.Data/Core/SFError.cs
+++ b/Snowflake.Data/Core/SFError.cs
@@ -78,6 +78,9 @@ namespace Snowflake.Data.Core
 
         [SFErrorAttr(errorCode = 270057)]
         BROWSER_RESPONSE_TIMEOUT,
+        
+        [SFErrorAttr(errorCode = 270058)]
+        INCONSISTENT_RESULT_ERROR,
     }
 
     class SFErrorAttr : Attribute

--- a/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ */
+
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,7 +10,7 @@ namespace Snowflake.Data.Core.Session
 {
     internal sealed class ConnectionCacheManager : IConnectionManager
     {
-        private readonly SessionPool _sessionPool = new SessionPool();
+        private readonly SessionPool _sessionPool = SessionPool.CreateSessionCache();
         public SFSession GetSession(string connectionString, SecureString password) => _sessionPool.GetSession(connectionString, password);
         public Task<SFSession> GetSessionAsync(string connectionString, SecureString password, CancellationToken cancellationToken)
             => _sessionPool.GetSessionAsync(connectionString, password, cancellationToken);
@@ -19,5 +23,6 @@ namespace Snowflake.Data.Core.Session
         public int GetCurrentPoolSize() => _sessionPool.GetCurrentPoolSize();
         public bool SetPooling(bool poolingEnabled) => _sessionPool.SetPooling(poolingEnabled);
         public bool GetPooling() => _sessionPool.GetPooling();
+        public SessionPool GetPool(string _) => _sessionPool;
     }
 }

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Data.Client;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Core.Session
+{
+    internal sealed class ConnectionPoolManager : IConnectionManager
+    {
+        private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<ConnectionPoolManager>();
+        private static readonly Object s_poolsLock = new Object();
+        private readonly Dictionary<string, SessionPool> _pools;
+
+        internal ConnectionPoolManager()
+        {
+            lock (s_poolsLock)
+            {
+                _pools = new Dictionary<string, SessionPool>();
+            }
+        }
+        
+        public SFSession GetSession(string connectionString, SecureString password)
+        {
+            s_logger.Debug($"ConnectionPoolManager::GetSession");
+            return GetPool(connectionString, password).GetSession();
+        }
+
+        public Task<SFSession> GetSessionAsync(string connectionString, SecureString password, CancellationToken cancellationToken)
+        {
+            s_logger.Debug($"ConnectionPoolManager::GetSessionAsync");
+            return GetPool(connectionString, password).GetSessionAsync(cancellationToken);
+        }
+
+        public bool AddSession(SFSession session)
+        {
+            s_logger.Debug($"ConnectionPoolManager::AddSession for {session.ConnectionString}");
+            return GetPool(session.ConnectionString, session.Password).AddSession(session);
+        }
+
+        public void ClearAllPools()
+        {
+            s_logger.Debug("ConnectionPoolManager::ClearAllPools");
+            foreach (var sessionPool in _pools.Values)
+            {
+                sessionPool.ClearAllPools();       
+            }
+            _pools.Clear();
+        }
+        
+        public void SetMaxPoolSize(int maxPoolSize)
+        {
+            s_logger.Debug("ConnectionPoolManager::SetMaxPoolSize for all pools");
+            foreach (var pool in _pools.Values)
+            {
+                pool.SetMaxPoolSize(maxPoolSize);
+            }
+        }
+
+        public int GetMaxPoolSize()
+        {
+            s_logger.Debug("ConnectionPoolManager::GetMaxPoolSize");
+            var values = _pools.Values.Select(it => it.GetMaxPoolSize()).Distinct().ToList();
+            return values.Count == 1
+                ? values.First()
+                : throw new SnowflakeDbException(SFError.INCONSISTENT_RESULT_ERROR, "Multiple pools have different Max Pool Size values");
+        }
+
+        public void SetTimeout(long connectionTimeout)
+        {
+            s_logger.Debug("ConnectionPoolManager::SetTimeout for all pools");
+            foreach (var pool in _pools.Values)
+            {
+                pool.SetTimeout(connectionTimeout);
+            }
+        }
+
+        public long GetTimeout()
+        {
+            s_logger.Debug("ConnectionPoolManager::GetTimeout");
+            var values = _pools.Values.Select(it => it.GetTimeout()).Distinct().ToList();
+            return values.Count == 1
+                ? values.First()
+                : throw new SnowflakeDbException(SFError.INCONSISTENT_RESULT_ERROR, "Multiple pools have different Timeout values");
+        }
+
+        public int GetCurrentPoolSize()
+        {
+            s_logger.Debug("ConnectionPoolManager::GetCurrentPoolSize");
+            var values = _pools.Values.Select(it => it.GetCurrentPoolSize()).Distinct().ToList();
+            return values.Count == 1
+                ? values.First()
+                : throw new SnowflakeDbException(SFError.INCONSISTENT_RESULT_ERROR, "Multiple pools have different Current Pool Size values");
+        }
+
+        public bool SetPooling(bool poolingEnabled)
+        {
+            s_logger.Debug("ConnectionPoolManager::SetPooling for all pools");
+            return _pools.Values
+                .Select(pool => pool.SetPooling(poolingEnabled))
+                .All(setPoolingResult => setPoolingResult);
+        }
+
+        public bool GetPooling() 
+        {
+            s_logger.Debug("ConnectionPoolManager::GetPooling");
+            var values = _pools.Values.Select(it => it.GetPooling()).Distinct().ToList();
+            return values.Count == 1
+                ? values.First()
+                : throw new SnowflakeDbException(SFError.INCONSISTENT_RESULT_ERROR, "Multiple pools have different Pooling values");
+        }
+
+        internal SessionPool GetPool(string connectionString, SecureString password)
+        {
+            s_logger.Debug($"ConnectionPoolManager::GetPool");
+            var poolKey = GetPoolKey(connectionString);
+            
+            if (_pools.TryGetValue(poolKey, out var item))
+                return item;
+            lock (s_poolsLock)
+            {
+                if (_pools.TryGetValue(poolKey, out var poolCreatedWhileWaitingOnLock))
+                    return poolCreatedWhileWaitingOnLock;
+                s_logger.Info($"Creating new pool");
+                var pool = SessionPool.CreateSessionPool(connectionString, password);
+                _pools.Add(poolKey, pool);
+                return pool;
+            }
+        }
+
+        public SessionPool GetPool(string connectionString)
+        {
+            s_logger.Debug($"ConnectionPoolManager::GetPool");
+            return GetPool(connectionString, null);
+        }
+
+        // TODO: SNOW-937188 
+        private string GetPoolKey(string connectionString)
+        {
+            return connectionString;
+        }
+    }
+}

--- a/Snowflake.Data/Core/Session/ConnectionPoolType.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolType.cs
@@ -1,0 +1,8 @@
+namespace Snowflake.Data.Core.Session
+{
+    internal enum ConnectionPoolType
+    {
+        SingleConnectionCache,
+        MultipleConnectionPool
+    }
+}

--- a/Snowflake.Data/Core/Session/IConnectionManager.cs
+++ b/Snowflake.Data/Core/Session/IConnectionManager.cs
@@ -21,5 +21,6 @@ namespace Snowflake.Data.Core.Session
         int GetCurrentPoolSize();
         bool SetPooling(bool poolingEnabled);
         bool GetPooling();
+        SessionPool GetPool(string connectionString);
     }
 }

--- a/Snowflake.Data/Core/Session/ISessionFactory.cs
+++ b/Snowflake.Data/Core/Session/ISessionFactory.cs
@@ -1,0 +1,9 @@
+using System.Security;
+
+namespace Snowflake.Data.Core.Session
+{
+    internal interface ISessionFactory
+    {
+        SFSession NewSession(string connectionString, SecureString password);
+    }
+}

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
 using System;
@@ -15,7 +15,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.Text.RegularExpressions;
-using Snowflake.Data.Configuration;
 
 namespace Snowflake.Data.Core
 {
@@ -69,7 +68,8 @@ namespace Snowflake.Data.Core
         private readonly EasyLoggingStarter _easyLoggingStarter = EasyLoggingStarter.Instance;
 
         private long _startTime = 0;
-        internal string connStr = null;
+        internal string ConnectionString { get; }
+        internal SecureString Password { get; }
 
         private QueryContextCache _queryContextCache = new QueryContextCache(_defaultQueryContextCacheSize);
 
@@ -145,8 +145,9 @@ namespace Snowflake.Data.Core
             EasyLoggingStarter easyLoggingStarter)
         {
             _easyLoggingStarter = easyLoggingStarter;
-            connStr = connectionString;
-            properties = SFSessionProperties.parseConnectionString(connectionString, password);
+            ConnectionString = connectionString;
+            Password = password;
+            properties = SFSessionProperties.parseConnectionString(ConnectionString, Password);
             _disableQueryContextCache = bool.Parse(properties[SFSessionProperty.DISABLEQUERYCONTEXTCACHE]);
             ValidateApplicationName(properties);
             try
@@ -215,7 +216,7 @@ namespace Snowflake.Data.Core
             return uriBuilder.Uri;
         }
 
-        internal void Open()
+        internal virtual void Open()
         {
             logger.Debug("Open Session");
 
@@ -227,7 +228,7 @@ namespace Snowflake.Data.Core
             authenticator.Authenticate();
         }
 
-        internal async Task OpenAsync(CancellationToken cancellationToken)
+        internal virtual async Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Session Async");
 
@@ -557,12 +558,12 @@ namespace Snowflake.Data.Core
             }
         }
 
-        internal bool IsNotOpen()
+        internal virtual bool IsNotOpen()
         {
             return _startTime == 0;
         }
 
-        internal bool IsExpired(long timeoutInSeconds, long utcTimeInSeconds)
+        internal virtual bool IsExpired(long timeoutInSeconds, long utcTimeInSeconds)
         {
             return _startTime + timeoutInSeconds <= utcTimeInSeconds;
         }

--- a/Snowflake.Data/Core/Session/SessionFactory.cs
+++ b/Snowflake.Data/Core/Session/SessionFactory.cs
@@ -1,0 +1,12 @@
+using System.Security;
+
+namespace Snowflake.Data.Core.Session
+{
+    internal class SessionFactory : ISessionFactory
+    {
+        public SFSession NewSession(string connectionString, SecureString password)
+        {
+            return new SFSession(connectionString, password);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Connection Pool v2
- introduction of connection manager handling multiple pool of sessions
- ability to switch Connection Manager between v1 and v2
- controlling pool settings for each pool independently
- default pool version: v1

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name