### PR TITLE
Pool/SNOW-937183 Prevent evicted connections from returning to the pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,12 @@ CancellationTokenSource cancellationTokenSource  = new CancellationTokenSource()
 ((SnowflakeDbConnection)conn).CloseAsync(cancellationTokenSource.Token);
 ```
 
+Evict the Connection
+--------------------
+
+For the open connection, call the `PreventFromReturningToPool()` to make the connection not return to the pool.
+The busy sessions counter will be decreased when the connection is closed.
+
 Logging
 -------
 The Snowflake Connector for .NET uses [log4net](http://logging.apache.org/log4net/) as the logging framework.

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ CancellationTokenSource cancellationTokenSource  = new CancellationTokenSource()
 Evict the Connection
 --------------------
 
-For the open connection, call the `PreventPooling()` to make the connection not return to the pool.
+For the open connection, call the `PreventPooling()` to mark the connection to be removed on close instead being still pooled.
 The busy sessions counter will be decreased when the connection is closed.
 
 Logging

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ CancellationTokenSource cancellationTokenSource  = new CancellationTokenSource()
 Evict the Connection
 --------------------
 
-For the open connection, call the `PreventFromReturningToPool()` to make the connection not return to the pool.
+For the open connection, call the `PreventPooling()` to make the connection not return to the pool.
 The busy sessions counter will be decreased when the connection is closed.
 
 Logging

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -61,7 +61,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             
             // act
             connection.PreventFromReturningToPool();
-            await connection.CloseAsync().ConfigureAwait(false);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             
             // assert
             Assert.AreEqual(0, pool.GetCurrentPoolSize());
@@ -80,11 +80,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connection = new TestSnowflakeDbConnection(mockDbProviderFactory.Object);
             connection.ConnectionString = connectionString;
             await connection.OpenAsync().ConfigureAwait(false);
-            await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted).ConfigureAwait(false);
+            connection.BeginTransaction(); // not using async version because it is not available on .net framework
             Assert.AreEqual(true, connection.HasActiveExplicitTransaction());
             
             // act
-            await connection.CloseAsync().ConfigureAwait(false);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             
             // assert
             Assert.AreEqual(0, pool.GetCurrentPoolSize(), "Should not return connection to the pool");

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -60,7 +60,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.AreEqual(1, pool.GetCurrentPoolSize());
             
             // act
-            connection.PreventFromReturningToPool();
+            connection.PreventPooling();
             await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             
             // assert

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -1,8 +1,12 @@
+using System.Data;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core.Session;
+using Snowflake.Data.Tests.Mock;
 using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.IntegrationTests
@@ -43,6 +47,47 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             // cleanup
             await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        
+        [Test]
+        public async Task TestPreventConnectionFromReturningToPool()
+        {
+            // arrange
+            var connectionString = ConnectionString + "minPoolSize=0";
+            var connection = new SnowflakeDbConnection(connectionString);
+            await connection.OpenAsync().ConfigureAwait(false);
+            var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
+            Assert.AreEqual(1, pool.GetCurrentPoolSize());
+            
+            // act
+            connection.PreventFromReturningToPool();
+            await connection.CloseAsync().ConfigureAwait(false);
+            
+            // assert
+            Assert.AreEqual(0, pool.GetCurrentPoolSize());
+        }
+        
+        [Test]
+        public async Task TestReleaseConnectionWhenRollbackFailsAsync()
+        {
+            // arrange
+            var connectionString = ConnectionString + "minPoolSize=0";
+            var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
+            var commandThrowingExceptionOnlyForRollback = MockHelper.CommandThrowingExceptionOnlyForRollback();
+            var mockDbProviderFactory = new Mock<DbProviderFactory>();
+            mockDbProviderFactory.Setup(p => p.CreateCommand()).Returns(commandThrowingExceptionOnlyForRollback.Object);
+            Assert.AreEqual(0, pool.GetCurrentPoolSize());
+            var connection = new TestSnowflakeDbConnection(mockDbProviderFactory.Object);
+            connection.ConnectionString = connectionString;
+            await connection.OpenAsync().ConfigureAwait(false);
+            await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted).ConfigureAwait(false);
+            Assert.AreEqual(true, connection.HasActiveExplicitTransaction());
+            
+            // act
+            await connection.CloseAsync().ConfigureAwait(false);
+            
+            // assert
+            Assert.AreEqual(0, pool.GetCurrentPoolSize(), "Should not return connection to the pool");
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
@@ -387,7 +387,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.AreEqual(1, pool.GetCurrentPoolSize());
             
             // act
-            connection.PreventFromReturningToPool();
+            connection.PreventPooling();
             connection.Close();
             
             // assert

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -119,7 +119,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var thrown = Assert.Throws<Exception>(() => connection.PreventPooling());
             
             // assert
-            Assert.That(thrown.Message, Does.Contain("Connection is not ready to prevent its session from returning to the pool"));
+            Assert.That(thrown.Message, Does.Contain("Session not yet created for this connection. Unable to prevent the session from pooling"));
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
  */
 
+using System;
 using System.Data;
 using System.Threading;
 using NUnit.Framework;
@@ -106,6 +107,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             Assert.AreEqual(ConnectionState.Closed, conn1.State);
             Assert.AreEqual(0, SnowflakeDbConnectionPool.GetPool(conn1.ConnectionString).GetCurrentPoolSize());
+        }
+
+        [Test]
+        public void TestFailWhenPreventingFromReturningToPoolNotOpenedConnection()
+        {
+            // arrange
+            var connection = new SnowflakeDbConnection(ConnectionString);
+            
+            // act
+            var thrown = Assert.Throws<Exception>(() => connection.PreventFromReturningToPool());
+            
+            // assert
+            Assert.That(thrown.Message, Does.Contain("Connection is not ready to prevent its session from returning to the pool"));
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -116,7 +116,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connection = new SnowflakeDbConnection(ConnectionString);
             
             // act
-            var thrown = Assert.Throws<Exception>(() => connection.PreventFromReturningToPool());
+            var thrown = Assert.Throws<Exception>(() => connection.PreventPooling());
             
             // assert
             Assert.That(thrown.Message, Does.Contain("Connection is not ready to prevent its session from returning to the pool"));

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
@@ -312,7 +312,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.AreEqual(0, pool.GetCurrentPoolSize());
             
             // act
-            connection.PreventFromReturningToPool();
+            connection.PreventPooling();
             connection.Close();
             
             // assert

--- a/Snowflake.Data.Tests/Mock/MockHelper.cs
+++ b/Snowflake.Data.Tests/Mock/MockHelper.cs
@@ -1,0 +1,18 @@
+using Moq;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+
+namespace Snowflake.Data.Tests.Mock
+{
+    public static class MockHelper
+    {
+        public static Mock<SnowflakeDbCommand> CommandThrowingExceptionOnlyForRollback()
+        {
+            var command = new Mock<SnowflakeDbCommand>();
+            command.CallBase = true;
+            command.SetupSet(it => it.CommandText = "ROLLBACK")
+                .Throws(new SnowflakeDbException(SFError.INTERNAL_ERROR, "Unexpected failure on transaction rollback when connection is returned to the pool with pending transaction"));
+            return command;
+        }
+    }
+}

--- a/Snowflake.Data.Tests/Mock/TestSnowflakeDbConnection.cs
+++ b/Snowflake.Data.Tests/Mock/TestSnowflakeDbConnection.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+using Snowflake.Data.Client;
+
+namespace Snowflake.Data.Tests.Mock
+{
+    public class TestSnowflakeDbConnection : SnowflakeDbConnection
+    {
+        public TestSnowflakeDbConnection(DbProviderFactory dbProviderFactory)
+        {
+            DbProviderFactory = dbProviderFactory;
+        }
+
+        protected override DbProviderFactory DbProviderFactory { get; }
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
@@ -45,6 +45,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         }
 
         [Test]
+        [Retry(2)]
         public void TestWaitUntilResourceAvailable()
         {
             // arrange

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -106,11 +106,11 @@ namespace Snowflake.Data.Client
         public override ConnectionState State => _connectionState;
         internal SnowflakeDbTransaction ExplicitTransaction { get; set; } // tracks only explicit transaction operations
 
-        public void PreventFromReturningToPool()
+        public void PreventPooling()
         {
             if (SfSession == null)
             {
-                throw new Exception("Connection is not ready to prevent its session from returning to the pool");
+                throw new Exception("Session not yet created for this connection. Unable to prevent the session from pooling");
             }
             SfSession.SetPooling(false);
         }
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Client
             }
             _connectionState = ConnectionState.Closed;
         }
-        
+
 #if NETCOREAPP3_0_OR_GREATER
         // CloseAsync was added to IDbConnection as part of .NET Standard 2.1, first supported by .NET Core 3.0.
         // Adding an override for CloseAsync will prevent the need for casting to SnowflakeDbConnection to call CloseAsync(CancellationToken).

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -54,6 +54,12 @@ namespace Snowflake.Data.Client
             return ConnectionManager.AddSession(session);
         }
 
+        internal static void ReleaseBusySession(SFSession session)
+        {
+            s_logger.Debug("SnowflakeDbConnectionPool::ReleaseBusySession");
+            ConnectionManager.ReleaseBusySession(session);
+        }
+
         public static void ClearAllPools()
         {
             s_logger.Debug("SnowflakeDbConnectionPool::ClearAllPools");

--- a/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
@@ -15,6 +15,7 @@ namespace Snowflake.Data.Core.Session
         public Task<SFSession> GetSessionAsync(string connectionString, SecureString password, CancellationToken cancellationToken)
             => _sessionPool.GetSessionAsync(connectionString, password, cancellationToken);
         public bool AddSession(SFSession session) => _sessionPool.AddSession(session, false);
+        public void ReleaseBusySession(SFSession session) => _sessionPool.ReleaseBusySession(session);
         public void ClearAllPools() => _sessionPool.ClearSessions();
         public void SetMaxPoolSize(int maxPoolSize) => _sessionPool.SetMaxPoolSize(maxPoolSize);
         public int GetMaxPoolSize() => _sessionPool.GetMaxPoolSize();

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -46,6 +46,12 @@ namespace Snowflake.Data.Core.Session
             return GetPool(session.ConnectionString, session.Password).AddSession(session, true);
         }
 
+        public void ReleaseBusySession(SFSession session)
+        {
+            s_logger.Debug($"ConnectionPoolManager::ReleaseBusySession for {session.ConnectionString}");
+            GetPool(session.ConnectionString, session.Password).ReleaseBusySession(session);
+        }
+
         public void ClearAllPools()
         {
             s_logger.Debug("ConnectionPoolManager::ClearAllPools");

--- a/Snowflake.Data/Core/Session/IConnectionManager.cs
+++ b/Snowflake.Data/Core/Session/IConnectionManager.cs
@@ -13,6 +13,7 @@ namespace Snowflake.Data.Core.Session
         SFSession GetSession(string connectionString, SecureString password);
         Task<SFSession> GetSessionAsync(string connectionString, SecureString password, CancellationToken cancellationToken);
         bool AddSession(SFSession session);
+        void ReleaseBusySession(SFSession session);
         void ClearAllPools();
         void SetMaxPoolSize(int maxPoolSize);
         int GetMaxPoolSize();

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -77,6 +77,13 @@ namespace Snowflake.Data.Core
 
         private bool _disableQueryContextCache = false;
 
+        public bool GetPooling() => _poolConfig.PoolingEnabled;
+
+        public void SetPooling(bool isEnabled)
+        {
+            _poolConfig.PoolingEnabled = isEnabled;
+        }
+
         internal void ProcessLoginResponse(LoginResponse authnResponse)
         {
             if (authnResponse.success)

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -391,10 +391,17 @@ namespace Snowflake.Data.Core.Session
         internal void ReleaseBusySession(SFSession session)
         {
             s_logger.Debug("SessionPool::ReleaseBusySession");
+            int currentPoolSize;
             lock (_sessionPoolLock)
             {
                 _busySessionsCounter.Decrease();
+                currentPoolSize = GetCurrentPoolSize();
             }
+            var currentSizeMessageOldPool = $"After releasing a busy session from the pool, the pool size is: {currentPoolSize}";
+            var poolSizeMessage = IsMultiplePoolsVersion()
+                ? $"{currentSizeMessageOldPool} - pool identified by: {ConnectionString}"
+                : currentSizeMessageOldPool;
+            s_logger.Debug(poolSizeMessage);
         }
         
         internal bool AddSession(SFSession session, bool ensureMinPoolSize)


### PR DESCRIPTION
### Description
Prevent evicted connections from returning to the pool

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
