### PR TITLE
SNOW-961434 Fix usage of insecure mode in connection parameters

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -79,7 +79,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var config = properties.BuildHttpClientConfig();
 
             // then
-            Assert.AreEqual(properties.insecureMode, config.CrlCheckEnabled);
+            Assert.AreEqual(!properties.insecureMode, config.CrlCheckEnabled);
             Assert.AreEqual(properties.proxyProperties.proxyHost, config.ProxyHost);
             Assert.AreEqual(properties.proxyProperties.proxyPort, config.ProxyPort);
             Assert.AreEqual(properties.proxyProperties.proxyUser, config.ProxyUser);

--- a/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
+++ b/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
@@ -75,7 +75,7 @@ namespace Snowflake.Data.Core
         internal HttpClientConfig BuildHttpClientConfig()
         {
             return new HttpClientConfig(
-                insecureMode,
+                !insecureMode,
                 proxyProperties.proxyHost,
                 proxyProperties.proxyPort,
                 proxyProperties.proxyUser,


### PR DESCRIPTION
### Description
SNOW-961434 Fix usage of insecure mode in connection parameters

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name