### PR TITLE
SNOW-950923 fix to provide QueryID for failures during GET/PUT file operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ using (IDbConnection conn = new SnowflakeDbConnection())
 
     }
 ```
-In case of a failure a SnowflakeDbException will be thrown and will provide QueryId.
+In case of a failure a SnowflakeDbException will be thrown with the affected QueryId.
 Inner exception (if applicable) will provide some details on the failure cause and
 it will be for example: FileNotFoundException, DirectoryNotFoundException.
 

--- a/README.md
+++ b/README.md
@@ -672,6 +672,66 @@ using (IDbConnection conn = new SnowflakeDbConnection())
 }
 ```
 
+PUT local files to stage
+------------------------
+
+PUT command can be used to upload files of a local directory or a single local file to the Snowflake stages (named, internal table stage or internal user stage).
+Such staging files can be used to load data into a table. 
+More on this topic: [File staging with PUT](https://docs.snowflake.com/en/sql-reference/sql/put).
+
+In the driver the command can be executed in a bellow way:
+```cs
+using (IDbConnection conn = new SnowflakeDbConnection())
+{
+    try
+    {
+	    conn.ConnectionString = "<connecting parameter>";
+	    conn.Open();
+	    var cmd = (SnowflakeDbCommand)conn.CreateCommand(); // cast allows get QueryId from the command
+	
+	    cmd.CommandText = $"PUT file://some_data.csv @my_schema.my_stage AUTO_COMPRESS=TRUE";
+	    var reader = cmd.ExecuteReader();
+	    Assert.IsTrue(reader.read()); // on success
+        Assert.DoesNotThrow(() => Guid.Parse(cmd.GetQueryId()));
+    }
+    catch (SnowflakeDbException e)
+    {
+        Assert.DoesNotThrow(() => Guid.Parse(e.QueryId)); // when failed
+        Assert.That(e.InnerException.GetType(), Is.EqualTo(typeof(FileNotFoundException)));
+
+    }
+```
+In case of a failure a SnowflakeDbException will be thrown and will provide QueryId.
+Inner exception (if applicable) will provide some details on the failure cause and
+it will be for example: FileNotFoundException, DirectoryNotFoundException.
+
+GET stage files
+---------------
+GET command allows to download stage directories or files to a local directory.
+It can be used in connection with named stage, table internal stage or user stage. 
+Detailed information on the command: [Downloading files with GET](https://docs.snowflake.com/en/sql-reference/sql/get).
+
+To use the command in a driver similar code can be executed in a client app:
+```cs
+    try
+    {
+	    conn.ConnectionString = "<connecting parameter>";
+	    conn.Open();
+	    var cmd = (SnowflakeDbCommand)conn.CreateCommand(); // cast allows get QueryId from the command
+	
+	    cmd.CommandText = $"GET @my_schema.my_stage/stage_file.csv file://local_file.csv AUTO_COMPRESS=TRUE";
+	    var reader = cmd.ExecuteReader();
+	    Assert.IsTrue(reader.read()); // if succeeded
+        Assert.DoesNotThrow(() => Guid.Parse(cmd.GetQueryId()));
+    }
+    catch (SnowflakeDbException e)
+    {
+        Assert.DoesNotThrow(() => Guid.Parse(e.QueryId)); // on failure
+    }
+```
+In case of a failure a SnowflakeDbException will be thrown or DBDataReader will return a False response.
+In any case QueryId should be available from the exception or command property.
+
 Close the Connection
 --------------------
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -505,7 +505,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     if (e.InnerException is SnowflakeDbException)
                     {
-                        SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
+                        SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.REQUEST_TIMEOUT);
 
                         stopwatch.Stop();
                         int delta = 10; // in case server time slower.
@@ -803,7 +803,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (SnowflakeDbException e)
                 {
-                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.UNKNOWN_AUTHENTICATOR);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e, SFError.UNKNOWN_AUTHENTICATOR);
                 }
 
             }
