### PR TITLE
SNOW-1433638 sql trimming only for PUT/GET detection

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -70,13 +70,10 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestTrimSqlBlockComment()
         {
-            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
-            sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession);
-            SFBaseResultSet resultSet = statement.Execute(0, "/*comment*/select 1/*comment*/", null, false, false);
-            Assert.AreEqual(true, resultSet.Next());
-            Assert.AreEqual("1", resultSet.GetString(0));
+            const string SqlSource = "/*comment*/select 1/*comment*/";
+            const string SqlExpected = "select 1";
+
+            Assert.AreEqual(SqlExpected, SFStatement.TrimSql(SqlSource));
         }
 
         /// <summary>
@@ -85,13 +82,10 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestTrimSqlBlockCommentMultiline()
         {
-            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
-            sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession);
-            SFBaseResultSet resultSet = statement.Execute(0, "/*comment\r\ncomment*/select 1/*comment\r\ncomment*/", null, false, false);
-            Assert.AreEqual(true, resultSet.Next());
-            Assert.AreEqual("1", resultSet.GetString(0));
+            const string SqlSource = "/*comment\r\ncomment*/select 1/*comment\r\ncomment*/";
+            const string SqlExpected = "select 1";
+
+            Assert.AreEqual(SqlExpected, SFStatement.TrimSql(SqlSource));
         }
 
         /// <summary>
@@ -100,13 +94,10 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestTrimSqlLineComment()
         {
-            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
-            sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession);
-            SFBaseResultSet resultSet = statement.Execute(0, "--comment\r\nselect 1\r\n--comment", null, false, false);
-            Assert.AreEqual(true, resultSet.Next());
-            Assert.AreEqual("1", resultSet.GetString(0));
+            const string SqlSource = "--comment\r\nselect 1\r\n--comment";
+            const string SqlExpected = "select 1\r\n--comment";
+
+            Assert.AreEqual(SqlExpected, SFStatement.TrimSql(SqlSource));
         }
 
         /// <summary>
@@ -115,13 +106,10 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestTrimSqlLineCommentWithClosingNewline()
         {
-            Mock.MockRestSessionExpiredInQueryExec restRequester = new Mock.MockRestSessionExpiredInQueryExec();
-            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
-            sfSession.Open();
-            SFStatement statement = new SFStatement(sfSession);
-            SFBaseResultSet resultSet = statement.Execute(0, "--comment\r\nselect 1\r\n--comment\r\n", null, false, false);
-            Assert.AreEqual(true, resultSet.Next());
-            Assert.AreEqual("1", resultSet.GetString(0));
+            const string SqlSource = "--comment\r\nselect 1\r\n--comment\r\n";
+            const string SqlExpected = "select 1";
+
+            Assert.AreEqual(SqlExpected, SFStatement.TrimSql(SqlSource));
         }
 
         [Test]


### PR DESCRIPTION
### Description
SNOW-1433638 sql trimming only for PUT/GET detection
Symbol -- cannot be treated as a string.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
