### PR TITLE
SNOW-1373131 disable connection pooling for external browser authentication

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -914,6 +914,30 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com";
                 conn.Open();
                 Assert.AreEqual(ConnectionState.Open, conn.State);
+
+                // connection pooling is disabled for external browser by default
+                Assert.AreEqual(false, SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
+                using (IDbCommand command = conn.CreateCommand())
+                {
+                    command.CommandText = "SELECT CURRENT_USER()";
+                    Assert.AreEqual("QA", command.ExecuteScalar().ToString());
+                }
+            }
+        }
+
+        [Test]
+        [Ignore("This test requires manual interaction and therefore cannot be run in CI")]
+        public void TestSSOConnectionWithPoolingEnabled()
+        {
+            // Use external browser to log in using proper password for qa@snowflakecomputing.com
+            using (IDbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString
+                    = ConnectionStringWithoutAuth
+                      + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com;POOLINGENABLED=TRUE";
+                conn.Open();
+                Assert.AreEqual(ConnectionState.Open, conn.State);
+                Assert.AreEqual(true, SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
                 using (IDbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT CURRENT_USER()";

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -102,6 +102,40 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.AreEqual(value, properties[sessionProperty]);
         }
 
+        [Test]
+        [TestCase("", "false")]
+        [TestCase("poolingEnabled=true", "true")]
+        [TestCase("poolingEnabled=false", "false")]
+        public void TestPoolingEnabledForExternalBrowserAuthenticator(string connectionParam, string expectedPoolingEnabled)
+        {
+            // arrange
+            var connectionString = $"ACCOUNT=test;AUTHENTICATOR=externalbrowser;{connectionParam}";
+
+            // act
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, null);
+
+            // assert
+            Assert.AreEqual(expectedPoolingEnabled, properties[SFSessionProperty.POOLINGENABLED]);
+        }
+
+        [Test]
+        [TestCase(BasicAuthenticator.AUTH_NAME, "true")]
+        [TestCase(KeyPairAuthenticator.AUTH_NAME, "true")]
+        [TestCase(OAuthAuthenticator.AUTH_NAME, "true")]
+        [TestCase(OktaAuthenticator.AUTH_NAME, "true")]
+        [TestCase(ExternalBrowserAuthenticator.AUTH_NAME, "false")]
+        public void TestDefaultPoolingEnabledForAuthenticator(string authenticator, string expectedPoolingEnabled)
+        {
+            // arrange
+            var connectionString = $"ACCOUNT=test;USER=test;PASSWORD=test;TOKEN=test;AUTHENTICATOR={authenticator}";
+
+            // act
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, null);
+
+            // assert
+            Assert.AreEqual(expectedPoolingEnabled, properties[SFSessionProperty.POOLINGENABLED]);
+        }
+
         public static IEnumerable<TestCase> ConnectionStringTestCases()
         {
             string defAccount = "testaccount";
@@ -192,7 +226,7 @@ namespace Snowflake.Data.Tests.UnitTests
                     { SFSessionProperty.CHANGEDSESSION, DefaultValue(SFSessionProperty.CHANGEDSESSION) },
                     { SFSessionProperty.WAITINGFORIDLESESSIONTIMEOUT, DefaultValue(SFSessionProperty.WAITINGFORIDLESESSIONTIMEOUT) },
                     { SFSessionProperty.EXPIRATIONTIMEOUT, DefaultValue(SFSessionProperty.EXPIRATIONTIMEOUT) },
-                    { SFSessionProperty.POOLINGENABLED, DefaultValue(SFSessionProperty.POOLINGENABLED) }
+                    { SFSessionProperty.POOLINGENABLED, "false" } // by default pooling is disabled for externalbrowser authentication
                 }
             };
             var testCaseWithProxySettings = new TestCase()

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -253,6 +253,7 @@ namespace Snowflake.Data.Core
             }
 
             ValidateAuthenticator(properties);
+            DisableConnectionPoolingForExternalBrowser(properties);
             CheckSessionProperties(properties);
             ValidateFileTransferMaxBytesInMemoryProperty(properties);
             ValidateAccountDomain(properties);
@@ -286,7 +287,14 @@ namespace Snowflake.Data.Core
 
         private static void ValidateAuthenticator(SFSessionProperties properties)
         {
-            var knownAuthenticators = new[] { BasicAuthenticator.AUTH_NAME, OktaAuthenticator.AUTH_NAME, OAuthAuthenticator.AUTH_NAME, KeyPairAuthenticator.AUTH_NAME, ExternalBrowserAuthenticator.AUTH_NAME };
+            var knownAuthenticators = new[] {
+                BasicAuthenticator.AUTH_NAME,
+                OktaAuthenticator.AUTH_NAME,
+                OAuthAuthenticator.AUTH_NAME,
+                KeyPairAuthenticator.AUTH_NAME,
+                ExternalBrowserAuthenticator.AUTH_NAME
+            };
+
             if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var authenticator))
             {
                 authenticator = authenticator.ToLower();
@@ -295,6 +303,26 @@ namespace Snowflake.Data.Core
                     var error = $"Unknown authenticator: {authenticator}";
                     logger.Error(error);
                     throw new SnowflakeDbException(SFError.UNKNOWN_AUTHENTICATOR, authenticator);
+                }
+            }
+        }
+
+        private static void DisableConnectionPoolingForExternalBrowser(SFSessionProperties properties)
+        {
+            if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var authenticator))
+            {
+                authenticator = authenticator.ToLower();
+                if (authenticator.Equals(ExternalBrowserAuthenticator.AUTH_NAME))
+                {
+                    if (!properties.TryGetValue(SFSessionProperty.POOLINGENABLED, out var poolingEnabledStr))
+                    {
+                        properties.Add(SFSessionProperty.POOLINGENABLED, "false");
+                        logger.Info("Connection pooling is disabled for external browser authentication");
+                    }
+                    else if (Boolean.TryParse(poolingEnabledStr, out var poolingEnabled) && poolingEnabled)
+                    {
+                        logger.Warn("Connection pooling is enabled for external browser authentication");
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description
Disable connection pooling for external browser authentication

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
