### PR TITLE
SNOW-817091: Async execution

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
@@ -333,7 +333,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             Thread.Sleep(5000);
             SFStatement statement = new SFStatement(conn1.SfSession);
-            SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false);
+            SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false, false);
             Assert.AreEqual(true, resultSet.Next());
             Assert.AreEqual("1", resultSet.GetString(0));
             SnowflakeDbConnectionPool.ClearAllPools();

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1606,6 +1606,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
+
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Arrange

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -516,7 +516,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test, NonParallelizable]
+        [Test]
         public void TestGetResultsOfUnknownQueryIdAsync()
         {
             string unknownQueryId = "ab123fed-1abc-987f-987f-1234a56b789c";
@@ -1669,7 +1669,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test, NonParallelizable]
+        [Test]
         public void TestGetResultsOfUnknownQueryId()
         {
             string unknownQueryId = "ba987def-1abc-987f-987f-1234a56b789c";

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -295,20 +295,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     cancelToken.Cancel();
-#if NET471
                     var thrown = Assert.ThrowsAsync<OperationCanceledException>(async () =>
                         await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
-#else
-                    var thrown = Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                        await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
-#endif
 
                     // Assert
-#if NET472
-                    Assert.IsTrue(thrown.Message.Contains("A task was canceled"));
-#else
                     Assert.IsTrue(thrown.Message.Contains("The operation was canceled"));
-#endif
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -206,7 +206,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Assert
                     Assert.IsTrue(reader.Read());
                     Assert.AreEqual($"waited {expectedWaitTime} seconds", reader.GetString(0));
-                    Assert.AreEqual(QueryStatus.SUCCESS, queryStatus);
+                    Assert.AreEqual(QueryStatus.Success, queryStatus);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -277,7 +277,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Assert
                     Assert.IsTrue(reader.Read());
                     Assert.AreEqual($"waited {expectedWaitTime} seconds", reader.GetString(0));
-                    Assert.AreEqual(QueryStatus.SUCCESS, queryStatus);
+                    Assert.AreEqual(QueryStatus.Success, queryStatus);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -403,7 +403,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
 
                     // Assert
-                    Assert.AreEqual(QueryStatus.FAILED_WITH_ERROR, queryStatus);
+                    Assert.AreEqual(QueryStatus.FailedWithError, queryStatus);
 
                     // Act
                     var thrown = Assert.ThrowsAsync<SnowflakeDbException>(async () =>
@@ -481,7 +481,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(unknownQueryId, CancellationToken.None).ConfigureAwait(false);
 
                     // Assert
-                    Assert.AreEqual(QueryStatus.NO_DATA, queryStatus);
+                    Assert.AreEqual(QueryStatus.NoData, queryStatus);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1405,7 +1405,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Assert
                     Assert.IsTrue(reader.Read());
                     Assert.AreEqual($"waited {expectedWaitTime} seconds", reader.GetString(0));
-                    Assert.AreEqual(QueryStatus.SUCCESS, cmd.GetQueryStatus(queryId));
+                    Assert.AreEqual(QueryStatus.Success, cmd.GetQueryStatus(queryId));
                 }
 
                 conn.Close();
@@ -1474,7 +1474,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Assert
                     Assert.IsTrue(reader.Read());
                     Assert.AreEqual($"waited {expectedWaitTime} seconds", reader.GetString(0));
-                    Assert.AreEqual(QueryStatus.SUCCESS, cmd.GetQueryStatus(queryId));
+                    Assert.AreEqual(QueryStatus.Success, cmd.GetQueryStatus(queryId));
                 }
 
                 conn.Close();
@@ -1523,7 +1523,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Assert
                     Assert.IsFalse(QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryIdTwo)));
-                    Assert.AreEqual(QueryStatus.SUCCESS, cmd.GetQueryStatus(queryIdTwo));
+                    Assert.AreEqual(QueryStatus.Success, cmd.GetQueryStatus(queryIdTwo));
                     Assert.IsFalse(conn.SfSession.StillRunningAsyncQueries());
                 }
 
@@ -1554,7 +1554,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
 
                     // Assert
-                    Assert.AreEqual(QueryStatus.FAILED_WITH_ERROR, cmd.GetQueryStatus(queryId));
+                    Assert.AreEqual(QueryStatus.FailedWithError, cmd.GetQueryStatus(queryId));
 
                     // Act
                     var thrown = Assert.Throws<SnowflakeDbException>(() => cmd.GetResultsFromQueryId(queryId));
@@ -1662,7 +1662,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = cmd.GetQueryStatus(unknownQueryId);
 
                     // Assert
-                    Assert.AreEqual(QueryStatus.NO_DATA, queryStatus);
+                    Assert.AreEqual(QueryStatus.NoData, queryStatus);
                 }
 
                 conn.Close();

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -516,7 +516,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void TestGetResultsOfUnknownQueryIdAsync()
         {
             string unknownQueryId = "ab123fed-1abc-987f-987f-1234a56b789c";
@@ -1669,7 +1669,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void TestGetResultsOfUnknownQueryId()
         {
             string unknownQueryId = "ba987def-1abc-987f-987f-1234a56b789c";

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1605,6 +1605,31 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
+        public void TestAsyncExecQueryPutGetThrowsNotImplemented()
+        {
+            using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
+                {
+                    // Arrange
+                    cmd.CommandText = $"PUT file://non_existent_file.csv @~;";
+                    //cmd.CommandText = "GET @~ file://C:\\tmp\\;";
+
+                    // Act
+                    var thrown = Assert.Throws<NotImplementedException>(() => cmd.ExecuteInAsyncMode());
+
+                    // Assert
+                    Assert.IsTrue(thrown.Message.Contains("Get and Put are not supported in async execution mode"));
+                }
+
+                conn.Close();
+            }
+        }
+
+        [Test]
         public void TestGetStatusOfInvalidQueryId()
         {
             string fakeQueryId = "fakeQueryId";

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -457,6 +457,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
+                    // Arrange
                     QueryResultsAwaiter queryResultsAwaiter = new QueryResultsAwaiter(new QueryResultsRetryConfig(queryResultsRetryCount, queryResultsRetryPattern));
 
                     // Act

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -307,11 +307,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     cancelToken.Cancel();
+#if NET471
+                    var thrown = Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                        await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
+#else
                     var thrown = Assert.ThrowsAsync<TaskCanceledException>(async () =>
                         await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
+#endif
 
                     // Assert
-#if NETFRAMEWORK
+#if NET472
                     Assert.IsTrue(thrown.Message.Contains("A task was canceled"));
 #else
                     Assert.IsTrue(thrown.Message.Contains("The operation was canceled"));

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -310,10 +310,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.ThrowsAsync<TaskCanceledException>(async () =>
                         await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
 
-
                     // Assert
-                    Console.WriteLine(thrown.Message);
+#if NETFRAMEWORK
+                    Assert.IsTrue(thrown.Message.Contains("A task was canceled"));
+#else
                     Assert.IsTrue(thrown.Message.Contains("The operation was canceled"));
+#endif
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -214,7 +214,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
-        public async Task TestMixedSyncAndAsyncQueryAsync()
+        public async Task TestExecuteNormalQueryWhileAsyncExecQueryIsRunningAsync()
         {
             string queryId;
             var expectedWaitTime = 5;
@@ -1362,7 +1362,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
-        public void TestMixedSyncAndAsyncQuery()
+        public void TestExecuteNormalQueryWhileAsyncExecQueryIsRunning()
         {
             string queryId;
             var expectedWaitTime = 5;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -317,13 +317,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Arrange
+                    var statusMaxRetryCount = 5;
                     var statusRetryCount = 0;
                     cmd.CommandText = $"SELECT * FROM FAKE_TABLE;";
 
                     // Act
                     var queryId = await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
-                    while (statusRetryCount < 5 && QueryStatuses.IsStillRunning(queryStatus))
+                    while (statusRetryCount < statusMaxRetryCount && QueryStatuses.IsStillRunning(queryStatus))
                     {
                         Thread.Sleep(1000);
                         queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
@@ -1410,12 +1411,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Arrange
+                    var statusMaxRetryCount = 5;
                     var statusRetryCount = 0;
                     cmd.CommandText = $"SELECT * FROM FAKE_TABLE;";
 
                     // Act
                     queryId = cmd.ExecuteInAsyncMode();
-                    while (statusRetryCount < 5 && QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)))
+                    while (statusRetryCount < statusMaxRetryCount && QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)))
                     {
                         Thread.Sleep(1000);
                         statusRetryCount++;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1616,10 +1616,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     // Arrange
                     cmd.CommandText = $"PUT file://non_existent_file.csv @~;";
-                    //cmd.CommandText = "GET @~ file://C:\\tmp\\;";
 
                     // Act
                     var thrown = Assert.Throws<NotImplementedException>(() => cmd.ExecuteInAsyncMode());
+
+                    // Assert
+                    Assert.IsTrue(thrown.Message.Contains("Get and Put are not supported in async execution mode"));
+
+                    // Arrange
+                    cmd.CommandText = "GET @~ file://C:\\tmp\\;";
+
+                    // Act
+                    thrown = Assert.Throws<NotImplementedException>(() => cmd.ExecuteInAsyncMode());
 
                     // Assert
                     Assert.IsTrue(thrown.Message.Contains("Get and Put are not supported in async execution mode"));

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -197,7 +197,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                     // Assert
-                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
+                    Assert.IsTrue(conn.IsStillRunning(queryStatus));
+                    Assert.IsFalse(conn.IsAnError(queryStatus));
 
                     // Act
                     DbDataReader reader = await cmd.GetResultsFromQueryIdAsync(queryId, CancellationToken.None).ConfigureAwait(false);
@@ -237,7 +238,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                 // Assert
-                Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
+                Assert.IsTrue(connections[0].IsStillRunning(queryStatus));
             }
 
             // Execute a normal query
@@ -291,7 +292,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                     // Assert
-                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
+                    Assert.IsTrue(conn.IsStillRunning(queryStatus));
 
                     // Act
                     cancelToken.Cancel();
@@ -324,7 +325,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Act
                     var queryId = await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
-                    while (statusRetryCount < statusMaxRetryCount && QueryStatusExtensions.IsStillRunning(queryStatus))
+                    while (statusRetryCount < statusMaxRetryCount && conn.IsStillRunning(queryStatus))
                     {
                         Thread.Sleep(1000);
                         queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
@@ -1351,9 +1352,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     queryId = cmd.ExecuteInAsyncMode();
+                    var queryStatus = cmd.GetQueryStatus(queryId);
 
                     // Assert
-                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)));
+                    Assert.IsTrue(conn.IsStillRunning(queryStatus));
+                    Assert.IsFalse(conn.IsAnError(queryStatus));
 
                     // Act
                     DbDataReader reader = cmd.GetResultsFromQueryId(queryId);
@@ -1391,7 +1394,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 queryId = cmd.ExecuteInAsyncMode();
 
                 // Assert
-                Assert.IsTrue(QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)));
+                Assert.IsTrue(connections[0].IsStillRunning(cmd.GetQueryStatus(queryId)));
             }
 
             // Execute a normal query