@@ -858,7 +858,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 catch (Exception e)
                 {
                     Assert.IsInstanceOf<SnowflakeDbException>(e);
-                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e, SFError.INTERNAL_ERROR);
                     Assert.IsTrue(e.Message.Contains(
                         $"The retry count has reached its limit of {expectedMaxRetryCount} and " +
                         $"the timeout elapsed has reached its limit of {expectedMaxConnectionTimeout} " +

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -505,8 +505,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     if (e.InnerException is SnowflakeDbException)
                     {
-                        Assert.AreEqual(SFError.REQUEST_TIMEOUT.GetAttribute<SFErrorAttr>().errorCode,
-                        ((SnowflakeDbException)e.InnerException).ErrorCode);
+                        SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
 
                         stopwatch.Stop();
                         int delta = 10; // in case server time slower.
@@ -804,7 +803,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (SnowflakeDbException e)
                 {
-                    Assert.AreEqual(SFError.UNKNOWN_AUTHENTICATOR.GetAttribute<SFErrorAttr>().errorCode, e.ErrorCode);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.UNKNOWN_AUTHENTICATOR);
                 }
 
             }
@@ -859,7 +858,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 catch (Exception e)
                 {
                     Assert.IsInstanceOf<SnowflakeDbException>(e);
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode, ((SnowflakeDbException)e).ErrorCode);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
                     Assert.IsTrue(e.Message.Contains(
                         $"The retry count has reached its limit of {expectedMaxRetryCount} and " +
                         $"the timeout elapsed has reached its limit of {expectedMaxConnectionTimeout} " +
@@ -1851,7 +1850,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new MockSnowflakeDbConnection())
             {
-                int timeoutSec = 15;
+                int timeoutSec = 5;
                 string loginTimeOut5sec = String.Format(ConnectionString + "connection_timeout={0};maxHttpRetries=0",
                     timeoutSec);
                 conn.ConnectionString = loginTimeOut5sec;
@@ -1866,9 +1865,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (AggregateException e)
                 {
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode,
-                        ((SnowflakeDbException)e.InnerException).ErrorCode);
-
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
                 }
                 stopwatch.Stop();
                 int delta = 10; // in case server time slower.
@@ -1904,9 +1901,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (AggregateException e)
                 {
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode,
-                        ((SnowflakeDbException)e.InnerException).ErrorCode);
-
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
                 }
                 stopwatch.Stop();
                 int delta = 10; // in case server time slower.
@@ -1939,8 +1934,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (AggregateException e)
                 {
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode,
-                        ((SnowflakeDbException)e.InnerException).ErrorCode);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
                 }
                 stopwatch.Stop();
                 int delta = 10; // in case server time slower.
@@ -2145,7 +2139,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 catch (Exception e)
                 {
                     Assert.IsInstanceOf<SnowflakeDbException>(e.InnerException);
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode, ((SnowflakeDbException)e.InnerException).ErrorCode);
+                    SnowflakeDbExceptionAssert.HasErrorCode(e.InnerException, SFError.INTERNAL_ERROR);
                     Exception oktaException;
 #if NETFRAMEWORK
                     oktaException = e.InnerException.InnerException.InnerException;

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1,8 +1,9 @@
 ﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
 using System.Data.Common;
