### PR TITLE
SNOW-982481 Drop obsolete time sync for macos builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,8 +152,6 @@ jobs:
         dotnet: ['net6.0']
         cloud_env: ['AZURE', 'GCP', 'AWS']
     steps:
-      - name: Sync clock
-        run: sudo sntp -sS time.windows.com
       - uses: actions/checkout@v3
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
### Description
Drop obsolete time sync caused by https://github.com/actions/runner/issues/2996

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name