### PR TITLE
SNOW-957736: Fix SnowflakeDbConnection.Dispose behaviour

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Data.Client
         
         internal int _connectionTimeout;
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         private static Mutex _arraybindingMutex = new Mutex();
 
@@ -361,20 +361,29 @@ namespace Snowflake.Data.Client
 
         protected override void Dispose(bool disposing)
         {
-            if (disposed)
-                return;
-
-            try
+            if (!_disposed)
             {
-                this.Close();
-            } 
-            catch (Exception ex)
-            {
-                // Prevent an exception from being thrown when disposing of this object
-                logger.Error("Unable to close connection", ex);
+                if (disposing)
+                {
+                    try
+                    {
+                        Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Prevent an exception from being thrown when disposing of this object
+                        logger.Error("Unable to close connection", ex);
+                    }
+                }
+                else
+                {
+                    SfSession?.close();
+                    SfSession = null;
+                    _connectionState = ConnectionState.Closed;
+                }
+                
+                _disposed = true;
             }
-
-            disposed = true;
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
### Description
The connection which is not closed properly by the user should not enter the connection pool.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name