+using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {
@@ -1841,7 +1842,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new MockSnowflakeDbConnection())
             {
-                int timeoutSec = 5;
+                int timeoutSec = 15;
                 string loginTimeOut5sec = String.Format(ConnectionString + "connection_timeout={0};maxHttpRetries=0",
                     timeoutSec);
                 conn.ConnectionString = loginTimeOut5sec;
@@ -1966,8 +1967,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 catch (AggregateException e)
                 {
-                    Assert.AreEqual(SFError.INTERNAL_ERROR.GetAttribute<SFErrorAttr>().errorCode,
-                        ((SnowflakeDbException)e.InnerException).ErrorCode);
+                    SnowflakeDbExceptionAssert.HasErrorCode((SnowflakeDbException)e.InnerException, SFError.INTERNAL_ERROR);
                 }
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -7,7 +7,6 @@ using System.Data;
 using System.Data.Common;
 using System.IO.Compression;
 using System.Text;
-using Castle.Components.DictionaryAdapter;
 using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.IntegrationTests
@@ -533,7 +532,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             String additionalAttribute = "", 
             ResultStatus expectedStatus = ResultStatus.UPLOADED)
         {
-            String queryId;
+            string queryId;
             using (var command = conn.CreateCommand())
             {
                 // Prepare PUT query

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -2,6 +2,9 @@
  * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
+using Amazon.S3.Transfer;
+using Snowflake.Data.Client;
+
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;
@@ -487,15 +490,17 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Set command to upload
             _responseData.command = CommandTypes.UPLOAD.ToString();
+            _responseData.queryId = Guid.NewGuid().ToString();
             _fileTransferAgent = new SFFileTransferAgent(_putQuery,
                 _session,
                 _responseData,
                 _cancellationToken);
 
             // Act
-            Exception ex = Assert.Throws<ArgumentException>(() => _fileTransferAgent.execute());
+            SnowflakeDbException ex = Assert.Throws<SnowflakeDbException>(() => _fileTransferAgent.execute());
 
             // Assert
+            Assert.AreEqual(_responseData.queryId, ex.QueryId);
             Assert.That(ex.Message, Does.Match($"No file found for: {tempUploadRootDirectory}\\*/{tempUploadSecondDirectory}\\*/{mockFileName}"));
 
             for (int i = 0; i < numberOfDirectories; i++)
@@ -579,17 +584,21 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Set command to download
             _responseData.command = CommandTypes.DOWNLOAD.ToString();
+            _responseData.queryId = Guid.NewGuid().ToString();
             _fileTransferAgent = new SFFileTransferAgent(GetQuery,
                 _session,
                 _responseData,
                 _cancellationToken);
 
             // Act
-            Exception ex = Assert.Throws<AggregateException>(() => _fileTransferAgent.execute());
+            SnowflakeDbException ex = Assert.Throws<SnowflakeDbException>(() => _fileTransferAgent.execute());
 
             // Assert
-            Assert.IsInstanceOf<FileNotFoundException>(ex.InnerException);
-            Assert.That(ex.InnerException.Message, Does.Match("Could not find file .*"));
+            Assert.AreEqual(_responseData.queryId, ex.QueryId);
+            Assert.IsInstanceOf<AggregateException>(ex.InnerException);
+            var innerException = ((AggregateException)ex.InnerException)?.InnerExceptions[0];
+            Assert.IsInstanceOf<FileNotFoundException>(innerException);
+            Assert.That(innerException?.Message, Does.Match("Could not find file .*"));
         }
 
         [Test]
@@ -606,17 +615,21 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Set command to download
             _responseData.command = CommandTypes.DOWNLOAD.ToString();
+            _responseData.queryId = Guid.NewGuid().ToString();
             _fileTransferAgent = new SFFileTransferAgent(GetQuery,
                 _session,
                 _responseData,
                 _cancellationToken);
 
             // Act
-            Exception ex = Assert.Throws<AggregateException>(() => _fileTransferAgent.execute());
+            SnowflakeDbException ex = Assert.Throws<SnowflakeDbException>(() => _fileTransferAgent.execute());
 
             // Assert
-            Assert.IsInstanceOf<DirectoryNotFoundException>(ex.InnerException);
-            Assert.That(ex.InnerException.Message, Does.Match("Could not find a part of the path .*"));
+            Assert.AreEqual(_responseData.queryId, ex.QueryId);
+            Assert.IsInstanceOf<AggregateException>(ex.InnerException);
+            var innerException = ((AggregateException)ex.InnerException)?.InnerExceptions[0];
+            Assert.IsInstanceOf<DirectoryNotFoundException>(innerException);
+            Assert.That(innerException?.Message, Does.Match("Could not find a part of the path .*"));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -4,6 +4,7 @@
 
 using Amazon.S3.Transfer;
 using Snowflake.Data.Client;
+using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.UnitTests
 {
@@ -311,7 +312,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        public void TestUploadWithWilcardInTheFilename()
+        public void TestUploadWithWildcardInTheFilename()
         {
             // Arrange
             UploadSetUpFile();
@@ -461,7 +462,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        public void TestUploadThrowsArgumentExceptionForMissingRootDirectoryWithWildcard()
+        public void TestUploadThrowsExceptionForMissingRootDirectoryWithWildcard()
         {
             // Arrange
             UploadSetUpFile();
@@ -501,6 +502,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.AreEqual(_responseData.queryId, ex.QueryId);
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.IO_ERROR_ON_GETPUT_COMMAND);
             Assert.That(ex.Message, Does.Match($"No file found for: {tempUploadRootDirectory}\\*/{tempUploadSecondDirectory}\\*/{mockFileName}"));
 
             for (int i = 0; i < numberOfDirectories; i++)
@@ -595,6 +597,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.AreEqual(_responseData.queryId, ex.QueryId);
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.IO_ERROR_ON_GETPUT_COMMAND);
             Assert.IsInstanceOf<AggregateException>(ex.InnerException);
             var innerException = ((AggregateException)ex.InnerException)?.InnerExceptions[0];
             Assert.IsInstanceOf<FileNotFoundException>(innerException);
@@ -626,6 +629,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.AreEqual(_responseData.queryId, ex.QueryId);
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.IO_ERROR_ON_GETPUT_COMMAND);
             Assert.IsInstanceOf<AggregateException>(ex.InnerException);
             var innerException = ((AggregateException)ex.InnerException)?.InnerExceptions[0];
             Assert.IsInstanceOf<DirectoryNotFoundException>(innerException);

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -2,7 +2,6 @@
  * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
-using Amazon.S3.Transfer;
 using Snowflake.Data.Client;
 using Snowflake.Data.Tests.Util;
 

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -70,7 +70,7 @@ namespace Snowflake.Data.Tests.UnitTests
         const string FileContent = "FTAFileContent";
 
         [SetUp]
-        public void BeforeTest()
+        public void BeforeEachTest()
         {
             // Base object's names on worker thread id
             var threadSuffix = TestContext.CurrentContext.WorkerId?.Replace('#', '_');
@@ -121,7 +121,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [TearDown]
-        public void AfterTest()
+        public void AfterEachTest()
         {
             // Delete stage directory recursively
             if (Directory.Exists(t_locationStage))

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -1,0 +1,14 @@
+using Snowflake.Data.Core;
+using Snowflake.Data.Client;
+using NUnit.Framework;
+
+namespace Snowflake.Data.Tests.Util
+{
+    public static class SnowflakeDbExceptionAssert
+    {
+        public static void HasErrorCode(SnowflakeDbException exception, SFError sfError)
+        {
+            Assert.AreEqual(exception.ErrorCode, sfError.GetAttribute<SFErrorAttr>().errorCode);
+        }
+    }
+}

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
 using Snowflake.Data.Core;
 using Snowflake.Data.Client;
 using NUnit.Framework;
@@ -9,6 +14,74 @@ namespace Snowflake.Data.Tests.Util
         public static void HasErrorCode(SnowflakeDbException exception, SFError sfError)
         {
             Assert.AreEqual(exception.ErrorCode, sfError.GetAttribute<SFErrorAttr>().errorCode);
+        }
+        
+        public static void HasErrorCode(Exception exception, SFError sfError)
+        {
+            Assert.NotNull(exception);
+            switch (exception)
+            {
+                case SnowflakeDbException snowflakeDbException:
+                    Assert.AreEqual(snowflakeDbException.ErrorCode, sfError.GetAttribute<SFErrorAttr>().errorCode);
+                    break;
+                default:
+                    Assert.Fail(exception.GetType() + " type is not " + typeof(SnowflakeDbException));
+                    break;
+            }
+        }
+
+        public static void HasHttpErrorCodeInExceptionChain(Exception exception, HttpStatusCode expected)
+        {
+            var exceptions = CollectExceptions(exception);
+            Assert.AreEqual(true,
+                exceptions.Any(e =>
+                {
+                    switch (e)
+                    {
+                        case SnowflakeDbException se:
+                            return se.ErrorCode == (int)expected;
+                        case HttpRequestException he:
+#if NETFRAMEWORK
+                            return he.Message.Contains(((int)expected).ToString());
+#else
+                            return he.StatusCode == expected;
+#endif 
+                        default:
+                            return false;
+                    }
+                }),
+                $"Any of exceptions in the chain should have HTTP Status: {expected}");
+        }
+
+        public static void HasMessageInExceptionChain(Exception exception, string expected)
+        {
+            var exceptions = CollectExceptions(exception);
+            Assert.AreEqual(true,
+                exceptions.Any(e => e.Message.Contains(expected)),
+                $"Any of exceptions in the chain should contain message: {expected}");
+        }
+
+        private static List<Exception> CollectExceptions(Exception exception)
+        {
+            var collected = new List<Exception>();
+            if (exception is null)
+                return collected;
+            switch (exception)
+            {
+                case AggregateException aggregate:
+                    var inner = aggregate.Flatten().InnerExceptions;
+                    // collected.AddRange(inner.OfType<SnowflakeDbException>());
+                    collected.AddRange(inner);
+                    collected.AddRange(inner
+                        .Where(e => e.InnerException != null)
+                        .SelectMany(e => CollectExceptions(e.InnerException)));
+                    break;
+                case Exception general:
+                    collected.AddRange(CollectExceptions(general.InnerException));
+                    collected.Add(general);
+                    break;
+            }
+            return collected;
         }
     }
 }

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -70,7 +70,6 @@ namespace Snowflake.Data.Tests.Util
             {
                 case AggregateException aggregate:
                     var inner = aggregate.Flatten().InnerExceptions;
-                    // collected.AddRange(inner.OfType<SnowflakeDbException>());
                     collected.AddRange(inner);
                     collected.AddRange(inner
                         .Where(e => e.InnerException != null)

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -339,12 +339,17 @@ namespace Snowflake.Data.Client
 
         private void SetStatement() 
         {
+            if (connection == null)
+            {
+                throw new SnowflakeDbException(SFError.EXECUTE_COMMAND_ON_CLOSED_CONNECTION);
+            }
+            
             var session = (connection as SnowflakeDbConnection).SfSession;
 
             // SetStatement is called when executing a command. If SfSession is null
             // the connection has never been opened. Exception might be a bit vague.
             if (session == null)
-                throw new Exception("Can't execute command when connection has never been opened");
+                throw new SnowflakeDbException(SFError.EXECUTE_COMMAND_ON_CLOSED_CONNECTION);
 
             this.sfStatement = new SFStatement(session);
         }

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -27,7 +27,7 @@ namespace Snowflake.Data.Client
 
         private int VendorCode;
 
-        public string QueryId { get; }
+        public string QueryId { get; set; }
 
         public override int ErrorCode
         {

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -23,8 +23,9 @@ namespace Snowflake.Data.Client
         static private ResourceManager rm = new ResourceManager("Snowflake.Data.Core.ErrorMessages",
             typeof(SnowflakeDbException).Assembly);
 
-        public string SqlState { get; private set; }
-
+        private string _sqlState;
+        public override string SqlState => _sqlState;
+        
         private int VendorCode;
 
         public string QueryId { get; set; }
@@ -40,7 +41,7 @@ namespace Snowflake.Data.Client
         public SnowflakeDbException(string sqlState, int vendorCode, string errorMessage, string queryId)
             : base(FormatExceptionMessage(errorMessage, vendorCode, sqlState, queryId))
         {
-            SqlState = sqlState;
+            _sqlState = sqlState;
             VendorCode = vendorCode;
             QueryId = queryId;
         }
@@ -62,7 +63,7 @@ namespace Snowflake.Data.Client
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty))
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            SqlState = sqlState;
+            _sqlState = sqlState;
         }
 
         public SnowflakeDbException(Exception innerException, SFError error, params object[] args)
@@ -75,7 +76,7 @@ namespace Snowflake.Data.Client
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty), innerException)
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            SqlState = sqlState;
+            _sqlState = sqlState;
         }
 
         static string FormatExceptionMessage(SFError error,

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -40,35 +40,42 @@ namespace Snowflake.Data.Client
         public SnowflakeDbException(string sqlState, int vendorCode, string errorMessage, string queryId)
             : base(FormatExceptionMessage(errorMessage, vendorCode, sqlState, queryId))
         {
-            this.SqlState = sqlState;
-            this.VendorCode = vendorCode;
-            this.QueryId = queryId;
+            SqlState = sqlState;
+            VendorCode = vendorCode;
+            QueryId = queryId;
+        }
+
+        public SnowflakeDbException(SFError error, string queryId, params object[] args)
+            : base(FormatExceptionMessage(error, args, string.Empty, queryId))
+        {
+            VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
+            QueryId = queryId;
         }
 
         public SnowflakeDbException(SFError error, params object[] args)
             : base(FormatExceptionMessage(error, args, string.Empty, string.Empty))
         {
-            this.VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
+            VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
         }
 
         public SnowflakeDbException(string sqlState, SFError error, params object[] args)
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty))
         {
-            this.VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            this.SqlState = sqlState;
+            VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
+            SqlState = sqlState;
         }
 
         public SnowflakeDbException(Exception innerException, SFError error, params object[] args)
             : base(FormatExceptionMessage(error, args, string.Empty, string.Empty), innerException)
         {
-            this.VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
+            VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
         }
 
         public SnowflakeDbException(Exception innerException, string sqlState, SFError error, params object[] args)
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty), innerException)
         {
-            this.VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            this.SqlState = sqlState;
+            VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
+            SqlState = sqlState;
         }
 
         static string FormatExceptionMessage(SFError error,

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -45,8 +45,8 @@ namespace Snowflake.Data.Client
             QueryId = queryId;
         }
 
