### PR TITLE
Pool/SNOW-1353952 GetPool interface [WIP]

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 using System;
@@ -40,6 +40,12 @@ namespace Snowflake.Data.Client
         {
             s_logger.Debug($"SnowflakeDbConnectionPool::GetSessionAsync");
             return ConnectionManager.GetSessionAsync(connectionString, password, cancellationToken);
+        }
+
+        public static SnowflakeDbSessionPool GetPool(string connectionString, SecureString password)
+        {
+            s_logger.Debug($"SnowflakeDbConnectionPool::GetPool");
+            return new SnowflakeDbSessionPool(ConnectionManager.GetPool(connectionString, password));
         }
 
         internal static SessionPool GetPool(string connectionString)

--- a/Snowflake.Data/Client/SnowflakeDbSessionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbSessionPool.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+using System;
+using Snowflake.Data.Core.Session;
+
+namespace Snowflake.Data.Client
+{
+    public class SnowflakeDbSessionPool : IDisposable
+    {
+        private SessionPool _sessionPool;
+
+        internal SnowflakeDbSessionPool(SessionPool sessionPool)
+            => _sessionPool = sessionPool ?? throw new NullReferenceException("SessionPool not provided!");
+        public void Dispose() => _sessionPool = null;
+
+        public void SetMaxPoolSize(int size) => _sessionPool.SetMaxPoolSize(size);
+        public int GetMaxPoolSize() => _sessionPool.GetMaxPoolSize();
+
+        public void SetTimeout(long seconds) => _sessionPool.SetTimeout(seconds);
+        public long GetTimeout() => _sessionPool.GetTimeout();
+
+        public int GetCurrentPoolSize() => _sessionPool.GetCurrentPoolSize();
+
+        public bool SetPooling(bool isEnable) => _sessionPool.SetPooling(isEnable);
+        public bool GetPooling() => _sessionPool.GetPooling();
+    }
+}

--- a/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 using System.Security;
@@ -25,5 +25,6 @@ namespace Snowflake.Data.Core.Session
         public bool SetPooling(bool poolingEnabled) => _sessionPool.SetPooling(poolingEnabled);
         public bool GetPooling() => _sessionPool.GetPooling();
         public SessionPool GetPool(string _) => _sessionPool;
+        public SessionPool GetPool(string _, SecureString __) => _sessionPool;
     }
 }

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 using System;
@@ -119,7 +119,7 @@ namespace Snowflake.Data.Core.Session
             return true; // in new pool pooling is always enabled by default, disabling only by connection string parameter
         }
 
-        internal SessionPool GetPool(string connectionString, SecureString password)
+        public SessionPool GetPool(string connectionString, SecureString password)
         {
             s_logger.Debug($"ConnectionPoolManager::GetPool");
             var poolKey = GetPoolKey(connectionString);
@@ -140,6 +140,11 @@ namespace Snowflake.Data.Core.Session
         public SessionPool GetPool(string connectionString)
         {
             s_logger.Debug($"ConnectionPoolManager::GetPool");
+            if (!connectionString.ToLower().Contains("password="))
+            {
+                s_logger.Error($"To obtain a pool a password must to be given with a connection string or SecureString parameter");
+                throw new SnowflakeDbException(SFError.MISSING_CONNECTION_PROPERTY, "Could not provide the pool without the password");
+            }
             return GetPool(connectionString, null);
         }
 

--- a/Snowflake.Data/Core/Session/IConnectionManager.cs
+++ b/Snowflake.Data/Core/Session/IConnectionManager.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 using System.Security;
@@ -23,5 +23,6 @@ namespace Snowflake.Data.Core.Session
         bool SetPooling(bool poolingEnabled);
         bool GetPooling();
         SessionPool GetPool(string connectionString);
+        SessionPool GetPool(string connectionString, SecureString password);
     }
 }


### PR DESCRIPTION
### Description
With a new pool implementation user needs to change/get pool settings using particular pool and not via SnowflakeDbConnectionPool interface

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
