### PR TITLE
SNOW-998036: Add check if command text is set before executing

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -39,9 +39,6 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestCommandExecuteThrowsExceptionWhenCommandTextIsNotSet()
         {
-            // Arrange
-            SnowflakeDbConnection conn = new SnowflakeDbConnection();
-
             // Act
             var thrown = Assert.Throws<Exception>(() => command.ExecuteScalar());
 
@@ -53,7 +50,6 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestCommandExecuteAsyncThrowsExceptionWhenCommandTextIsNotSet()
         {
             // Arrange
-            SnowflakeDbConnection conn = new SnowflakeDbConnection();
             Task<object> commandTask = command.ExecuteScalarAsync(CancellationToken.None);
 
             // Act

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -35,6 +35,19 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
+        public void TestCommandExecuteThrowsExceptionWhenCommandTextIsNotSet()
+        {
+            // Arrange
+            SnowflakeDbConnection conn = new SnowflakeDbConnection();
+
+            // Act
+            var thrown = Assert.Throws<Exception>(() => command.ExecuteScalar());
+
+            // Assert
+            Assert.AreEqual(thrown.Message, "Unable to execute command due to command text not being set");
+        }
+
+        [Test]
         public void TestCommandPrepareThrowsNotImplemented()
         {
             Assert.Throws<NotImplementedException>(() => command.Prepare());

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -7,6 +7,8 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using Snowflake.Data.Client;
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     [TestFixture]
     class SFDbCommandTest
@@ -45,6 +47,20 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.AreEqual(thrown.Message, "Unable to execute command due to command text not being set");
+        }
+
+        [Test]
+        public void TestCommandExecuteAsyncThrowsExceptionWhenCommandTextIsNotSet()
+        {
+            // Arrange
+            SnowflakeDbConnection conn = new SnowflakeDbConnection();
+            Task<object> commandTask = command.ExecuteScalarAsync(CancellationToken.None);
+
+            // Act
+            var thrown = Assert.Throws<AggregateException>(() => commandTask.Wait());
+
+            // Assert
+            Assert.AreEqual(thrown.InnerException.Message, "Unable to execute command due to command text not being set");
         }
 
         [Test]

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -351,14 +351,26 @@ namespace Snowflake.Data.Client
 
         private SFBaseResultSet ExecuteInternal(bool describeOnly = false)
         {
+            CheckIfCommandTextIsSet();
             SetStatement();
             return sfStatement.Execute(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly);
         }
 
         private Task<SFBaseResultSet> ExecuteInternalAsync(CancellationToken cancellationToken, bool describeOnly = false)
         {
+            CheckIfCommandTextIsSet();
             SetStatement();
             return sfStatement.ExecuteAsync(CommandTimeout, CommandText, convertToBindList(parameterCollection.parameterList), describeOnly, cancellationToken);
+        }
+
+        private void CheckIfCommandTextIsSet()
+        {
+            if (string.IsNullOrEmpty(CommandText))
+            {
+                var errorMessage = "Unable to execute command due to command text not being set";
+                logger.Error(errorMessage);
+                throw new Exception(errorMessage);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
Add check if command text is set before executing

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name