-        public SnowflakeDbException(SFError error, string queryId, params object[] args)
-            : base(FormatExceptionMessage(error, args, string.Empty, queryId))
+        public SnowflakeDbException(SFError error, string queryId, Exception innerException)
+            : base(FormatExceptionMessage(error, new object[] {innerException.Message}, string.Empty, queryId))
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
             QueryId = queryId;

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Data.Client
         static private ResourceManager rm = new ResourceManager("Snowflake.Data.Core.ErrorMessages",
             typeof(SnowflakeDbException).Assembly);
 
-        public string SqlState { get; private set; }
+        public new string SqlState { get; private set; }
 
         private int VendorCode;
 

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -23,9 +23,7 @@ namespace Snowflake.Data.Client
         static private ResourceManager rm = new ResourceManager("Snowflake.Data.Core.ErrorMessages",
             typeof(SnowflakeDbException).Assembly);
 
-        private string _sqlState;
-        public override string SqlState => _sqlState;
-        
+        public string SqlState { get; private set; }
         private int VendorCode;
 
         public string QueryId { get; set; }
@@ -41,7 +39,7 @@ namespace Snowflake.Data.Client
         public SnowflakeDbException(string sqlState, int vendorCode, string errorMessage, string queryId)
             : base(FormatExceptionMessage(errorMessage, vendorCode, sqlState, queryId))
         {
-            _sqlState = sqlState;
+            SqlState = sqlState;
             VendorCode = vendorCode;
             QueryId = queryId;
         }