@@ -1444,7 +1447,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     queryId = cmd.ExecuteInAsyncMode();
-                    while (statusRetryCount < statusMaxRetryCount && QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)))
+                    while (statusRetryCount < statusMaxRetryCount && conn.IsStillRunning(cmd.GetQueryStatus(queryId)))
                     {
                         Thread.Sleep(1000);
                         statusRetryCount++;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -537,7 +537,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.Throws<AggregateException>(() => readerTask.Wait());
 
                     // Assert
+#if NETFRAMEWORK
+                    Assert.IsTrue(thrown.InnerException.Message.Contains($"Max retry for no data is reached"));
+#else
                     Assert.IsTrue(thrown.Message.Contains($"Max retry for no data is reached"));
+#endif
                 }
 
                 task = conn.CloseAsync(CancellationToken.None);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -338,15 +338,17 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Arrange
+                    var statusRetryCount = 0;
                     cmd.CommandText = $"SELECT * FROM FAKE_TABLE;";
 
                     // Act
                     var queryId = await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
-                    while (QueryStatuses.IsStillRunning(queryStatus))
+                    while (statusRetryCount < 5 && QueryStatuses.IsStillRunning(queryStatus))
                     {
                         Thread.Sleep(1000);
                         queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
+                        statusRetryCount++;
                     }
 
                     // Assert
@@ -1441,13 +1443,15 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Arrange
+                    var statusRetryCount = 0;
                     cmd.CommandText = $"SELECT * FROM FAKE_TABLE;";
 
                     // Act
                     queryId = cmd.ExecuteInAsyncMode();
-                    while (QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)))
+                    while (statusRetryCount < 5 && QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)))
                     {
                         Thread.Sleep(1000);
+                        statusRetryCount++;
                     }
 
                     // Assert

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -197,7 +197,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                     // Assert
-                    Assert.IsTrue(QueryStatuses.IsStillRunning(queryStatus));
+                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
 
                     // Act
                     DbDataReader reader = await cmd.GetResultsFromQueryIdAsync(queryId, CancellationToken.None).ConfigureAwait(false);
@@ -237,7 +237,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                 // Assert
-                Assert.IsTrue(QueryStatuses.IsStillRunning(queryStatus));
+                Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
             }
 
             // Execute a normal query
@@ -291,7 +291,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
 
                     // Assert
-                    Assert.IsTrue(QueryStatuses.IsStillRunning(queryStatus));
+                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(queryStatus));
 
                     // Act
                     cancelToken.Cancel();
@@ -324,7 +324,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Act
                     var queryId = await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
-                    while (statusRetryCount < statusMaxRetryCount && QueryStatuses.IsStillRunning(queryStatus))
+                    while (statusRetryCount < statusMaxRetryCount && QueryStatusExtensions.IsStillRunning(queryStatus))
                     {
                         Thread.Sleep(1000);
                         queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
@@ -1326,7 +1326,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     queryId = cmd.ExecuteInAsyncMode();
 
                     // Assert
-                    Assert.IsTrue(QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)));
+                    Assert.IsTrue(QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)));
 
                     // Act
                     DbDataReader reader = cmd.GetResultsFromQueryId(queryId);
@@ -1364,7 +1364,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 queryId = cmd.ExecuteInAsyncMode();
 
                 // Assert
-                Assert.IsTrue(QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)));
+                Assert.IsTrue(QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)));
             }
 
             // Execute a normal query
@@ -1417,7 +1417,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     queryId = cmd.ExecuteInAsyncMode();
-                    while (statusRetryCount < statusMaxRetryCount && QueryStatuses.IsStillRunning(cmd.GetQueryStatus(queryId)))
+                    while (statusRetryCount < statusMaxRetryCount && QueryStatusExtensions.IsStillRunning(cmd.GetQueryStatus(queryId)))
                     {
                         Thread.Sleep(1000);
                         statusRetryCount++;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1717,10 +1717,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Act
-                    var thrown = Assert.Throws<Exception>(() => cmd.GetResultsFromQueryId(fakeQueryId));
+                    var thrown = Assert.Throws<AggregateException>(() => cmd.GetResultsFromQueryId(fakeQueryId));
 
                     // Assert
-                    Assert.IsTrue(thrown.Message.Contains($"The given query id {fakeQueryId} is not valid uuid"));
+                    Assert.IsTrue(thrown.InnerException.Message.Contains($"The given query id {fakeQueryId} is not valid uuid"));
                 }
 
                 conn.Close();
@@ -1763,10 +1763,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
                     // Act
-                    var thrown = Assert.Throws<Exception>(() => cmd.GetResultsFromQueryId(unknownQueryId));
+                    var thrown = Assert.Throws<AggregateException>(() => cmd.GetResultsFromQueryId(unknownQueryId));
 
                     // Assert
