### PR TITLE
SNOW-1232318 fix account name validation

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -27,11 +27,34 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
+        [TestCase("a", "a", "a.snowflakecomputing.com")]
+        [TestCase("ab", "ab", "ab.snowflakecomputing.com")]
+        [TestCase("a.b", "a", "a.b.snowflakecomputing.com")]
+        [TestCase("a-b", "a-b", "a-b.snowflakecomputing.com")]
+        [TestCase("a_b", "a_b", "a-b.snowflakecomputing.com")]
+        [TestCase("abc", "abc", "abc.snowflakecomputing.com")]
+        public void TestValidateCorrectAccountNames(string accountName, string expectedAccountName, string expectedHost)
+        {
+            // arrange
+            var connectionString = $"ACCOUNT={accountName};USER=test;PASSWORD=test;";
+            
+            // act
+            var properties = SFSessionProperties.parseConnectionString(connectionString, null);
+            
+            // assert
+            Assert.AreEqual(expectedAccountName, properties[SFSessionProperty.ACCOUNT]);
+            Assert.AreEqual(expectedHost, properties[SFSessionProperty.HOST]);
+        }
+        
+        [Test]
         [TestCase("ACCOUNT=testaccount;USER=testuser;PASSWORD=testpassword;FILE_TRANSFER_MEMORY_THRESHOLD=0;", "Error: Invalid parameter value 0 for FILE_TRANSFER_MEMORY_THRESHOLD")]
         [TestCase("ACCOUNT=testaccount;USER=testuser;PASSWORD=testpassword;FILE_TRANSFER_MEMORY_THRESHOLD=xyz;", "Error: Invalid parameter value xyz for FILE_TRANSFER_MEMORY_THRESHOLD")]
         [TestCase("ACCOUNT=testaccount?;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value testaccount? for ACCOUNT")]
         [TestCase("ACCOUNT=complicated.long.testaccount?;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value complicated.long.testaccount? for ACCOUNT")]
         [TestCase("ACCOUNT=?testaccount;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value ?testaccount for ACCOUNT")]
+        [TestCase("ACCOUNT=.testaccount;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value .testaccount for ACCOUNT")]
+        [TestCase("ACCOUNT=testaccount.;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value testaccount. for ACCOUNT")]
+        [TestCase("ACCOUNT=test%account;USER=testuser;PASSWORD=testpassword", "Error: Invalid parameter value test%account for ACCOUNT")]
         public void TestThatItFailsForWrongConnectionParameter(string connectionString, string expectedErrorMessagePart)
         {
             // act

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -33,6 +33,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase("a-b", "a-b", "a-b.snowflakecomputing.com")]
         [TestCase("a_b", "a_b", "a-b.snowflakecomputing.com")]
         [TestCase("abc", "abc", "abc.snowflakecomputing.com")]
+        [TestCase("xy12345.us-east-2.aws", "xy12345", "xy12345.us-east-2.aws.snowflakecomputing.com")]
         public void TestValidateCorrectAccountNames(string accountName, string expectedAccountName, string expectedHost)
         {
             // arrange

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -117,8 +117,13 @@ namespace Snowflake.Data.Core
                 SFSessionProperty.PRIVATE_KEY_PWD,
                 SFSessionProperty.PROXYPASSWORD,
             };
-        
-        private const string AccountRegexString = "^\\w[\\w.-]+\\w$";
+
+        private static readonly List<string> s_accountRegexStrings = new List<string>
+        {
+            "^\\w",
+            "\\w$",
+            "^[\\w.-]+$"
+        };
 
         public override bool Equals(object obj)
         {
@@ -292,8 +297,7 @@ namespace Snowflake.Data.Core
             var account = properties[SFSessionProperty.ACCOUNT];
             if (string.IsNullOrEmpty(account))
                 return;
-            var match = Regex.Match(account, AccountRegexString, RegexOptions.IgnoreCase);
-            if (match.Success)
+            if (IsAccountRegexMatched(account))
                 return;
             logger.Error($"Invalid account {account}");
             throw new SnowflakeDbException(
@@ -302,6 +306,11 @@ namespace Snowflake.Data.Core
                 account,
                 SFSessionProperty.ACCOUNT);
         }
+
+        private static bool IsAccountRegexMatched(string account) =>
+            s_accountRegexStrings
+                .Select(regex => Regex.Match(account, regex, RegexOptions.IgnoreCase))
+                .All(match => match.Success);
 
         private static void checkSessionProperties(SFSessionProperties properties)
         {


### PR DESCRIPTION
### Description
SNOW-1232318 Fix account name validation to allow account name be even 1 or 2 chars long

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name