### PR TITLE
SNOW-1373257 Make secure password be a part of pool key

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -3,7 +3,6 @@
  */
 
 using System;
-using System.Net;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +11,7 @@ using Snowflake.Data.Core;
 using Snowflake.Data.Core.Session;
 using Moq;
 using Snowflake.Data.Client;
+using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.UnitTests
@@ -22,10 +22,8 @@ namespace Snowflake.Data.Tests.UnitTests
         private readonly ConnectionPoolManager _connectionPoolManager = new ConnectionPoolManager();
         private const string ConnectionString1 = "db=D1;warehouse=W1;account=A1;user=U1;password=P1;role=R1;minPoolSize=1;";
         private const string ConnectionString2 = "db=D2;warehouse=W2;account=A2;user=U2;password=P2;role=R2;minPoolSize=1;";
-        private const string ConnectionString3 = "db=D3;warehouse=W3;account=A3;user=U3;role=R3;minPoolSize=1;";
-        private readonly SecureString _password1 = null;
-        private readonly SecureString _password2 = null;
-        private readonly SecureString _password3 = new NetworkCredential("", "P3").SecurePassword;
+        private const string ConnectionStringWithoutPassword = "db=D3;warehouse=W3;account=A3;user=U3;role=R3;minPoolSize=1;";
+        private readonly SecureString _password3 = SecureStringHelper.Encode("P3");
         private static PoolConfig s_poolConfig;
 
         [OneTimeSetUp]
@@ -53,21 +51,21 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestPoolManagerReturnsSessionPoolForGivenConnectionString()
         {
             // Act
-            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, null);
 
             // Assert
             Assert.AreEqual(ConnectionString1, sessionPool.ConnectionString);
-            Assert.AreEqual(_password1, sessionPool.Password);
+            Assert.AreEqual(null, sessionPool.Password);
         }
 
         [Test]
         public void TestPoolManagerReturnsSessionPoolForGivenConnectionStringAndSecurelyProvidedPassword()
         {
             // Act
-            var sessionPool = _connectionPoolManager.GetPool(ConnectionString3, _password3);
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionStringWithoutPassword, _password3);
 
             // Assert
-            Assert.AreEqual(ConnectionString3, sessionPool.ConnectionString);
+            Assert.AreEqual(ConnectionStringWithoutPassword, sessionPool.ConnectionString);
             Assert.AreEqual(_password3, sessionPool.Password);
         }
 
@@ -75,7 +73,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestPoolManagerThrowsWhenPasswordNotProvided()
         {
             // Act/Assert
-            Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetPool(ConnectionString3, null));
+            Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetPool(ConnectionStringWithoutPassword, null));
         }
 
         [Test]
@@ -85,8 +83,8 @@ namespace Snowflake.Data.Tests.UnitTests
             var anotherConnectionString = ConnectionString1;
 
             // Act
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(anotherConnectionString, _password1);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(anotherConnectionString, null);
 
             // Assert
             Assert.AreEqual(sessionPool1, sessionPool2);
@@ -99,8 +97,8 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.AreNotSame(ConnectionString1, ConnectionString2);
 
             // Act
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
 
             // Assert
             Assert.AreNotSame(sessionPool1, sessionPool2);
@@ -113,32 +111,32 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetSessionWorksForSpecifiedConnectionString()
         {
             // Act
-            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, _password1);
+            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, null);
 
             // Assert
             Assert.AreEqual(ConnectionString1, sfSession.ConnectionString);
-            Assert.AreEqual(_password1, sfSession.Password);
+            Assert.AreEqual(null, sfSession.Password);
         }
 
         [Test]
         public async Task TestGetSessionAsyncWorksForSpecifiedConnectionString()
         {
             // Act
-            var sfSession = await _connectionPoolManager.GetSessionAsync(ConnectionString1, _password1, CancellationToken.None);
+            var sfSession = await _connectionPoolManager.GetSessionAsync(ConnectionString1, null, CancellationToken.None);
 
             // Assert
             Assert.AreEqual(ConnectionString1, sfSession.ConnectionString);
-            Assert.AreEqual(_password1, sfSession.Password);
+            Assert.AreEqual(null, sfSession.Password);
         }
 
         [Test]
         public void TestCountingOfSessionProvidedByPool()
         {
             // Act
-            _connectionPoolManager.GetSession(ConnectionString1, _password1);
+            _connectionPoolManager.GetSession(ConnectionString1, null);
 
             // Assert
-            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, null);
             Assert.AreEqual(1, sessionPool.GetCurrentPoolSize());
         }
 
