### PR TITLE
SNOW-973444: Change Prepare to be handled as a Noop

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -60,9 +60,9 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        public void TestCommandPrepareThrowsNotImplemented()
+        public void TestCommandPrepareShouldNotThrowsException()
         {
-            Assert.Throws<NotImplementedException>(() => command.Prepare());
+            Assert.DoesNotThrow(() => command.Prepare());
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -239,9 +239,12 @@ namespace Snowflake.Data.Client
                 return DBNull.Value;
         }
 
+        /// <summary>
+        /// Prepares the command for execution.
+        /// This method is currently not implemented and acts as a no-operation (Noop).
+        /// </summary>
         public override void Prepare()
         {
-            // Currently handled as a Noop
         }
 
         public string GetQueryId()

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -241,7 +241,7 @@ namespace Snowflake.Data.Client
 
         public override void Prepare()
         {
-            throw new NotImplementedException();
+            // Currently handled as a Noop
         }
 
         public string GetQueryId()


### PR DESCRIPTION
### Description
Change Prepare method to be handled as a noop, removed throw NotImplementedException.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name