### PR TITLE
Add the "https://" prefix even if the endpoint isn't surrounded by brackets

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -316,10 +316,10 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 if(start > -1 && end > -1 && end > start)
                 {
                     endpoint = endpoint.Substring(start + 1, end - start - 1);
-                    if(!endpoint.Contains("https"))
-                    {
-                        endpoint = "https://" + endpoint;
-                    }
+                }
+                if (!endpoint.Contains("https"))
+                {
+                    endpoint = "https://" + endpoint;
                 }
                 clientConfig.ServiceURL = endpoint;
             }


### PR DESCRIPTION
### Description
This currently throws an exception when setting the ServiceURL property if the endpoint is not surrounded by brackets. I moved the code that adds the "https://" prefix outside of the code that removes the surrounding brackets so that it is always included when there's an endpoint.


### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name