### PR TITLE
SNOW-856231 easy logging - not fail on directory serch error

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -137,6 +137,7 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
             
             // assert
             Assert.IsNull(filePath);
+            t_environmentOperations.Verify(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile), Times.Once);
         }
         
         [Test]
@@ -150,6 +151,7 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
             
             // assert
             Assert.IsNull(filePath);
+            t_environmentOperations.Verify(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile), Times.Once);
         }
 
         private static void MockHomeDirectory()

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -127,13 +127,24 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
         }
 
         [Test]
-        public void TestThatReturnsNullIfDirectoryBasedSearchFailsWithUnexpectedError()
+        public void TestThatDoesNotFailWhenSearchForOneOfDirectoriesFails()
         {
             // arrange
-            t_environmentOperations
-                .Setup(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile))
-                .Throws(() => new Exception("No home directory"));
+            MockHomeDirectoryFails();
+
+            // act
+            var filePath = t_finder.FindConfigFilePath(null);
             
+            // assert
+            Assert.IsNull(filePath);
+        }
+        
+        [Test]
+        public void TestThatDoesNotFailWhenOneOfDirectoriesNotDefined()
+        {
+            // arrange
+            MockHomeDirectoryReturnsNull();
+
             // act
             var filePath = t_finder.FindConfigFilePath(null);
             
@@ -146,6 +157,20 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
             t_environmentOperations
                 .Setup(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile))
                 .Returns(HomeDirectory);
+        }
+
+        private static void MockHomeDirectoryFails()
+        {
+            t_environmentOperations
+                .Setup(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile))
+                .Throws(() => new Exception("No home directory"));
+        }
+
+        private static void MockHomeDirectoryReturnsNull()
+        {
+            t_environmentOperations
+                .Setup(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile))
+                .Returns((string) null);
         }
 
         private static void MockFileFromEnvironmentalVariable()

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -126,6 +126,21 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
             Assert.IsNull(filePath);
         }
 
+        [Test]
+        public void TestThatReturnsNullIfDirectoryBasedSearchFailsWithUnexpectedError()
+        {
+            // arrange
+            t_environmentOperations
+                .Setup(e => e.GetFolderPath(Environment.SpecialFolder.UserProfile))
+                .Throws(() => new Exception("No home directory"));
+            
+            // act
+            var filePath = t_finder.FindConfigFilePath(null);
+            
+            // assert
+            Assert.IsNull(filePath);
+        }
+
         private static void MockHomeDirectory()
         {
             t_environmentOperations


### PR DESCRIPTION
### Description
Prevent to fail if client config file could not be found because of an unexpected error during the phase of searching in predefined directory. It could happen if for example there is no home folder in the operating system.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name