### PR TITLE
SNOW-914532: Fix variable name in ClearAllPoolsAsync

### DIFF
--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -196,11 +196,11 @@ namespace Snowflake.Data.Core.Session
         internal async void ClearAllPoolsAsync()
         {
             s_logger.Debug("SessionPool::ClearAllPoolsAsync");
-            foreach (SFSession session in _sessionPool)
+            foreach (SFSession session in _sessions)
             {
                 await session.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
-            _sessionPool.Clear();
+            _sessions.Clear();
         }
 
         public void SetMaxPoolSize(int size)


### PR DESCRIPTION
### Description

The PR renames the variable to the correct name for ClearAllPoolsAsync

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name