### PR TITLE
SNOW-990111 easy logging driver directory + Mono.Unix

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -43,6 +43,7 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
             t_environmentOperations = new Mock<EnvironmentOperations>();
             t_finder = new EasyLoggingConfigFinder(t_fileOperations.Object, t_unixOperations.Object, t_environmentOperations.Object);
             MockHomeDirectory();
+            MockExecutionDirectory();
         }
         
         [Test]
@@ -213,6 +214,13 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
                 .Throws(() => new Exception("No home directory"));
         }
 
+        private static void MockExecutionDirectory()
+        {
+            t_environmentOperations
+                .Setup(e => e.GetExecutionDirectory())
+                .Returns(DriverDirectory);
+        }
+        
         private static void MockFileOnHomePathDoesNotExist()
         {
             t_fileOperations

--- a/Snowflake.Data/Configuration/EasyLoggingConfigFinder.cs
+++ b/Snowflake.Data/Configuration/EasyLoggingConfigFinder.cs
@@ -68,8 +68,8 @@ namespace Snowflake.Data.Configuration
 
         private string GetHomeDirectory() => HomeDirectoryProvider.HomeDirectory(_environmentOperations);
 
-        private string GetFilePathFromDriverLocation() => SearchForConfigInDirectory(() => ".", "driver");
-
+        private string GetFilePathFromDriverLocation() => SearchForConfigInDirectory(() => _environmentOperations.GetExecutionDirectory(), "driver");
+        
         private string SearchForConfigInDirectory(Func<string> directoryProvider, string directoryDescription)
         {
             try

--- a/Snowflake.Data/Core/Tools/EnvironmentOperations.cs
+++ b/Snowflake.Data/Core/Tools/EnvironmentOperations.cs
@@ -3,6 +3,7 @@
  */
 
 using System;
+using System.IO;
 
 namespace Snowflake.Data.Core.Tools
 {
@@ -18,6 +19,12 @@ namespace Snowflake.Data.Core.Tools
         public virtual string GetFolderPath(Environment.SpecialFolder folder)
         {
             return Environment.GetFolderPath(folder);
+        }
+
+        public virtual string GetExecutionDirectory()
+        {
+            var executablePath = Environment.GetCommandLineArgs()[0];
+            return Path.GetDirectoryName(executablePath);
         }
     }
 }

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.6.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Azure.Storage.Common" Version="12.12.0" />
-    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />


### PR DESCRIPTION
### Description
Easy Logging: get driver directory from executable path and use Mono.Unix 

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name