@@ -63,7 +61,7 @@ namespace Snowflake.Data.Client
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty))
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            _sqlState = sqlState;
+            SqlState = sqlState;
         }
 
         public SnowflakeDbException(Exception innerException, SFError error, params object[] args)
@@ -76,7 +74,7 @@ namespace Snowflake.Data.Client
             : base(FormatExceptionMessage(error, args, sqlState, string.Empty), innerException)
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
-            _sqlState = sqlState;
+            SqlState = sqlState;
         }
 
         static string FormatExceptionMessage(SFError error,

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Data.Client
         static private ResourceManager rm = new ResourceManager("Snowflake.Data.Core.ErrorMessages",
             typeof(SnowflakeDbException).Assembly);
 
-        public new string SqlState { get; private set; }
+        public string SqlState { get; private set; }
 
         private int VendorCode;
 

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Data.Client
         }
 
         public SnowflakeDbException(SFError error, string queryId, Exception innerException)
-            : base(FormatExceptionMessage(error, new object[] {innerException.Message}, string.Empty, queryId))
+            : base(FormatExceptionMessage(error, new object[] {innerException.Message}, string.Empty, queryId), innerException)
         {
             VendorCode = error.GetAttribute<SFErrorAttr>().errorCode;
             QueryId = queryId;

--- a/Snowflake.Data/Core/ErrorMessages.resx
+++ b/Snowflake.Data/Core/ErrorMessages.resx
@@ -185,5 +185,8 @@
   </data>
   <data name="IO_ERROR_ON_GETPUT_COMMAND" xml:space="preserve">
     <value>IO operation failed. Error: {0}</value>
+  </data>  
+  <data name="EXECUTE_COMMAND_ON_CLOSED_CONNECTION" xml:space="preserve">
+    <value>Executing command on a non-opened connection.</value>
   </data>
 </root>

--- a/Snowflake.Data/Core/ErrorMessages.resx
+++ b/Snowflake.Data/Core/ErrorMessages.resx
@@ -183,4 +183,7 @@
   <data name="BROWSER_RESPONSE_TIMEOUT" xml:space="preserve">
     <value>Browser response timed out after {0} seconds.</value>
   </data>
+  <data name="IO_ERROR_ON_GETPUT_COMMAND" xml:space="preserve">
+    <value>IO operation failed. Error: {0}</value>
+  </data>
 </root>

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -241,7 +241,6 @@ namespace Snowflake.Data.Core
                 }
                 throw new SnowflakeDbException(SFError.IO_ERROR_ON_GETPUT_COMMAND, TransferMetadata.queryId, e);
             }
