### PR TITLE
Fix lowercase db or schema in connection string

### DIFF
--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -119,14 +119,19 @@ namespace Snowflake.Data.Core
             string schemaValue;
             string roleName;
             queryParams[RestParams.SF_QUERY_WAREHOUSE] = properties.TryGetValue(SFSessionProperty.WAREHOUSE, out warehouseValue) ? warehouseValue : "";
-            queryParams[RestParams.SF_QUERY_DB] = properties.TryGetValue(SFSessionProperty.DB, out dbValue) ? dbValue : "";
-            queryParams[RestParams.SF_QUERY_SCHEMA] = properties.TryGetValue(SFSessionProperty.SCHEMA, out schemaValue) ? schemaValue : "";
+            queryParams[RestParams.SF_QUERY_DB] = EscapeDbObjectForUrl(properties.TryGetValue(SFSessionProperty.DB, out dbValue) ? dbValue : "");
+            queryParams[RestParams.SF_QUERY_SCHEMA] = EscapeDbObjectForUrl(properties.TryGetValue(SFSessionProperty.SCHEMA, out schemaValue) ? schemaValue : "");
             queryParams[RestParams.SF_QUERY_ROLE] = properties.TryGetValue(SFSessionProperty.ROLE, out roleName) ? roleName : "";
             queryParams[RestParams.SF_QUERY_REQUEST_ID] = Guid.NewGuid().ToString();
             queryParams[RestParams.SF_QUERY_REQUEST_GUID] = Guid.NewGuid().ToString();
 
             var loginUrl = BuildUri(RestPath.SF_LOGIN_PATH, queryParams);
             return loginUrl;
+        }
+
+        private string EscapeDbObjectForUrl(string name)
+        {
+            return name == string.Empty ? name : $"\"{name.Replace("\"", "\"\"")}\"";
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
There's a bug, that having specified database or schema name in connection string, that contains any lowercase letter, throws exception during connection opening.

This PR fixes that.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name