### PR TITLE
SNOW-984600 Avoid closing expired sessions synchronously with obtained lock

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1780,8 +1780,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, timeoutSec * 1000 - delta);
-                // But never more than 2 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 2) * 1000);
+                // But never more than 3 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 3) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(timeoutSec, conn.ConnectionTimeout);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1780,8 +1780,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, timeoutSec * 1000 - delta);
-                // But never more than 1 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 1) * 1000);
+                // But never more than 2 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 2) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(timeoutSec, conn.ConnectionTimeout);
@@ -1818,8 +1818,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, retryTimeout * 1000 - delta);
-                // But never more than 1 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (retryTimeout + 1) * 1000);
+                // But never more than 2 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (retryTimeout + 2) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(retryTimeout, conn.ConnectionTimeout);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1780,8 +1780,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, timeoutSec * 1000 - delta);
-                // But never more than 3 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 3) * 1000);
+                // But never more than 2 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 2) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(timeoutSec, conn.ConnectionTimeout);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
@@ -409,12 +409,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var session = conn1.SfSession;
             conn1.Close();
             Assert.IsTrue(session.IsEstablished());
-            Thread.Sleep(SessionTimeoutSeconds * 1000);
+            Thread.Sleep(SessionTimeoutSeconds * 1000); // wait until the session is expired
             var conn2 = new SnowflakeDbConnection(ConnectionString);
                 
             // act
             conn2.Open(); // it gets a session from the caching pool firstly closing session of conn1 in background
-            Thread.Sleep(TimeForBackgroundSessionCloseMillis);
+            Thread.Sleep(TimeForBackgroundSessionCloseMillis); // wait for closing expired session
             
             // assert
             Assert.IsFalse(session.IsEstablished());

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -242,7 +242,7 @@ namespace Snowflake.Data.Core
         internal void close()
         {
             // Nothing to do if the session is not open
-            if (null == sessionToken) return;
+            if (!IsEstablished()) return;
 
             stopHeartBeatForThisSession();
 
@@ -274,7 +274,7 @@ namespace Snowflake.Data.Core
         internal async Task CloseAsync(CancellationToken cancellationToken)
         {
             // Nothing to do if the session is not open
-            if (null == sessionToken) return;
+            if (!IsEstablished()) return;
 
             stopHeartBeatForThisSession();
 
@@ -302,6 +302,8 @@ namespace Snowflake.Data.Core
             // Just in case the session won't be closed twice
             sessionToken = null;
         }
+
+        internal bool IsEstablished() => sessionToken != null;
 
         internal void renewSession()
         {
@@ -504,7 +506,7 @@ namespace Snowflake.Data.Core
             logger.Debug("heartbeat");
 
             bool retry = false;
-            if (sessionToken != null)
+            if (IsEstablished())
             {
                 do
                 {

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Core.Session
             {
                 foreach (SFSession session in _sessions)
                 {
-                    Task.Run(() => session.close());
+                    session.close(); // it is left synchronously here because too much async tasks slows down testing
                 }
                 _sessions.Clear();
             }

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -57,8 +57,8 @@ namespace Snowflake.Data.Core.Session
                 {
                     if (item.IsExpired(_timeout, timeNow))
                     {
+                        Task.Run(() => item.close());
                         _sessions.Remove(item);
-                        item.close();
                     }
                 }
             }
@@ -96,7 +96,7 @@ namespace Snowflake.Data.Core.Session
                         long timeNow = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                         if (session.IsExpired(_timeout, timeNow))
                         {
-                            session.close();
+                            Task.Run(() => session.close());
                             i--;
                         }
                         else
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Core.Session
             {
                 foreach (SFSession session in _sessions)
                 {
-                    session.close();
+                    Task.Run(() => session.close());
                 }
                 _sessions.Clear();
             }


### PR DESCRIPTION
### Description
Avoid closing sessions synchronously with obtained lock

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name