-            
         }
 
         public async Task executeAsync(CancellationToken cancellationToken)

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -228,16 +228,6 @@ namespace Snowflake.Data.Core
                     download();
                 }
             }
-            catch (FileNotFoundException e)
-            {
-                Logger.Error("File not found while transferring file(s): " + e.Message);
-                throw new SnowflakeDbException(SFError.IO_ERROR_ON_GETPUT_COMMAND, TransferMetadata.queryId, e);
-            }
-            catch (IOException e)
-            {
-                Logger.Error("IO operation error while transferring file(s): " + e.Message);
-                throw new SnowflakeDbException(SFError.IO_ERROR_ON_GETPUT_COMMAND, TransferMetadata.queryId, e);
-            }
             catch (Exception e)
             {
                 Logger.Error("Error while transferring file(s): " + e.Message);

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -709,8 +709,9 @@ namespace Snowflake.Data.Core
             {
                 return int.Parse(maxBytesInMemoryString);
             }
-            catch (Exception e)
+            catch (Exception)
             {
+                Logger.Warn("Default for FILE_TRANSFER_MEMORY_THRESHOLD used due to invalid session value.");
                 return FileTransferConfiguration.DefaultMaxBytesInMemory;
             }
         }
@@ -1278,7 +1279,8 @@ namespace Snowflake.Data.Core
             }
             catch (Exception ex)
             {
-                throw ex;
+                Logger.Error("UploadSingleFileAsync encountered an error: " + ex.Message);
+                throw;
             }
             finally
             {
@@ -1315,7 +1317,8 @@ namespace Snowflake.Data.Core
             }
             catch (Exception ex)
             {
-                throw ex;
+                Logger.Error("DownloadSingleFile encountered an error: " + ex.Message);
+                throw;
             }
             finally
             {
@@ -1352,7 +1355,8 @@ namespace Snowflake.Data.Core
             }
             catch (Exception ex)
             {
-                throw ex;
+                Logger.Error("DownloadSingleFileAsync encountered an error: " + ex.Message);
+                throw;
             }
             finally
             {

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -238,6 +238,19 @@ namespace Snowflake.Data.Core
                 Logger.Error("IO operation error while transferring file(s): " + e.Message);
                 throw new SnowflakeDbException(SFError.IO_ERROR_ON_GETPUT_COMMAND, TransferMetadata.queryId, e);
             }