-                    Assert.IsTrue(thrown.Message.Contains($"Max retry for no data is reached"));
+                    Assert.IsTrue(thrown.InnerException.Message.Contains($"Max retry for no data is reached"));
                 }
 
                 conn.Close();

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -213,7 +213,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public async Task TestExecuteNormalQueryWhileAsyncExecQueryIsRunningAsync()
         {
             string queryId;
@@ -1349,7 +1349,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public void TestExecuteNormalQueryWhileAsyncExecQueryIsRunning()
         {
             string queryId;

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -8,7 +8,8 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using System;
 
-    public enum ServerQueryStatus
+    // Based on the values that the server sends back
+    public enum TestQueryStatus
     {
         RUNNING,
         ABORTING,
@@ -19,7 +20,7 @@ namespace Snowflake.Data.Tests.UnitTests
         FAILED_WITH_INCIDENT,
         DISCONNECTED,
         RESUMING_WAREHOUSE,
-        // purposeful typo.Is present in QueryDTO.java
+        // purposeful typo
         QUEUED_REPARING_WAREHOUSE,
         RESTARTED,
         BLOCKED,
@@ -143,19 +144,19 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        [TestCase(ServerQueryStatus.RUNNING, true)]
-        [TestCase(ServerQueryStatus.RESUMING_WAREHOUSE, true)]
-        [TestCase(ServerQueryStatus.QUEUED, true)]
-        [TestCase(ServerQueryStatus.QUEUED_REPARING_WAREHOUSE, true)]
-        [TestCase(ServerQueryStatus.NO_DATA, true)]
-        [TestCase(ServerQueryStatus.ABORTING, false)]
-        [TestCase(ServerQueryStatus.SUCCESS, false)]
-        [TestCase(ServerQueryStatus.FAILED_WITH_ERROR, false)]
-        [TestCase(ServerQueryStatus.ABORTED, false)]
-        [TestCase(ServerQueryStatus.FAILED_WITH_INCIDENT, false)]
-        [TestCase(ServerQueryStatus.DISCONNECTED, false)]
-        [TestCase(ServerQueryStatus.RESTARTED, false)]
-        [TestCase(ServerQueryStatus.BLOCKED, false)]
+        [TestCase(TestQueryStatus.RUNNING, true)]
+        [TestCase(TestQueryStatus.RESUMING_WAREHOUSE, true)]
+        [TestCase(TestQueryStatus.QUEUED, true)]
+        [TestCase(TestQueryStatus.QUEUED_REPARING_WAREHOUSE, true)]
+        [TestCase(TestQueryStatus.NO_DATA, true)]
+        [TestCase(TestQueryStatus.ABORTING, false)]
+        [TestCase(TestQueryStatus.SUCCESS, false)]
+        [TestCase(TestQueryStatus.FAILED_WITH_ERROR, false)]
+        [TestCase(TestQueryStatus.ABORTED, false)]
+        [TestCase(TestQueryStatus.FAILED_WITH_INCIDENT, false)]
+        [TestCase(TestQueryStatus.DISCONNECTED, false)]
+        [TestCase(TestQueryStatus.RESTARTED, false)]
+        [TestCase(TestQueryStatus.BLOCKED, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
             QueryStatus queryStatus;
@@ -164,19 +165,19 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        [TestCase(ServerQueryStatus.ABORTING, true)]
-        [TestCase(ServerQueryStatus.FAILED_WITH_ERROR, true)]
-        [TestCase(ServerQueryStatus.ABORTED, true)]
-        [TestCase(ServerQueryStatus.FAILED_WITH_INCIDENT, true)]
-        [TestCase(ServerQueryStatus.DISCONNECTED, true)]
-        [TestCase(ServerQueryStatus.BLOCKED, true)]
-        [TestCase(ServerQueryStatus.RUNNING, false)]
-        [TestCase(ServerQueryStatus.RESUMING_WAREHOUSE, false)]
-        [TestCase(ServerQueryStatus.QUEUED, false)]
-        [TestCase(ServerQueryStatus.QUEUED_REPARING_WAREHOUSE, false)]
-        [TestCase(ServerQueryStatus.NO_DATA, false)]
-        [TestCase(ServerQueryStatus.SUCCESS, false)]
-        [TestCase(ServerQueryStatus.RESTARTED, false)]
+        [TestCase(TestQueryStatus.ABORTING, true)]
+        [TestCase(TestQueryStatus.FAILED_WITH_ERROR, true)]
+        [TestCase(TestQueryStatus.ABORTED, true)]
+        [TestCase(TestQueryStatus.FAILED_WITH_INCIDENT, true)]
+        [TestCase(TestQueryStatus.DISCONNECTED, true)]
+        [TestCase(TestQueryStatus.BLOCKED, true)]
+        [TestCase(TestQueryStatus.RUNNING, false)]
+        [TestCase(TestQueryStatus.RESUMING_WAREHOUSE, false)]
+        [TestCase(TestQueryStatus.QUEUED, false)]
+        [TestCase(TestQueryStatus.QUEUED_REPARING_WAREHOUSE, false)]
+        [TestCase(TestQueryStatus.NO_DATA, false)]
+        [TestCase(TestQueryStatus.SUCCESS, false)]
+        [TestCase(TestQueryStatus.RESTARTED, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
             QueryStatus queryStatus;

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -140,7 +140,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.Blocked, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, QueryStatuses.IsStillRunning(status));
+            Assert.AreEqual(expectedResult, QueryStatusExtensions.IsStillRunning(status));
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.Restarted, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, QueryStatuses.IsAnError(status));
+            Assert.AreEqual(expectedResult, QueryStatusExtensions.IsAnError(status));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -180,7 +180,6 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.Disconnected, false)]
         [TestCase(QueryStatus.Restarted, false)]
         [TestCase(QueryStatus.Blocked, false)]
-        [TestCase(QueryStatus.Unknown, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, QueryStatusExtensions.IsStillRunning(status));
@@ -200,7 +199,6 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.NoData, false)]
         [TestCase(QueryStatus.Success, false)]
         [TestCase(QueryStatus.Restarted, false)]
-        [TestCase(QueryStatus.Unknown, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, QueryStatusExtensions.IsAnError(status));

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -8,25 +8,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using System;
 
-    // Based on the values that the server sends back
-    public enum TestQueryStatus
-    {
-        RUNNING,
-        ABORTING,
-        SUCCESS,
-        FAILED_WITH_ERROR,
-        ABORTED,
-        QUEUED,
-        FAILED_WITH_INCIDENT,
-        DISCONNECTED,
-        RESUMING_WAREHOUSE,
-        // purposeful typo
-        QUEUED_REPARING_WAREHOUSE,
-        RESTARTED,
-        BLOCKED,
-        NO_DATA,
-    }
-
     /**
      * Mock rest request test
      */
@@ -144,45 +125,41 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        [TestCase(TestQueryStatus.RUNNING, true)]
-        [TestCase(TestQueryStatus.RESUMING_WAREHOUSE, true)]
-        [TestCase(TestQueryStatus.QUEUED, true)]
-        [TestCase(TestQueryStatus.QUEUED_REPARING_WAREHOUSE, true)]
-        [TestCase(TestQueryStatus.NO_DATA, true)]
-        [TestCase(TestQueryStatus.ABORTING, false)]
-        [TestCase(TestQueryStatus.SUCCESS, false)]
-        [TestCase(TestQueryStatus.FAILED_WITH_ERROR, false)]
-        [TestCase(TestQueryStatus.ABORTED, false)]
-        [TestCase(TestQueryStatus.FAILED_WITH_INCIDENT, false)]
-        [TestCase(TestQueryStatus.DISCONNECTED, false)]
-        [TestCase(TestQueryStatus.RESTARTED, false)]
-        [TestCase(TestQueryStatus.BLOCKED, false)]
+        [TestCase(QueryStatus.Running, true)]
+        [TestCase(QueryStatus.ResumingWarehouse, true)]
+        [TestCase(QueryStatus.Queued, true)]
+        [TestCase(QueryStatus.QueuedReparingWarehouse, true)]
+        [TestCase(QueryStatus.NoData, true)]
+        [TestCase(QueryStatus.Aborting, false)]
+        [TestCase(QueryStatus.Success, false)]
+        [TestCase(QueryStatus.FailedWithError, false)]
+        [TestCase(QueryStatus.Aborted, false)]
+        [TestCase(QueryStatus.FailedWithIncident, false)]
+        [TestCase(QueryStatus.Disconnected, false)]
+        [TestCase(QueryStatus.Restarted, false)]
+        [TestCase(QueryStatus.Blocked, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
-            QueryStatus queryStatus;
-            Enum.TryParse(status.ToString(), true, out queryStatus);
-            Assert.AreEqual(expectedResult, QueryStatuses.IsStillRunning(queryStatus));
+            Assert.AreEqual(expectedResult, QueryStatuses.IsStillRunning(status));
         }
 
         [Test]
-        [TestCase(TestQueryStatus.ABORTING, true)]
-        [TestCase(TestQueryStatus.FAILED_WITH_ERROR, true)]
-        [TestCase(TestQueryStatus.ABORTED, true)]
-        [TestCase(TestQueryStatus.FAILED_WITH_INCIDENT, true)]
-        [TestCase(TestQueryStatus.DISCONNECTED, true)]
-        [TestCase(TestQueryStatus.BLOCKED, true)]
-        [TestCase(TestQueryStatus.RUNNING, false)]
-        [TestCase(TestQueryStatus.RESUMING_WAREHOUSE, false)]
-        [TestCase(TestQueryStatus.QUEUED, false)]
-        [TestCase(TestQueryStatus.QUEUED_REPARING_WAREHOUSE, false)]
-        [TestCase(TestQueryStatus.NO_DATA, false)]
-        [TestCase(TestQueryStatus.SUCCESS, false)]
-        [TestCase(TestQueryStatus.RESTARTED, false)]
+        [TestCase(QueryStatus.Aborting, true)]
+        [TestCase(QueryStatus.FailedWithError, true)]
+        [TestCase(QueryStatus.Aborted, true)]
+        [TestCase(QueryStatus.FailedWithIncident, true)]
+        [TestCase(QueryStatus.Disconnected, true)]
+        [TestCase(QueryStatus.Blocked, true)]
+        [TestCase(QueryStatus.Running, false)]
+        [TestCase(QueryStatus.ResumingWarehouse, false)]
+        [TestCase(QueryStatus.Queued, false)]
+        [TestCase(QueryStatus.QueuedReparingWarehouse, false)]
+        [TestCase(QueryStatus.NoData, false)]
+        [TestCase(QueryStatus.Success, false)]
+        [TestCase(QueryStatus.Restarted, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
-            QueryStatus queryStatus;
-            Enum.TryParse(status.ToString(), true, out queryStatus);
-            Assert.AreEqual(expectedResult, QueryStatuses.IsAnError(queryStatus));
+            Assert.AreEqual(expectedResult, QueryStatuses.IsAnError(status));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -6,6 +6,25 @@ namespace Snowflake.Data.Tests.UnitTests
 {
     using Snowflake.Data.Core;
     using NUnit.Framework;
+    using System;
+
+    public enum ServerQueryStatus
+    {
+        RUNNING,
+        ABORTING,
+        SUCCESS,
+        FAILED_WITH_ERROR,
+        ABORTED,
+        QUEUED,
+        FAILED_WITH_INCIDENT,
+        DISCONNECTED,
+        RESUMING_WAREHOUSE,
+        // purposeful typo.Is present in QueryDTO.java
+        QUEUED_REPARING_WAREHOUSE,
+        RESTARTED,
+        BLOCKED,
+        NO_DATA,
+    }
 
     /**
      * Mock rest request test
@@ -124,41 +143,45 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        [TestCase(QueryStatus.RUNNING, true)]
-        [TestCase(QueryStatus.RESUMING_WAREHOUSE, true)]
-        [TestCase(QueryStatus.QUEUED, true)]
-        [TestCase(QueryStatus.QUEUED_REPARING_WAREHOUSE, true)]
-        [TestCase(QueryStatus.NO_DATA, true)]
-        [TestCase(QueryStatus.ABORTING, false)]
-        [TestCase(QueryStatus.SUCCESS, false)]
-        [TestCase(QueryStatus.FAILED_WITH_ERROR, false)]
-        [TestCase(QueryStatus.ABORTED, false)]
-        [TestCase(QueryStatus.FAILED_WITH_INCIDENT, false)]
-        [TestCase(QueryStatus.DISCONNECTED, false)]
-        [TestCase(QueryStatus.RESTARTED, false)]
-        [TestCase(QueryStatus.BLOCKED, false)]
+        [TestCase(ServerQueryStatus.RUNNING, true)]
+        [TestCase(ServerQueryStatus.RESUMING_WAREHOUSE, true)]
+        [TestCase(ServerQueryStatus.QUEUED, true)]
+        [TestCase(ServerQueryStatus.QUEUED_REPARING_WAREHOUSE, true)]
+        [TestCase(ServerQueryStatus.NO_DATA, true)]
+        [TestCase(ServerQueryStatus.ABORTING, false)]
+        [TestCase(ServerQueryStatus.SUCCESS, false)]
+        [TestCase(ServerQueryStatus.FAILED_WITH_ERROR, false)]
+        [TestCase(ServerQueryStatus.ABORTED, false)]
+        [TestCase(ServerQueryStatus.FAILED_WITH_INCIDENT, false)]
+        [TestCase(ServerQueryStatus.DISCONNECTED, false)]
+        [TestCase(ServerQueryStatus.RESTARTED, false)]
+        [TestCase(ServerQueryStatus.BLOCKED, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, QueryStatuses.IsStillRunning(status));
+            QueryStatus queryStatus;
+            Enum.TryParse(status.ToString(), true, out queryStatus);
+            Assert.AreEqual(expectedResult, QueryStatuses.IsStillRunning(queryStatus));
         }
 
         [Test]
-        [TestCase(QueryStatus.ABORTING, true)]
-        [TestCase(QueryStatus.FAILED_WITH_ERROR, true)]
-        [TestCase(QueryStatus.ABORTED, true)]
-        [TestCase(QueryStatus.FAILED_WITH_INCIDENT, true)]
-        [TestCase(QueryStatus.DISCONNECTED, true)]
-        [TestCase(QueryStatus.BLOCKED, true)]
-        [TestCase(QueryStatus.RUNNING, false)]
-        [TestCase(QueryStatus.RESUMING_WAREHOUSE, false)]
-        [TestCase(QueryStatus.QUEUED, false)]
-        [TestCase(QueryStatus.QUEUED_REPARING_WAREHOUSE, false)]
-        [TestCase(QueryStatus.NO_DATA, false)]
-        [TestCase(QueryStatus.SUCCESS, false)]
-        [TestCase(QueryStatus.RESTARTED, false)]
+        [TestCase(ServerQueryStatus.ABORTING, true)]
+        [TestCase(ServerQueryStatus.FAILED_WITH_ERROR, true)]
+        [TestCase(ServerQueryStatus.ABORTED, true)]
+        [TestCase(ServerQueryStatus.FAILED_WITH_INCIDENT, true)]
+        [TestCase(ServerQueryStatus.DISCONNECTED, true)]
+        [TestCase(ServerQueryStatus.BLOCKED, true)]
+        [TestCase(ServerQueryStatus.RUNNING, false)]
+        [TestCase(ServerQueryStatus.RESUMING_WAREHOUSE, false)]
+        [TestCase(ServerQueryStatus.QUEUED, false)]
+        [TestCase(ServerQueryStatus.QUEUED_REPARING_WAREHOUSE, false)]
+        [TestCase(ServerQueryStatus.NO_DATA, false)]
+        [TestCase(ServerQueryStatus.SUCCESS, false)]
+        [TestCase(ServerQueryStatus.RESTARTED, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, QueryStatuses.IsAnError(status));
+            QueryStatus queryStatus;
+            Enum.TryParse(status.ToString(), true, out queryStatus);
+            Assert.AreEqual(expectedResult, QueryStatuses.IsAnError(queryStatus));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -138,6 +138,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.Disconnected, false)]
         [TestCase(QueryStatus.Restarted, false)]
         [TestCase(QueryStatus.Blocked, false)]
+        [TestCase(QueryStatus.Unknown, false)]
         public void TestIsStillRunning(QueryStatus status, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, QueryStatusExtensions.IsStillRunning(status));
@@ -157,6 +158,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(QueryStatus.NoData, false)]
         [TestCase(QueryStatus.Success, false)]
         [TestCase(QueryStatus.Restarted, false)]
+        [TestCase(QueryStatus.Unknown, false)]
         public void TestIsAnError(QueryStatus status, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, QueryStatusExtensions.IsAnError(status));

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -125,6 +125,50 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
+        [TestCase("UNKNOWN", QueryStatus.Unknown)]
+        [TestCase("RANDOM_STATUS", QueryStatus.Unknown)]
+        [TestCase("aBcZyX", QueryStatus.Unknown)]
+        [TestCase("running", QueryStatus.Running)]
+        [TestCase("RUNNING", QueryStatus.Running)]
+        [TestCase("resuming_warehouse", QueryStatus.ResumingWarehouse)]
+        [TestCase("RESUMING_WAREHOUSE", QueryStatus.ResumingWarehouse)]
+        [TestCase("queued", QueryStatus.Queued)]
+        [TestCase("QUEUED", QueryStatus.Queued)]
+        [TestCase("queued_reparing_warehouse", QueryStatus.QueuedReparingWarehouse)]
+        [TestCase("QUEUED_REPARING_WAREHOUSE", QueryStatus.QueuedReparingWarehouse)]
+        [TestCase("no_data", QueryStatus.NoData)]
+        [TestCase("NO_DATA", QueryStatus.NoData)]
+        [TestCase("aborting", QueryStatus.Aborting)]
+        [TestCase("ABORTING", QueryStatus.Aborting)]
+        [TestCase("success", QueryStatus.Success)]
+        [TestCase("SUCCESS", QueryStatus.Success)]
+        [TestCase("failed_with_error", QueryStatus.FailedWithError)]
+        [TestCase("FAILED_WITH_ERROR", QueryStatus.FailedWithError)]
+        [TestCase("aborted", QueryStatus.Aborted)]
+        [TestCase("ABORTED", QueryStatus.Aborted)]
+        [TestCase("failed_with_incident", QueryStatus.FailedWithIncident)]
+        [TestCase("FAILED_WITH_INCIDENT", QueryStatus.FailedWithIncident)]
+        [TestCase("disconnected", QueryStatus.Disconnected)]
+        [TestCase("DISCONNECTED", QueryStatus.Disconnected)]
+        [TestCase("restarted", QueryStatus.Restarted)]
+        [TestCase("RESTARTED", QueryStatus.Restarted)]
+        [TestCase("blocked", QueryStatus.Blocked)]
+        [TestCase("BLOCKED", QueryStatus.Blocked)]
+        public void TestGetQueryStatusByStringValue(string status, QueryStatus expectedStatus)
+        {
+            if (expectedStatus == QueryStatus.Unknown)
+            {
+                var thrown = Assert.Throws<Exception>(() => QueryStatusExtensions.GetQueryStatusByStringValue(status));
+                Assert.IsTrue(thrown.Message.Contains("The query status returned by the server is not recognized"));
+            }
+            else
+            {
+                var actualStatus = QueryStatusExtensions.GetQueryStatusByStringValue(status);
+                Assert.AreEqual(expectedStatus, actualStatus);
+            }
+        }
+
+        [Test]
         [TestCase(QueryStatus.Running, true)]
         [TestCase(QueryStatus.ResumingWarehouse, true)]
         [TestCase(QueryStatus.Queued, true)]

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -125,9 +125,6 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        [TestCase("UNKNOWN", QueryStatus.Unknown)]
-        [TestCase("RANDOM_STATUS", QueryStatus.Unknown)]
-        [TestCase("aBcZyX", QueryStatus.Unknown)]
         [TestCase("running", QueryStatus.Running)]
         [TestCase("RUNNING", QueryStatus.Running)]
         [TestCase("resuming_warehouse", QueryStatus.ResumingWarehouse)]
@@ -154,18 +151,19 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase("RESTARTED", QueryStatus.Restarted)]
         [TestCase("blocked", QueryStatus.Blocked)]
         [TestCase("BLOCKED", QueryStatus.Blocked)]
-        public void TestGetQueryStatusByStringValue(string status, QueryStatus expectedStatus)
+        public void TestGetQueryStatusByStringValue(string stringValue, QueryStatus expectedStatus)
         {
-            if (expectedStatus == QueryStatus.Unknown)
-            {
-                var thrown = Assert.Throws<Exception>(() => QueryStatusExtensions.GetQueryStatusByStringValue(status));
-                Assert.IsTrue(thrown.Message.Contains("The query status returned by the server is not recognized"));
-            }
-            else
-            {
-                var actualStatus = QueryStatusExtensions.GetQueryStatusByStringValue(status);
-                Assert.AreEqual(expectedStatus, actualStatus);
-            }
+            Assert.AreEqual(expectedStatus, QueryStatusExtensions.GetQueryStatusByStringValue(stringValue));
+        }
+
+        [Test]
+        [TestCase("UNKNOWN")]
+        [TestCase("RANDOM_STATUS")]
+        [TestCase("aBcZyX")]
+        public void TestGetQueryStatusByStringValueThrowsErrorForUnknownStatus(string stringValue)
+        {
+            var thrown = Assert.Throws<Exception>(() => QueryStatusExtensions.GetQueryStatusByStringValue(stringValue));
+            Assert.IsTrue(thrown.Message.Contains("The query status returned by the server is not recognized"));
         }
 
         [Test]

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -425,7 +425,7 @@ namespace Snowflake.Data.Client
                     cancellationToken.ThrowIfCancellationRequested();
                 }
 
-                status = GetQueryStatus(queryId);
+                status = await GetQueryStatusAsync(queryId, cancellationToken);
 
                 if (!QueryStatuses.IsStillRunning(status))
                 {

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -384,7 +384,7 @@ namespace Snowflake.Data.Client
                 }
 
                 // If no data, increment the no data counter
-                if (status == QueryStatus.NO_DATA)
+                if (status == QueryStatus.NoData)
                 {
                     noDataCounter++;
 

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -374,7 +374,7 @@ namespace Snowflake.Data.Client
 
                 status = isAsync ? await GetQueryStatusAsync(queryId, cancellationToken) : GetQueryStatus(queryId);
 
-                if (!QueryStatuses.IsStillRunning(status))
+                if (!QueryStatusExtensions.IsStillRunning(status))
                 {
                     return;
                 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -283,6 +283,7 @@ namespace Snowflake.Data.Client
 
         /// <summary>
         /// Execute a query in async mode.
+        /// Async mode means the server will respond immediately with the query ID and execute the query asynchronously
         /// </summary>
         /// <returns>The query id.</returns>
         public string ExecuteInAsyncMode()
@@ -294,6 +295,7 @@ namespace Snowflake.Data.Client
 
         /// <summary>
         /// Executes an asynchronous query in async mode.
+        /// Async mode means the server will respond immediately with the query ID and execute the query asynchronously
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns>The query id.</returns>

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -30,7 +30,7 @@ namespace Snowflake.Data.Client
         private const int AsyncNoDataMaxRetry = 24;
         private readonly int[] _asyncRetryPattern = { 1, 1, 2, 3, 4, 8, 10 };
 
-        private static readonly Regex UuidRegex = new Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+        private static readonly Regex UuidRegex = new Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
         public SnowflakeDbCommand()
         {

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -44,11 +44,6 @@ namespace Snowflake.Data.Client
             this.CommandText = cmdText;
         }
 
-        public SnowflakeDbCommand(SnowflakeDbConnection connection, QueryResultsRetryConfig queryResultsRetryConfig) : this(connection)
-        {
-            _queryResultsAwaiter = new QueryResultsAwaiter(queryResultsRetryConfig);
-        }
-
         public override string CommandText
         {
             get; set;

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -366,6 +366,12 @@ namespace Snowflake.Data.Client
             QueryStatus status;
             while (true)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    logger.Debug("Cancellation requested for getting results from query id");
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 status = isAsync ? await GetQueryStatusAsync(queryId, cancellationToken) : GetQueryStatus(queryId);
 
                 if (!QueryStatuses.IsStillRunning(status))

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -324,7 +324,6 @@ namespace Snowflake.Data.Client
                 logger.Error(errorMessage);
                 throw new Exception(errorMessage);
             }
-
         }
 
         /// <summary>

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -24,7 +24,7 @@ namespace Snowflake.Data.Client
 
         private SFLogger logger = SFLoggerFactory.GetLogger<SnowflakeDbCommand>();
 
-        private QueryResultsAwaiter _queryResultsAwaiter = new QueryResultsAwaiter();
+        private readonly QueryResultsAwaiter _queryResultsAwaiter = QueryResultsAwaiter.Instance;
 
         public SnowflakeDbCommand()
         {

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -419,6 +419,12 @@ namespace Snowflake.Data.Client
             QueryStatus status;
             while (true)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    logger.Debug("Cancellation requested for getting results from query id");
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 status = GetQueryStatus(queryId);
 
                 if (!QueryStatuses.IsStillRunning(status))

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -416,7 +416,6 @@ namespace Snowflake.Data.Client
             Task task = RetryUntilQueryResultIsAvailable(queryId, CancellationToken.None, false);
             task.Wait();
 
-            connection.SfSession.AsyncQueries.Remove(queryId);
             SFBaseResultSet resultSet = sfStatement.GetResultWithId(queryId);
 
             return new SnowflakeDbDataReader(this, resultSet);
@@ -434,7 +433,6 @@ namespace Snowflake.Data.Client
 
             await RetryUntilQueryResultIsAvailable(queryId, cancellationToken, true);
 
-            connection.SfSession.AsyncQueries.Remove(queryId);
             SFBaseResultSet resultSet = await sfStatement.GetResultWithIdAsync(queryId, cancellationToken).ConfigureAwait(false);
 
             return new SnowflakeDbDataReader(this, resultSet);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -402,6 +402,16 @@ namespace Snowflake.Data.Client
             }
         }
 
+        public bool IsStillRunning(QueryStatus status)
+        {
+            return QueryStatusExtensions.IsStillRunning(status);
+        }
+
+        public bool IsAnError(QueryStatus status)
+        {
+            return QueryStatusExtensions.IsAnError(status);
+        }
+
         ~SnowflakeDbConnection()
         {
             Dispose(false);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -153,8 +153,8 @@ namespace Snowflake.Data.Client
             {
                 var transactionRollbackStatus = SnowflakeDbConnectionPool.GetPooling() ? TerminateTransactionForDirtyConnectionReturningToPool() : TransactionRollbackStatus.Undefined;
                 
-                if (CanReuseSession(transactionRollbackStatus) &&
-                    SfSession.StillRunningAsyncQueries() &&
+                if ((CanReuseSession(transactionRollbackStatus) ||
+                    SfSession.StillRunningAsyncQueries()) &&
                     SnowflakeDbConnectionPool.AddSession(SfSession)
                     )
                 {
@@ -194,8 +194,8 @@ namespace Snowflake.Data.Client
                 {
                     var transactionRollbackStatus = SnowflakeDbConnectionPool.GetPooling() ? TerminateTransactionForDirtyConnectionReturningToPool() : TransactionRollbackStatus.Undefined;
 
-                    if (CanReuseSession(transactionRollbackStatus) &&
-                        await SfSession.StillRunningAsyncQueriesAsync(cancellationToken).ConfigureAwait(false) &&
+                    if ((CanReuseSession(transactionRollbackStatus) ||
+                        await SfSession.StillRunningAsyncQueriesAsync(cancellationToken).ConfigureAwait(false)) &&
                         SnowflakeDbConnectionPool.AddSession(SfSession))
                     {
                         logger.Debug($"Session pooled: {SfSession.sessionId}");

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -153,10 +153,7 @@ namespace Snowflake.Data.Client
             {
                 var transactionRollbackStatus = SnowflakeDbConnectionPool.GetPooling() ? TerminateTransactionForDirtyConnectionReturningToPool() : TransactionRollbackStatus.Undefined;
                 
-                if ((CanReuseSession(transactionRollbackStatus) ||
-                    SfSession.StillRunningAsyncQueries()) &&
-                    SnowflakeDbConnectionPool.AddSession(SfSession)
-                    )
+                if (CanReuseSession(transactionRollbackStatus) && SnowflakeDbConnectionPool.AddSession(SfSession))
                 {
                     logger.Debug($"Session pooled: {SfSession.sessionId}");
                 }
@@ -194,9 +191,7 @@ namespace Snowflake.Data.Client
                 {
                     var transactionRollbackStatus = SnowflakeDbConnectionPool.GetPooling() ? TerminateTransactionForDirtyConnectionReturningToPool() : TransactionRollbackStatus.Undefined;
 
-                    if ((CanReuseSession(transactionRollbackStatus) ||
-                        await SfSession.StillRunningAsyncQueriesAsync(cancellationToken).ConfigureAwait(false)) &&
-                        SnowflakeDbConnectionPool.AddSession(SfSession))
+                    if (CanReuseSession(transactionRollbackStatus) && SnowflakeDbConnectionPool.AddSession(SfSession))
                     {
                         logger.Debug($"Session pooled: {SfSession.sessionId}");
                         _connectionState = ConnectionState.Closed;

--- a/Snowflake.Data/Core/QueryResultsAwaiter.cs
+++ b/Snowflake.Data/Core/QueryResultsAwaiter.cs
@@ -11,7 +11,7 @@ using Snowflake.Data.Client;
 
 namespace Snowflake.Data.Core
 {
-    public class QueryResultsRetryConfig
+    internal class QueryResultsRetryConfig
     {
         private const int DefaultAsyncNoDataMaxRetry = 24;
 
@@ -41,6 +41,8 @@ namespace Snowflake.Data.Core
         private static readonly Regex UuidRegex = new Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
         private QueryResultsRetryConfig _queryResultsRetryConfig;
+
+        internal static readonly QueryResultsAwaiter Instance = new QueryResultsAwaiter();
 
         internal QueryResultsAwaiter()
         {

--- a/Snowflake.Data/Core/QueryResultsAwaiter.cs
+++ b/Snowflake.Data/Core/QueryResultsAwaiter.cs
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+using Snowflake.Data.Log;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.Text.RegularExpressions;
+using Snowflake.Data.Client;
+
+namespace Snowflake.Data.Core
+{
+    public class QueryResultsRetryConfig
+    {
+        private const int DefaultAsyncNoDataMaxRetry = 24;
+
+        private readonly int[] _defaultAsyncRetryPattern = { 1, 1, 2, 3, 4, 8, 10 };
+
+        internal readonly int _asyncNoDataMaxRetry;
+
+        internal readonly int[] _asyncRetryPattern;
+
+        internal QueryResultsRetryConfig()
+        {
+            _asyncNoDataMaxRetry = DefaultAsyncNoDataMaxRetry;
+            _asyncRetryPattern = _defaultAsyncRetryPattern;
+        }
+
+        internal QueryResultsRetryConfig(int asyncNoDataMaxRetry, int[] asyncRetryPattern)
+        {
+            _asyncNoDataMaxRetry = asyncNoDataMaxRetry;
+            _asyncRetryPattern = asyncRetryPattern;
+        }
+    }
+
+    internal class QueryResultsAwaiter
+    {
+        private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<QueryResultsAwaiter>();
+
+        private static readonly Regex UuidRegex = new Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+        private QueryResultsRetryConfig _queryResultsRetryConfig;
+
+        internal QueryResultsAwaiter()
+        {
+            _queryResultsRetryConfig = new QueryResultsRetryConfig();
+        }
+
+        internal QueryResultsAwaiter(QueryResultsRetryConfig queryResultsRetryConfig)
+        {
+            _queryResultsRetryConfig = queryResultsRetryConfig;
+        }
+
+        internal QueryStatus GetQueryStatus(SnowflakeDbConnection connection, string queryId)
+        {
+            if (UuidRegex.IsMatch(queryId))
+            {
+                var sfStatement = new SFStatement(connection.SfSession);
+                return sfStatement.GetQueryStatus(queryId);
+            }
+            else
+            {
+                var errorMessage = $"The given query id {queryId} is not valid uuid";
+                s_logger.Error(errorMessage);
+                throw new Exception(errorMessage);
+            }
+        }
+
+        internal async Task<QueryStatus> GetQueryStatusAsync(SnowflakeDbConnection connection, string queryId, CancellationToken cancellationToken)
+        {
+            if (UuidRegex.IsMatch(queryId))
+            {
+                var sfStatement = new SFStatement(connection.SfSession);
+                return await sfStatement.GetQueryStatusAsync(queryId, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var errorMessage = $"The given query id {queryId} is not valid uuid";
+                s_logger.Error(errorMessage);
+                throw new Exception(errorMessage);
+            }
+        }
+
+        /// <summary>
+        /// Checks query status until it is done executing.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="queryId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <param name="isAsync"></param>
+        internal async Task RetryUntilQueryResultIsAvailable(SnowflakeDbConnection connection, string queryId, CancellationToken cancellationToken, bool isAsync)
+        {
+            int retryPatternPos = 0;
+            int noDataCounter = 0;
+
+            QueryStatus status;
+            while (true)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    s_logger.Debug("Cancellation requested for getting results from query id");
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                status = isAsync ? await GetQueryStatusAsync(connection, queryId, cancellationToken) : GetQueryStatus(connection, queryId);
+
+                if (!QueryStatusExtensions.IsStillRunning(status))
+                {
+                    return;
+                }
+
+                // Timeout based on query status retry rules
+                if (isAsync)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(_queryResultsRetryConfig._asyncRetryPattern[retryPatternPos]), cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(_queryResultsRetryConfig._asyncRetryPattern[retryPatternPos]));
+                }
+
+                // If no data, increment the no data counter
+                if (status == QueryStatus.NoData)
+                {
+                    noDataCounter++;
+
+                    // Check if retry for no data is exceeded
+                    if (noDataCounter > _queryResultsRetryConfig._asyncNoDataMaxRetry)
+                    {
+                        var errorMessage = "Max retry for no data is reached";
+                        s_logger.Error(errorMessage);
+                        throw new Exception(errorMessage);
+                    }
+                }
+
+                if (retryPatternPos < _queryResultsRetryConfig._asyncRetryPattern.Length - 1)
+                {
+                    retryPatternPos++;
+                }
+            }
+        }
+    }
+}

--- a/Snowflake.Data/Core/RestParams.cs
+++ b/Snowflake.Data/Core/RestParams.cs
@@ -39,6 +39,8 @@ namespace Snowflake.Data.Core
 
         internal const string SF_QUERY_PATH = "/queries/v1/query-request";
 
+        internal const string SF_MONITOR_QUERY_PATH = "/monitoring/queries/";
+
         internal const string SF_SESSION_HEARTBEAT_PATH = SF_SESSION_PATH + "/heartbeat";
 
         internal const string SF_CONSOLE_LOGIN = "/console/login";

--- a/Snowflake.Data/Core/RestRequest.cs
+++ b/Snowflake.Data/Core/RestRequest.cs
@@ -129,6 +129,8 @@ namespace Snowflake.Data.Core
 
         internal bool _isLogin { get; set; }
 
+        internal bool _isStatusRequest { get; set; }
+
         public override string ToString()
         {
             return String.Format("SFRestRequest {{url: {0}, request body: {1} }}", Url.ToString(), 
@@ -154,7 +156,7 @@ namespace Snowflake.Data.Core
             // add quote otherwise it would be reported as error format
             string osInfo = "(" + SFEnvironment.ClientEnv.osVersion + ")";
 
-            if (isPutGet)
+            if (isPutGet || _isStatusRequest)
             {
                 message.Headers.Accept.Add(applicationJson);
             }
@@ -313,6 +315,9 @@ namespace Snowflake.Data.Core
 
         [JsonProperty(PropertyName = "queryContextDTO", NullValueHandling = NullValueHandling.Ignore)]
         internal RequestQueryContext QueryContextDTO { get; set; }
+
+        [JsonProperty(PropertyName = "asyncExec")]
+        internal bool asyncExec { get; set; }
     }
 
     // The query context in query response

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -423,6 +423,37 @@ namespace Snowflake.Data.Core
         internal long smkId { get; set; }
     }
 
+    internal class QueryStatusResponse : BaseRestResponse
+    {
+
+        [JsonProperty(PropertyName = "data")]
+        internal QueryStatusData data { get; set; }
+    }
+
+    internal class QueryStatusData
+    {
+        [JsonProperty(PropertyName = "queries", NullValueHandling = NullValueHandling.Ignore)]
+        internal List<QueryStatusDataQueries> queries { get; set; }
+    }
+
+    internal class QueryStatusDataQueries
+    {
+        [JsonProperty(PropertyName = "id", NullValueHandling = NullValueHandling.Ignore)]
+        internal string id { get; set; }
+
+        [JsonProperty(PropertyName = "status", NullValueHandling = NullValueHandling.Ignore)]
+        internal string status { get; set; }
+
+        [JsonProperty(PropertyName = "state", NullValueHandling = NullValueHandling.Ignore)]
+        internal string state { get; set; }
+
+        [JsonProperty(PropertyName = "errorCode", NullValueHandling = NullValueHandling.Ignore)]
+        internal string errorCode { get; set; }
+
+        [JsonProperty(PropertyName = "errorMessage", NullValueHandling = NullValueHandling.Ignore)]
+        internal string errorMessage { get; set; }
+    }
+
     // Retrieved from: https://stackoverflow.com/a/18997172
     internal class SingleOrArrayConverter<T> : JsonConverter
     {

--- a/Snowflake.Data/Core/SFBindUploader.cs
+++ b/Snowflake.Data/Core/SFBindUploader.cs
@@ -290,7 +290,7 @@ namespace Snowflake.Data.Core
                     try
                     {
                         SFStatement statement = new SFStatement(session);
-                        SFBaseResultSet resultSet = statement.Execute(0, CREATE_STAGE_STMT, null, false);
+                        SFBaseResultSet resultSet = statement.Execute(0, CREATE_STAGE_STMT, null, false, false);
                         session.SetArrayBindStage(STAGE_NAME);
                     }
                     catch (Exception e)
@@ -314,7 +314,7 @@ namespace Snowflake.Data.Core
                 try
                 {
                     SFStatement statement = new SFStatement(session);
-                    var resultSet = await statement.ExecuteAsync(0, CREATE_STAGE_STMT, null, false, cancellationToken).ConfigureAwait(false);
+                    var resultSet = await statement.ExecuteAsync(0, CREATE_STAGE_STMT, null, false, false, cancellationToken).ConfigureAwait(false);
                     session.SetArrayBindStage(STAGE_NAME);
                 }
                 catch (Exception e)

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Core
         {
             try
             {
-                columnCount = responseData.rowType.Count;
+                columnCount = responseData.rowType?.Count ?? 0;
 
                 this.sfStatement = sfStatement;
                 UpdateSessionStatus(responseData);
@@ -40,10 +40,10 @@ namespace Snowflake.Data.Core
                     _chunkDownloader = ChunkDownloaderFactory.GetDownloader(responseData, this, cancellationToken);
                 }
 
-                _currentChunk = new SFResultChunk(responseData.rowSet);
+                _currentChunk = responseData.rowSet != null ? new SFResultChunk(responseData.rowSet) : null;
                 responseData.rowSet = null;
 
-                sfResultSetMetaData = new SFResultSetMetaData(responseData, this.sfStatement.SfSession);
+                sfResultSetMetaData = responseData.rowType != null ? new SFResultSetMetaData(responseData, this.sfStatement.SfSession) : null;
 
                 isClosed = false;
 

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -366,11 +366,7 @@ namespace Snowflake.Data.Core
 
                 var lastResultUrl = response.data?.getResultUrl;
 
-                if (asyncExec)
-                {
-                    SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
-                }
-                else
+                if (!asyncExec)
                 {
                     while (RequestInProgress(response) || SessionExpired(response))
                     {
@@ -628,11 +624,7 @@ namespace Snowflake.Data.Core
                 if (typeof(T) == typeof(QueryExecResponse))
                 {
                     QueryExecResponse queryResponse = (QueryExecResponse)(object)response;
-                    if (asyncExec)
-                    {
-                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
-                    }
-                    else
+                    if (!asyncExec)
                     {
                         var lastResultUrl = queryResponse.data?.getResultUrl;
 
@@ -719,11 +711,7 @@ namespace Snowflake.Data.Core
                 if (typeof(T) == typeof(QueryExecResponse))
                 {
                     QueryExecResponse queryResponse = (QueryExecResponse)(object)response;
-                    if (asyncExec)
-                    {
-                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
-                    }
-                    else
+                    if (!asyncExec)
                     {
                         var lastResultUrl = queryResponse.data?.getResultUrl;
 
@@ -830,7 +818,6 @@ namespace Snowflake.Data.Core
                 QueryStatus queryStatus;
                 Enum.TryParse(status, true, out queryStatus);
 
-                SfSession.AsyncQueries[queryId] = queryStatus;
                 return queryStatus;
             }
             catch
@@ -885,7 +872,6 @@ namespace Snowflake.Data.Core
                 QueryStatus queryStatus;
                 Enum.TryParse(status, true, out queryStatus);
 
-                SfSession.AsyncQueries[queryId] = queryStatus;
                 return queryStatus;
             }
             catch

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -31,7 +31,7 @@ namespace Snowflake.Data.Core
         FailedWithIncident,
         Disconnected,
         ResumingWarehouse,
-        // purposeful typo.Is present in QueryDTO.java
+        // purposeful typo
         QueuedReparingWarehouse,
         Restarted,
         Blocked,

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -49,9 +49,9 @@ namespace Snowflake.Data.Core
         Blocked,
     }
 
-    internal static class QueryStatuses
+    internal static class QueryStatusExtensions
     {
-        internal static QueryStatus GetQueryStatusByDescription(string description)
+        internal static QueryStatus GetQueryStatusByStringValue(string description)
         {
             return Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
@@ -834,7 +834,7 @@ namespace Snowflake.Data.Core
                 QueryStatus queryStatus = QueryStatus.NoData;
                 if (response.data.queries.Count != 0)
                 {
-                    queryStatus = QueryStatuses.GetQueryStatusByDescription(response.data.queries[0].status);
+                    queryStatus = QueryStatusExtensions.GetQueryStatusByStringValue(response.data.queries[0].status);
                 }
 
                 return queryStatus;
@@ -889,7 +889,7 @@ namespace Snowflake.Data.Core
                 QueryStatus queryStatus = QueryStatus.NoData;
                 if (response.data.queries.Count != 0)
                 {
-                    queryStatus = QueryStatuses.GetQueryStatusByDescription(response.data.queries[0].status);
+                    queryStatus = QueryStatusExtensions.GetQueryStatusByStringValue(response.data.queries[0].status);
                 }
 
                 return queryStatus;

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -55,7 +55,7 @@ namespace Snowflake.Data.Core
         {
             return Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
-                .FirstOrDefault(v => v.GetAttribute<DescriptionAttribute>().Description == description);
+                .FirstOrDefault(v => v.GetAttribute<DescriptionAttribute>().Description.Equals(description, StringComparison.OrdinalIgnoreCase));
         }
 
         internal static bool IsStillRunning(QueryStatus status)

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -22,20 +22,20 @@ namespace Snowflake.Data.Core
     /// </summary>
     public enum QueryStatus
     {
-        RUNNING,
-        ABORTING,
-        SUCCESS,
-        FAILED_WITH_ERROR,
-        ABORTED,
-        QUEUED,
-        FAILED_WITH_INCIDENT,
-        DISCONNECTED,
-        RESUMING_WAREHOUSE,
+        Running,
+        Aborting,
+        Success,
+        FailedWithError,
+        Aborted,
+        Queued,
+        FailedWithIncident,
+        Disconnected,
+        ResumingWarehouse,
         // purposeful typo.Is present in QueryDTO.java
-        QUEUED_REPARING_WAREHOUSE,
-        RESTARTED,
-        BLOCKED,
-        NO_DATA,
+        QueuedReparingWarehouse,
+        Restarted,
+        Blocked,
+        NoData,
     }
 
     internal static class QueryStatuses
@@ -44,11 +44,11 @@ namespace Snowflake.Data.Core
         {
             switch (status)
             {
-                case QueryStatus.RUNNING:
-                case QueryStatus.RESUMING_WAREHOUSE:
-                case QueryStatus.QUEUED:
-                case QueryStatus.QUEUED_REPARING_WAREHOUSE:
-                case QueryStatus.NO_DATA:
+                case QueryStatus.Running:
+                case QueryStatus.ResumingWarehouse:
+                case QueryStatus.Queued:
+                case QueryStatus.QueuedReparingWarehouse:
+                case QueryStatus.NoData:
                     return true;
                 default:
                     return false;
@@ -59,12 +59,12 @@ namespace Snowflake.Data.Core
         {
             switch (status)
             {
-                case QueryStatus.ABORTING:
-                case QueryStatus.FAILED_WITH_ERROR:
-                case QueryStatus.ABORTED:
-                case QueryStatus.FAILED_WITH_INCIDENT:
-                case QueryStatus.DISCONNECTED:
-                case QueryStatus.BLOCKED:
+                case QueryStatus.Aborting:
+                case QueryStatus.FailedWithError:
+                case QueryStatus.Aborted:
+                case QueryStatus.FailedWithIncident:
+                case QueryStatus.Disconnected:
+                case QueryStatus.Blocked:
                     return true;
                 default:
                     return false;
@@ -368,7 +368,7 @@ namespace Snowflake.Data.Core
 
                 if (asyncExec)
                 {
-                    SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.RUNNING);
+                    SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
                 }
                 else
                 {
@@ -630,7 +630,7 @@ namespace Snowflake.Data.Core
                     QueryExecResponse queryResponse = (QueryExecResponse)(object)response;
                     if (asyncExec)
                     {
-                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.RUNNING);
+                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
                     }
                     else
                     {
@@ -721,7 +721,7 @@ namespace Snowflake.Data.Core
                     QueryExecResponse queryResponse = (QueryExecResponse)(object)response;
                     if (asyncExec)
                     {
-                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.RUNNING);
+                        SfSession.AsyncQueries.Add(response.data.queryId, QueryStatus.Running);
                     }
                     else
                     {
@@ -825,10 +825,10 @@ namespace Snowflake.Data.Core
                         queryId);
                 }
 
-                var status = response.data.queries.Count != 0 ? response.data.queries[0].status : QueryStatus.NO_DATA.ToString();
+                var status = response.data.queries.Count != 0 ? response.data.queries[0].status.Replace("_", string.Empty) : QueryStatus.NoData.ToString();
 
                 QueryStatus queryStatus;
-                Enum.TryParse(status, out queryStatus);
+                Enum.TryParse(status, true, out queryStatus);
 
                 SfSession.AsyncQueries[queryId] = queryStatus;
                 return queryStatus;
@@ -880,10 +880,10 @@ namespace Snowflake.Data.Core
                         queryId);
                 }
 
-                var status = response.data.queries.Count != 0 ? response.data.queries[0].status : QueryStatus.NO_DATA.ToString();
+                var status = response.data.queries.Count != 0 ? response.data.queries[0].status.Replace("_", string.Empty) : QueryStatus.NoData.ToString();
 
                 QueryStatus queryStatus;
-                Enum.TryParse(status, out queryStatus);
+                Enum.TryParse(status, true, out queryStatus);
 
                 SfSession.AsyncQueries[queryId] = queryStatus;
                 return queryStatus;

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -20,6 +20,8 @@ namespace Snowflake.Data.Core
     /// </summary>
     public enum QueryStatus
     {
+        [Description("UNKNOWN")]
+        Unknown,
         [Description("NO_DATA")]
         NoData,
         [Description("RUNNING")]
@@ -53,9 +55,16 @@ namespace Snowflake.Data.Core
     {
         internal static QueryStatus GetQueryStatusByStringValue(string description)
         {
-            return Enum.GetValues(typeof(QueryStatus))
+            var status =  Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
                 .FirstOrDefault(v => v.GetAttribute<DescriptionAttribute>().Description.Equals(description, StringComparison.OrdinalIgnoreCase));
+
+            if (status == QueryStatus.Unknown)
+            {
+                throw new Exception("The query status returned by the server is not recognized");
+            }
+
+            return status;
         }
 
         internal static bool IsStillRunning(QueryStatus status)

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -3,13 +3,10 @@
  */
 
 using System;
-using System.Web;
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Snowflake.Data.Client;
-using Snowflake.Data.Core.FileTransfer;
 using Snowflake.Data.Log;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -11,7 +11,6 @@ using Snowflake.Data.Log;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
-using System.ComponentModel;
 
 namespace Snowflake.Data.Core
 {

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -500,13 +500,13 @@ namespace Snowflake.Data.Core
                     }
                 }
 
-                    QueryExecResponse response =
-                        ExecuteHelper<QueryExecResponse, QueryExecResponseData>(
-                             timeout,
-                             sql,
-                             bindings,
-                             describeOnly,
-                             asyncExec);
+                QueryExecResponse response =
+                ExecuteHelper<QueryExecResponse, QueryExecResponseData>(
+                    timeout,
+                    sql,
+                    bindings,
+                    describeOnly,
+                    asyncExec);
 
                 return BuildResultSet(response, CancellationToken.None);
             }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -411,6 +411,10 @@ namespace Snowflake.Data.Core
             {
                 if (IsPutOrGetCommand(trimmedSql))
                 {
+                    if (asyncExec)
+                    {
+                        throw new NotImplementedException("Get and Put are not supported in async execution mode");
+                    }
                     return ExecuteSqlWithPutGet(timeout, trimmedSql, bindings, describeOnly);
                 }
 

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -14,6 +14,7 @@ using Snowflake.Data.Log;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
+using System.ComponentModel;
 
 namespace Snowflake.Data.Core
 {
@@ -22,24 +23,44 @@ namespace Snowflake.Data.Core
     /// </summary>
     public enum QueryStatus
     {
+        [Description("NO_DATA")]
+        NoData,
+        [Description("RUNNING")]
         Running,
+        [Description("ABORTING")]
         Aborting,
+        [Description("SUCCESS")]
         Success,
+        [Description("FAILED_WITH_ERROR")]
         FailedWithError,
+        [Description("ABORTED")]
         Aborted,
+        [Description("QUEUED")]
         Queued,
+        [Description("FAILED_WITH_INCIDENT")]
         FailedWithIncident,
+        [Description("DISCONNECTED")]
         Disconnected,
+        [Description("RESUMING_WAREHOUSE")]
         ResumingWarehouse,
         // purposeful typo
+        [Description("QUEUED_REPARING_WAREHOUSE")]
         QueuedReparingWarehouse,
+        [Description("RESTARTED")]
         Restarted,
+        [Description("BLOCKED")]
         Blocked,
-        NoData,
     }
 
     internal static class QueryStatuses
     {
+        internal static QueryStatus GetQueryStatusByDescription(string description)
+        {
+            return Enum.GetValues(typeof(QueryStatus))
+                .Cast<QueryStatus>()
+                .FirstOrDefault(v => v.GetAttribute<DescriptionAttribute>().Description == description);
+        }
+
         internal static bool IsStillRunning(QueryStatus status)
         {
             switch (status)
@@ -813,10 +834,11 @@ namespace Snowflake.Data.Core
                         queryId);
                 }
 
-                var status = response.data.queries.Count != 0 ? response.data.queries[0].status.Replace("_", string.Empty) : QueryStatus.NoData.ToString();
-
-                QueryStatus queryStatus;
-                Enum.TryParse(status, true, out queryStatus);
+                QueryStatus queryStatus = QueryStatus.NoData;
+                if (response.data.queries.Count != 0)
+                {
+                    queryStatus = QueryStatuses.GetQueryStatusByDescription(response.data.queries[0].status);
+                }
 
                 return queryStatus;
             }
@@ -867,10 +889,11 @@ namespace Snowflake.Data.Core
                         queryId);
                 }
 
-                var status = response.data.queries.Count != 0 ? response.data.queries[0].status.Replace("_", string.Empty) : QueryStatus.NoData.ToString();
-
-                QueryStatus queryStatus;
-                Enum.TryParse(status, true, out queryStatus);
+                QueryStatus queryStatus = QueryStatus.NoData;
+                if (response.data.queries.Count != 0)
+                {
+                    queryStatus = QueryStatuses.GetQueryStatusByDescription(response.data.queries[0].status);
+                }
 
                 return queryStatus;
             }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -20,35 +20,40 @@ namespace Snowflake.Data.Core
     /// </summary>
     public enum QueryStatus
     {
-        [Description("UNKNOWN")]
+        [StringAttr(value = "UNKNOWN")]
         Unknown,
-        [Description("NO_DATA")]
+        [StringAttr(value = "NO_DATA")]
         NoData,
-        [Description("RUNNING")]
+        [StringAttr(value = "RUNNING")]
         Running,
-        [Description("ABORTING")]
+        [StringAttr(value = "ABORTING")]
         Aborting,
-        [Description("SUCCESS")]
+        [StringAttr(value = "SUCCESS")]
         Success,
-        [Description("FAILED_WITH_ERROR")]
+        [StringAttr(value = "FAILED_WITH_ERROR")]
         FailedWithError,
-        [Description("ABORTED")]
+        [StringAttr(value = "ABORTED")]
         Aborted,
-        [Description("QUEUED")]
+        [StringAttr(value = "QUEUED")]
         Queued,
-        [Description("FAILED_WITH_INCIDENT")]
+        [StringAttr(value = "FAILED_WITH_INCIDENT")]
         FailedWithIncident,
-        [Description("DISCONNECTED")]
+        [StringAttr(value = "DISCONNECTED")]
         Disconnected,
-        [Description("RESUMING_WAREHOUSE")]
+        [StringAttr(value = "RESUMING_WAREHOUSE")]
         ResumingWarehouse,
         // purposeful typo
-        [Description("QUEUED_REPARING_WAREHOUSE")]
+        [StringAttr(value = "QUEUED_REPARING_WAREHOUSE")]
         QueuedReparingWarehouse,
-        [Description("RESTARTED")]
+        [StringAttr(value = "RESTARTED")]
         Restarted,
-        [Description("BLOCKED")]
+        [StringAttr(value = "BLOCKED")]
         Blocked,
+    }
+
+    class StringAttr : Attribute
+    {
+        public string value { get; set; }
     }
 
     internal static class QueryStatusExtensions
@@ -57,7 +62,7 @@ namespace Snowflake.Data.Core
         {
             var status =  Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
-                .FirstOrDefault(v => v.GetAttribute<DescriptionAttribute>().Description.Equals(description, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(v => v.GetAttribute<StringAttr>().value.Equals(description, StringComparison.OrdinalIgnoreCase));
 
             if (status == QueryStatus.Unknown)
             {

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -497,12 +497,12 @@ namespace Snowflake.Data.Core
                 }
 
                 QueryExecResponse response =
-                ExecuteHelper<QueryExecResponse, QueryExecResponseData>(
-                    timeout,
-                    sql,
-                    bindings,
-                    describeOnly,
-                    asyncExec);
+                    ExecuteHelper<QueryExecResponse, QueryExecResponseData>(
+                        timeout,
+                        sql,
+                        bindings,
+                        describeOnly,
+                        asyncExec);
 
                 return BuildResultSet(response, CancellationToken.None);
             }

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -57,11 +57,11 @@ namespace Snowflake.Data.Core
 
     internal static class QueryStatusExtensions
     {
-        internal static QueryStatus GetQueryStatusByStringValue(string description)
+        internal static QueryStatus GetQueryStatusByStringValue(string stringValue)
         {
             var status =  Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
-                .FirstOrDefault(v => v.GetAttribute<StringAttr>().value.Equals(description, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(v => v.GetAttribute<StringAttr>().value.Equals(stringValue, StringComparison.OrdinalIgnoreCase));
 
             if (status == QueryStatus.Unknown)
             {

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -19,8 +19,6 @@ namespace Snowflake.Data.Core
     /// </summary>
     public enum QueryStatus
     {
-        [StringAttr(value = "UNKNOWN")]
-        Unknown,
         [StringAttr(value = "NO_DATA")]
         NoData,
         [StringAttr(value = "RUNNING")]
@@ -59,16 +57,10 @@ namespace Snowflake.Data.Core
     {
         internal static QueryStatus GetQueryStatusByStringValue(string stringValue)
         {
-            var status =  Enum.GetValues(typeof(QueryStatus))
+            var statuses = Enum.GetValues(typeof(QueryStatus))
                 .Cast<QueryStatus>()
-                .FirstOrDefault(v => v.GetAttribute<StringAttr>().value.Equals(stringValue, StringComparison.OrdinalIgnoreCase));
-
-            if (status == QueryStatus.Unknown)
-            {
-                throw new Exception("The query status returned by the server is not recognized");
-            }
-
-            return status;
+                .Where(v => v.GetAttribute<StringAttr>().value.Equals(stringValue, StringComparison.OrdinalIgnoreCase));
+            return statuses.Any() ? statuses.First() : throw new Exception("The query status returned by the server is not recognized");
         }
 
         internal static bool IsStillRunning(QueryStatus status)

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -577,54 +577,6 @@ namespace Snowflake.Data.Core
         {
             return _startTime + timeoutInSeconds <= utcTimeInSeconds;
         }
-
-        /// <summary>
-        /// Contains the ID and status of queries executed in async mode
-        /// </summary>
-        internal Dictionary<string, QueryStatus> AsyncQueries = new Dictionary<string, QueryStatus>();
-
-        /// <summary>
-        /// Checks if the session contains async queries that are still executing
-        /// </summary>
-        /// <returns>True if session can be closed, false otherwise</returns>
-        internal bool StillRunningAsyncQueries()
-        {
-            foreach (var query in AsyncQueries.ToList())
-            {
-                var sfStatement = new SFStatement(this);
-                var status = sfStatement.GetQueryStatus(query.Key);
-                if (QueryStatuses.IsStillRunning(status))
-                {
-                    return true;
-                }
-
-                AsyncQueries.Remove(query.Key);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Checks if the session contains async queries that are still executing
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns>True if session can be closed, false otherwise</returns>
-        internal async Task<bool> StillRunningAsyncQueriesAsync(CancellationToken cancellationToken)
-        {
-            foreach (var query in AsyncQueries.ToList())
-            {
-                var sfStatement = new SFStatement(this);
-                var status = await sfStatement.GetQueryStatusAsync(query.Key, cancellationToken).ConfigureAwait(false);
-                if (QueryStatuses.IsStillRunning(status))
-                {
-                    return true;
-                }
-
-                AsyncQueries.Remove(query.Key);
-            }
-
-            return false;
-        }
     }
 }
 


### PR DESCRIPTION
### Description
- Adds the option to execute queries in async mode
- Adds the capability to asynchronously wait for the query to finish and get the results using the query ID
- Adds checking the query status
- Adds checking if query is still running or encountered an error

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name