@@ -146,13 +144,13 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestCountingOfSessionReturnedBackToPool()
         {
             // Arrange
-            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, _password1);
+            var sfSession = _connectionPoolManager.GetSession(ConnectionString1, null);
 
             // Act
             _connectionPoolManager.AddSession(sfSession);
 
             // Assert
-            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            var sessionPool = _connectionPoolManager.GetPool(ConnectionString1, null);
             Assert.AreEqual(1, sessionPool.GetCurrentPoolSize());
         }
 
@@ -160,7 +158,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestSetMaxPoolSizeForAllPoolsDisabled()
         {
             // Arrange
-            _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            _connectionPoolManager.GetPool(ConnectionString1, null);
 
             // Act
             var thrown = Assert.Throws<Exception>(() => _connectionPoolManager.SetMaxPoolSize(3));
@@ -173,7 +171,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestSetTimeoutForAllPoolsDisabled()
         {
             // Arrange
-            _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            _connectionPoolManager.GetPool(ConnectionString1, null);
 
             // Act
             var thrown = Assert.Throws<Exception>(() => _connectionPoolManager.SetTimeout(3000));
@@ -186,7 +184,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestSetPoolingForAllPoolsDisabled()
         {
             // Arrange
-            _connectionPoolManager.GetPool(ConnectionString1, _password1);
+            _connectionPoolManager.GetPool(ConnectionString1, null);
 
             // Act
             var thrown = Assert.Throws<Exception>(() => _connectionPoolManager.SetPooling(false));
@@ -199,8 +197,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetPoolingOnManagerLevelAlwaysTrue()
         {
             // Arrange
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
             sessionPool1.SetPooling(true);
             sessionPool2.SetPooling(false);
 
@@ -217,8 +215,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetTimeoutOnManagerLevelWhenNotAllPoolsEqual()
         {
             // Arrange
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
             sessionPool1.SetTimeout(299);
             sessionPool2.SetTimeout(1313);
 
@@ -233,8 +231,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetTimeoutOnManagerLevelWhenAllPoolsEqual()
         {
             // Arrange
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
             sessionPool1.SetTimeout(3600);
             sessionPool2.SetTimeout(3600);
 
@@ -246,8 +244,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetMaxPoolSizeOnManagerLevelWhenNotAllPoolsEqual()
         {
             // Arrange
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
             sessionPool1.SetMaxPoolSize(1);
             sessionPool2.SetMaxPoolSize(17);
 
@@ -262,8 +260,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetMaxPoolSizeOnManagerLevelWhenAllPoolsEqual()
         {
             // Arrange
-            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, _password1);
-            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, _password2);
+            var sessionPool1 = _connectionPoolManager.GetPool(ConnectionString1, null);
+            var sessionPool2 = _connectionPoolManager.GetPool(ConnectionString2, null);
             sessionPool1.SetMaxPoolSize(33);
             sessionPool2.SetMaxPoolSize(33);
 
@@ -275,14 +273,79 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetCurrentPoolSizeReturnsSumOfPoolSizes()
         {
             // Arrange
-            EnsurePoolSize(ConnectionString1, _password1, 2);
-            EnsurePoolSize(ConnectionString2, _password2, 3);
+            EnsurePoolSize(ConnectionString1, null, 2);
+            EnsurePoolSize(ConnectionString2, null, 3);
 
             // act
             var poolSize = _connectionPoolManager.GetCurrentPoolSize();
 
             // assert
             Assert.AreEqual(5, poolSize);
+        }
+
+        [Test]
+        public void TestReturnPoolForSecurePassword()
+        {
+            // arrange
+            const string AnotherPassword = "anotherPassword";
+            EnsurePoolSize(ConnectionStringWithoutPassword, _password3, 1);
+
+            // act
+            var pool = _connectionPoolManager.GetPool(ConnectionStringWithoutPassword, SecureStringHelper.Encode(AnotherPassword)); // a new pool has been created because the password is different
+
+            // assert
+            Assert.AreEqual(0, pool.GetCurrentPoolSize());
+            Assert.AreEqual(AnotherPassword, SecureStringHelper.Decode(pool.Password));
+        }
+
+        [Test]
+        public void TestReturnDifferentPoolWhenPasswordProvidedInDifferentWay()
+        {
+            // arrange
+            var connectionStringWithPassword = $"{ConnectionStringWithoutPassword}password={SecureStringHelper.Decode(_password3)}";
+            EnsurePoolSize(ConnectionStringWithoutPassword, _password3, 2);
+            EnsurePoolSize(connectionStringWithPassword, null, 5);
+            EnsurePoolSize(connectionStringWithPassword, _password3, 8);
+
+            // act
+            var pool1 = _connectionPoolManager.GetPool(ConnectionStringWithoutPassword, _password3);
+            var pool2 = _connectionPoolManager.GetPool(connectionStringWithPassword, null);
+            var pool3 = _connectionPoolManager.GetPool(connectionStringWithPassword, _password3);
+
+            // assert
+            Assert.AreEqual(2, pool1.GetCurrentPoolSize());
+            Assert.AreEqual(5, pool2.GetCurrentPoolSize());
+            Assert.AreEqual(8, pool3.GetCurrentPoolSize());
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void TestGetPoolFailsWhenNoPasswordProvided(string password)
+        {
+            // arrange
+            var securePassword = password == null ? null : SecureStringHelper.Encode(password);
+
+            // act
+            var thrown = Assert.Throws<SnowflakeDbException>(() => _connectionPoolManager.GetPool(ConnectionStringWithoutPassword, securePassword));
+
+            // assert
+            Assert.That(thrown.Message, Does.Contain("Required property PASSWORD is not provided"));
+        }
+
+        [Test]
+        public void TestPoolDoesNotSerializePassword()
+        {
+            // arrange
+            var password = SecureStringHelper.Decode(_password3);
+            var connectionStringWithPassword = $"{ConnectionStringWithoutPassword}password={password}";
+            var pool = _connectionPoolManager.GetPool(connectionStringWithPassword, _password3);
+
+            // act
+            var serializedPool = pool.ToString();
+
+            // assert
+            Assert.IsFalse(serializedPool.Contains(password, StringComparison.OrdinalIgnoreCase));
         }
 
         private void EnsurePoolSize(string connectionString, SecureString password, int requiredCurrentSize)

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -345,7 +345,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var serializedPool = pool.ToString();
 
             // assert
-            Assert.IsFalse(serializedPool.Contains(password, StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(serializedPool.Contains(password));
         }
 
         private void EnsurePoolSize(string connectionString, SecureString password, int requiredCurrentSize)

--- a/Snowflake.Data.Tests/UnitTests/Tools/SecureStringHelperTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/SecureStringHelperTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using Snowflake.Data.Core.Tools;
+
+namespace Snowflake.Data.Tests.UnitTests.Tools
+{
+    [TestFixture]
+    public class SecureStringHelperTest
+    {
+        [Test]
+        public void TestConvertPassword()
+        {
+            // arrange
+            var passwordText = "testPassword";
+
+            // act
+            var securePassword = SecureStringHelper.Encode(passwordText);
+            var decodedPassword = SecureStringHelper.Decode(securePassword);
+
+            // assert
+            Assert.AreEqual(passwordText, decodedPassword);
+        }
+    }
+}

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -13,6 +13,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Core
 {
@@ -249,7 +250,7 @@ namespace Snowflake.Data.Core
 
             if (password != null && password.Length > 0)
             {
-                properties[SFSessionProperty.PASSWORD] = new NetworkCredential(string.Empty, password).Password;
+                properties[SFSessionProperty.PASSWORD] = SecureStringHelper.Decode(password);
             }
 
             ValidateAuthenticator(properties);

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -9,7 +9,6 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Snowflake.Data.Client;
-using Snowflake.Data.Core.Authenticator;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
 
@@ -118,6 +117,17 @@ namespace Snowflake.Data.Core.Session
                 throw;
             }
         }
+
+        internal void ValidateSecurePassword(SecureString password)
+        {
+            if (!ExtractPassword(Password).Equals(ExtractPassword(password)))
+            {
+                throw new Exception("Could not get a pool because of password mismatch");
+            }
+        }
+
+        private string ExtractPassword(SecureString password) =>
+            password == null ? string.Empty : SecureStringHelper.Decode(password);
 
         internal SFSession GetSession(string connStr, SecureString password)
         {

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -122,7 +122,9 @@ namespace Snowflake.Data.Core.Session
         {
             if (!ExtractPassword(Password).Equals(ExtractPassword(password)))
             {
-                throw new Exception("Could not get a pool because of password mismatch");
+                var errorMessage = "Could not get a pool because of password mismatch";
+                s_logger.Error(errorMessage + PoolIdentification());
+                throw new Exception(errorMessage);
             }
         }
 

--- a/Snowflake.Data/Core/Tools/SecureStringHelper.cs
+++ b/Snowflake.Data/Core/Tools/SecureStringHelper.cs
@@ -1,0 +1,12 @@
+using System.Net;
+using System.Security;
+
+namespace Snowflake.Data.Core.Tools
+{
+    internal static class SecureStringHelper
+    {
+        public static string Decode(SecureString password) => new NetworkCredential(string.Empty, password).Password;
+
+        public static SecureString Encode(string password) => new NetworkCredential(string.Empty, password).SecurePassword;
+    }
+}


### PR DESCRIPTION
### Description
SNOW-1373257 Make secure password be a part of pool key

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