+            catch (Exception e)
+            {
+                Logger.Error("Error while transferring file(s): " + e.Message);
+                if (e is SnowflakeDbException snowflakeException)
+                {
+                    if (snowflakeException.QueryId == null)
+                    {
+                        snowflakeException.QueryId = TransferMetadata.queryId;
+                    }
+                    throw snowflakeException;
+                }
+                throw new SnowflakeDbException(SFError.IO_ERROR_ON_GETPUT_COMMAND, TransferMetadata.queryId, e);
+            }
             
         }
 

--- a/Snowflake.Data/Core/SFBindUploader.cs
+++ b/Snowflake.Data/Core/SFBindUploader.cs
@@ -297,7 +297,7 @@ namespace Snowflake.Data.Core
                     {
                         session.SetArrayBindStageThreshold(0);
                         logger.Error("Failed to create temporary stage for array binds.", e);
-                        throw e;
+                        throw;
                     }
                 }
             }
@@ -321,7 +321,7 @@ namespace Snowflake.Data.Core
                 {
                     session.SetArrayBindStageThreshold(0);
                     logger.Error("Failed to create temporary stage for array binds.", e);
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/Snowflake.Data/Core/SFError.cs
+++ b/Snowflake.Data/Core/SFError.cs
@@ -80,7 +80,10 @@ namespace Snowflake.Data.Core
         BROWSER_RESPONSE_TIMEOUT,
 
         [SFErrorAttr(errorCode = 270058)]
-        IO_ERROR_ON_GETPUT_COMMAND
+        IO_ERROR_ON_GETPUT_COMMAND,
+        
+        [SFErrorAttr(errorCode = 270059)]
+        EXECUTE_COMMAND_ON_CLOSED_CONNECTION
     }
 
     class SFErrorAttr : Attribute

