### PR TITLE
fix dns names with underscore

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -305,6 +305,33 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.DISABLEQUERYCONTEXTCACHE, defDisableQueryContextCache }
                 }
             };
+            var testCaseUnderscoredAccountName = new TestCase()
+            {
+                ConnectionString = $"ACCOUNT=prefix_{defAccount};USER={defUser};PASSWORD={defPassword};",
+                ExpectedProperties = new SFSessionProperties()
+                {
+                    { SFSessionProperty.ACCOUNT, $"prefix_{defAccount}" },
+                    { SFSessionProperty.USER, defUser },
+                    { SFSessionProperty.HOST, $"prefix-{defAccount}.snowflakecomputing.com" },
+                    { SFSessionProperty.AUTHENTICATOR, defAuthenticator },
+                    { SFSessionProperty.SCHEME, defScheme },
+                    { SFSessionProperty.CONNECTION_TIMEOUT, defConnectionTimeout },
+                    { SFSessionProperty.PASSWORD, defPassword },
+                    { SFSessionProperty.PORT, defPort },
+                    { SFSessionProperty.VALIDATE_DEFAULT_PARAMETERS, "true" },
+                    { SFSessionProperty.USEPROXY, "false" },
+                    { SFSessionProperty.INSECUREMODE, "false" },
+                    { SFSessionProperty.DISABLERETRY, "false" },
+                    { SFSessionProperty.FORCERETRYON404, "false" },
+                    { SFSessionProperty.CLIENT_SESSION_KEEP_ALIVE, "false" },
+                    { SFSessionProperty.FORCEPARSEERROR, "false" },
+                    { SFSessionProperty.BROWSER_RESPONSE_TIMEOUT, defBrowserResponseTime },
+                    { SFSessionProperty.RETRY_TIMEOUT, defRetryTimeout },
+                    { SFSessionProperty.MAXHTTPRETRIES, defMaxHttpRetries },
+                    { SFSessionProperty.INCLUDERETRYREASON, defIncludeRetryReason },
+                    { SFSessionProperty.DISABLEQUERYCONTEXTCACHE, defDisableQueryContextCache }
+                }
+            };
             return new TestCase[]
             {
                 simpleTestCase,
@@ -314,7 +341,8 @@ namespace Snowflake.Data.Tests.UnitTests
                 testCaseWithFileTransferMaxBytesInMemory,
                 testCaseWithIncludeRetryReason,
                 testCaseWithDisableQueryContextCache,
-                testCaseComplicatedAccountName
+                testCaseComplicatedAccountName,
+                testCaseUnderscoredAccountName
             };
         }
         

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -260,7 +260,8 @@ namespace Snowflake.Data.Core
             if (!properties.ContainsKey(SFSessionProperty.HOST) ||
                 (0 == properties[SFSessionProperty.HOST].Length))
             {
-                string hostName = String.Format("{0}.snowflakecomputing.com", properties[SFSessionProperty.ACCOUNT]);
+                string compliantAccountName = properties[SFSessionProperty.ACCOUNT].Replace('_','-');
+                string hostName = String.Format("{0}.snowflakecomputing.com", compliantAccountName);
                 // Remove in case it's here but empty
                 properties.Remove(SFSessionProperty.HOST);
                 properties.Add(SFSessionProperty.HOST, hostName);


### PR DESCRIPTION
### Description
DNS names with underscores are not valid in the .net framework. This will construct a working HOST name by replacing with - which is how Snowflake solves for this use case, but users had to manually set HOST.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name