### PR TITLE
SNOW-974746 document that we currently do not support bind variables in multi-statement queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,8 @@ With version 2.0.18 and later of the .NET connector, you can send
 a batch of SQL statements, separated by semicolons,
 to be executed in a single request.
 
+**Note**: Snowflake does not currently support variable binding in multi-statement SQL requests.
+
 ---
 **Note**
 
@@ -554,6 +556,8 @@ using (DbCommand cmd = conn.CreateCommand())
 
 Bind Parameter
 --------------
+
+**Note**: Snowflake does not currently support variable binding in multi-statement SQL requests.
 
 This example shows how bound parameters are converted from C# data types to
 Snowflake data types. For example, if the data type of the Snowflake column


### PR DESCRIPTION
re: SNOW-974746 / #817 
document that we currently do not support bind variables in multi-statement queries, we're getting issues related to this

document-only change, based on https://docs.snowflake.com/en/developer-guide/sql-api/submitting-multiple-statements#specifying-multiple-sql-statements-in-the-request which sems to be valid for all the drivers