--- a/Snowflake.Data/Core/SFError.cs
+++ b/Snowflake.Data/Core/SFError.cs
@@ -78,6 +78,9 @@ namespace Snowflake.Data.Core
 
         [SFErrorAttr(errorCode = 270057)]
         BROWSER_RESPONSE_TIMEOUT,
+
+        [SFErrorAttr(errorCode = 270058)]
+        IO_ERROR_ON_GETPUT_COMMAND
     }
 
     class SFErrorAttr : Attribute

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -356,8 +356,7 @@ namespace Snowflake.Data.Core
                              bindings,
                              describeOnly);
 
-                    if (logger.IsDebugEnabled())
-                        logger.Debug("PUT/GET queryId: " + (response.data != null ? response.data.queryId : "Unknown"));
+                    logger.Debug("PUT/GET queryId: " + (response.data != null ? response.data.queryId : "Unknown"));
 
                     SFFileTransferAgent fileTransferAgent =
                         new SFFileTransferAgent(trimmedSql, SfSession, response.data, CancellationToken.None);

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -409,14 +409,16 @@ namespace Snowflake.Data.Core
                     return BuildResultSet(response, CancellationToken.None);
                 }
             }
+            catch (SnowflakeDbException ex)
+            {
+                logger.Error($"Query execution failed, QueryId: {ex.QueryId??"unavailable"}", ex);
+                _lastQueryId = ex.QueryId ?? _lastQueryId;
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.Error("Query execution failed.", ex);
-                if (ex is SnowflakeDbException snowflakeDbException)
-                {
-                    this._lastQueryId = snowflakeDbException.QueryId;
-                }
-                throw;
+                throw new SnowflakeDbException(ex, SFError.INTERNAL_ERROR);
             }
             finally
             {

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -359,7 +359,7 @@ namespace Snowflake.Data.Core
             }
         }
 
-        internal SFBaseResultSet ExecuteSqlWithPutGet(int timeout, string sql, Dictionary<string, BindingDTO> bindings, bool describeOnly)
+        private SFBaseResultSet ExecuteSqlWithPutGet(int timeout, string sql, Dictionary<string, BindingDTO> bindings, bool describeOnly)
         {
             try
             {
@@ -398,7 +398,7 @@ namespace Snowflake.Data.Core
             }
         }
         
-        internal SFBaseResultSet ExecuteSqlOtherThanPutGet(int timeout, string sql, Dictionary<string, BindingDTO> bindings, bool describeOnly)
+        private SFBaseResultSet ExecuteSqlOtherThanPutGet(int timeout, string sql, Dictionary<string, BindingDTO> bindings, bool describeOnly)
         {
             try
             {

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -412,9 +412,8 @@ namespace Snowflake.Data.Core
             catch (Exception ex)
             {
                 logger.Error("Query execution failed.", ex);
-                if (ex is SnowflakeDbException)
+                if (ex is SnowflakeDbException snowflakeDbException)
                 {
-                    var snowflakeDbException = (SnowflakeDbException)ex;
                     this._lastQueryId = snowflakeDbException.QueryId;
                 }
                 throw;


### PR DESCRIPTION
### Description
QueryID is super helpful when solving issues but it was not reachable when PUT/GET operation got failed at the command/exception level.
It was not available for successful scenario for PUT/GET commands as well.
This change actually introduces a new type of exception prior to the one used previously - FileNotFoundException/DirectoryNotFoundException and this previous exception is now an inner exception of SnowflakeDbException which we had to use to provide QueryId.
In rare cases (for instance when a connection was not opened) request to PUT/GET file on stage might still end up with a base Exception since QueryId won't be created in such a case.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name