### PR TITLE
Patch dotnet connector version bump

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1780,8 +1780,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, timeoutSec * 1000 - delta);
-                // But never more than 3 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 3) * 1000);
+                // But never more than 1 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (timeoutSec + 1) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(timeoutSec, conn.ConnectionTimeout);
@@ -1818,8 +1818,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the defined timeout since retry count is infinite
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, retryTimeout * 1000 - delta);
-                // But never more than 2 sec (buffer time) after the defined timeout
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (retryTimeout + 2) * 1000);
+                // But never more than 1 sec (buffer time) after the defined timeout
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (retryTimeout + 1) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(retryTimeout, conn.ConnectionTimeout);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
@@ -12,7 +12,6 @@ using Snowflake.Data.Core;
 using Snowflake.Data.Client;
 using Snowflake.Data.Log;
 using NUnit.Framework;
-using Snowflake.Data.Core.Session;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {
@@ -395,32 +394,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             SnowflakeDbConnectionPool.SetPooling(false);
             //Put a breakpoint at SFSession close function, after connection pool is off, it will send close session request.
-        }
-
-        [Test]
-        public void TestCloseSessionAfterTimeout()
-        {
-            // arrange
-            const int SessionTimeoutSeconds = 2;
-            const int TimeForBackgroundSessionCloseMillis = 2000;
-            SnowflakeDbConnectionPool.SetTimeout(SessionTimeoutSeconds);
-            var conn1 = new SnowflakeDbConnection(ConnectionString);
-            conn1.Open();
-            var session = conn1.SfSession;
-            conn1.Close();
-            Assert.IsTrue(session.IsEstablished());
-            Thread.Sleep(SessionTimeoutSeconds * 1000); // wait until the session is expired
-            var conn2 = new SnowflakeDbConnection(ConnectionString);
-                
-            // act
-            conn2.Open(); // it gets a session from the caching pool firstly closing session of conn1 in background
-            Thread.Sleep(TimeForBackgroundSessionCloseMillis); // wait for closing expired session
-            
-            // assert
-            Assert.IsFalse(session.IsEstablished());
-            
-            // cleanup
-            conn2.Close();
         }
     }
 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -242,7 +242,7 @@ namespace Snowflake.Data.Core
         internal void close()
         {
             // Nothing to do if the session is not open
-            if (!IsEstablished()) return;
+            if (null == sessionToken) return;
 
             stopHeartBeatForThisSession();
 
@@ -274,7 +274,7 @@ namespace Snowflake.Data.Core
         internal async Task CloseAsync(CancellationToken cancellationToken)
         {
             // Nothing to do if the session is not open
-            if (!IsEstablished()) return;
+            if (null == sessionToken) return;
 
             stopHeartBeatForThisSession();
 
@@ -302,8 +302,6 @@ namespace Snowflake.Data.Core
             // Just in case the session won't be closed twice
             sessionToken = null;
         }
-
-        internal bool IsEstablished() => sessionToken != null;
 
         internal void renewSession()
         {
@@ -506,7 +504,7 @@ namespace Snowflake.Data.Core
             logger.Debug("heartbeat");
 
             bool retry = false;
-            if (IsEstablished())
+            if (sessionToken != null)
             {
                 do
                 {

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -57,8 +57,8 @@ namespace Snowflake.Data.Core.Session
                 {
                     if (item.IsExpired(_timeout, timeNow))
                     {
-                        Task.Run(() => item.close());
                         _sessions.Remove(item);
+                        item.close();
                     }
                 }
             }
@@ -96,7 +96,7 @@ namespace Snowflake.Data.Core.Session
                         long timeNow = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                         if (session.IsExpired(_timeout, timeNow))
                         {
-                            Task.Run(() => session.close());
+                            session.close();
                             i--;
                         }
                         else
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Core.Session
             {
                 foreach (SFSession session in _sessions)
                 {
-                    session.close(); // it is left synchronously here because too much async tasks slows down testing
+                    session.close();
                 }
                 _sessions.Clear();
             }

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -13,7 +13,7 @@
     <Product>Snowflake Connector for .NET</Product>
     <Authors>howryu, tchen</Authors>
     <Copyright>Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.</Copyright>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <DebugType>Full</DebugType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
### Description
Hotfix release for SNOW-961434. Revert 8f35e5df SNOW-984600 from the release and bump path version.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name