### PR TITLE
Revert "SNOW-1473274 bump nunit to 4.1.0 (#971)"

### DIFF
--- a/Snowflake.Data.Tests/IcebergTests/TestIcebergTable.cs
+++ b/Snowflake.Data.Tests/IcebergTests/TestIcebergTable.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 using static Snowflake.Data.Tests.Util.TestData;
 
 namespace Snowflake.Data.Tests.IcebergTests

--- a/Snowflake.Data.Tests/IntegrationTests/EasyLoggingIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/EasyLoggingIT.cs
@@ -7,7 +7,6 @@ using Snowflake.Data.Client;
 using Snowflake.Data.Configuration;
 using Snowflake.Data.Core;
 using Snowflake.Data.Log;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 using static Snowflake.Data.Tests.UnitTests.Configuration.EasyLoggingConfigGenerator;
 
 namespace Snowflake.Data.Tests.IntegrationTests

--- a/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests
 {

--- a/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
@@ -11,7 +11,6 @@ using System.Data;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -15,12 +15,11 @@ using System.Text;
 using System.Globalization;
 using System.Collections.Generic;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {
 
-    [TestFixture]
+    [TestFixture]    
     class SFBindTestIT : SFBaseTest
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SFBindTestIT>();

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -20,8 +20,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Snowflake.Data.Tests.Mock;
     using System.Runtime.InteropServices;
     using System.Net.Http;
-    using NUnit.Framework.Legacy;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFConnectionIT : SFBaseTest
@@ -801,7 +799,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     IDbConnection conn = new SnowflakeDbConnection();
                     conn.ConnectionString = "scheme=http;host=test;port=8080;user=test;password=test;account=test;authenticator=" + wrongAuthenticator;
                     conn.Open();
-                    Assert.Fail($"Authentication of {wrongAuthenticator} should fail");
+                    Assert.Fail("Authentication of {0} should fail", wrongAuthenticator);
                 }
                 catch (SnowflakeDbException e)
                 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolAsyncIT.cs
@@ -10,10 +10,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
+using Snowflake.Data.Log;
 using Snowflake.Data.Tests.Mock;
 using Moq;
 using NUnit.Framework;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionPoolIT.cs
@@ -13,7 +13,6 @@ using Snowflake.Data.Client;
 using Snowflake.Data.Log;
 using NUnit.Framework;
 using Snowflake.Data.Core.Session;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
@@ -8,7 +8,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Snowflake.Data.Client;
     using System.Data;
     using System.Runtime.InteropServices;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbAdaptorIT : SFBaseTest

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -18,7 +18,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using System.Globalization;
     using Snowflake.Data.Tests.Mock;
     using Snowflake.Data.Core;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbCommandITAsync : SFBaseTestAsync

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -12,7 +12,6 @@ using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.IntegrationTests
 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
@@ -7,7 +7,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using NUnit.Framework;
     using System.Data;
     using System.Data.Common;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbFactoryIT : SFBaseTest

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
@@ -11,7 +11,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Snowflake.Data.Client;
     using Snowflake.Data.Core;
     using System.Threading.Tasks;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbTransactionIT : SFBaseTest

--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -12,7 +12,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Snowflake.Data.Client;
     using Snowflake.Data.Core;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFMultiStatementsIT : SFBaseTest

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -18,7 +18,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Snowflake.Data.Client;
     using Snowflake.Data.Core;
     using Snowflake.Data.Core.FileTransfer;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     [Parallelizable(ParallelScope.Children)]

--- a/Snowflake.Data.Tests/IntegrationTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFReusableChunkTest.cs
@@ -9,8 +9,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using Core;
     using Client;
     using System.Threading.Tasks;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
-
+    
     [TestFixture, NonParallelizable]
     class SFReusableChunkTest : SFBaseTest
     {

--- a/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
@@ -8,7 +8,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using System.Data;
     using Snowflake.Data.Client;
     using System.Data.Common;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFStatementTypeTest : SFBaseTest

--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -23,12 +23,11 @@ namespace Snowflake.Data.Tests
     using NUnit.Framework.Interfaces;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     /*
-     * This is the base class for all tests that call blocking methods in the library - it uses MockSynchronizationContext to verify that
+     * This is the base class for all tests that call blocking methods in the library - it uses MockSynchronizationContext to verify that 
      * there are no async deadlocks in the library
-     *
+     * 
      */
     [TestFixture]
     public class SFBaseTest : SFBaseTestAsync
@@ -434,7 +433,7 @@ namespace Snowflake.Data.Tests
             {
                 if (Environment.GetEnvironmentVariable(_key) == value)
                 {
-                    Assert.Ignore($"Test is ignored when environment variable {_key} is {value} ");
+                    Assert.Ignore("Test is ignored when environment variable {0} is {1} ", _key, value);
                 }
             }
         }

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/Snowflake.Data.Tests/UnitTests/ArrowChunkParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowChunkParserTest.cs
@@ -16,7 +16,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.IO;
     using System.Text;
     using System.Threading.Tasks;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture, NonParallelizable]
     class ArrowChunkParserTest

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
@@ -11,7 +11,6 @@ using Apache.Arrow.Types;
 using NUnit.Framework;
 using Snowflake.Data.Core;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests
 {

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
@@ -14,7 +14,6 @@ using Apache.Arrow.Ipc;
 using NUnit.Framework;
 using Snowflake.Data.Core;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests
 {

--- a/Snowflake.Data.Tests/UnitTests/ChunkDownloaderFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ChunkDownloaderFactoryTest.cs
@@ -10,7 +10,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System;
     using System.Collections.Generic;
     using System.Threading;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture, NonParallelizable]
     class ChunkDownloaderFactoryTest

--- a/Snowflake.Data.Tests/UnitTests/ChunkParserFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ChunkParserFactoryTest.cs
@@ -13,7 +13,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Security;
     using System.Text;
     using System.Threading;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture, NonParallelizable]
     class ChunkParserFactoryTest

--- a/Snowflake.Data.Tests/UnitTests/ConcatenatedStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConcatenatedStreamTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System;
     using System.IO;
     using System.Text;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class ConcatenatedStreamTest

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -10,7 +10,6 @@ using Moq;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;
 using Snowflake.Data.Core.Tools;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Configuration
 {

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 using static Snowflake.Data.Tests.UnitTests.Configuration.EasyLoggingConfigGenerator;
 
 namespace Snowflake.Data.Tests.UnitTests.Configuration

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigProviderTest.cs
@@ -5,7 +5,6 @@
 using Moq;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Configuration
 {

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingLogLevelTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingLogLevelTest.cs
@@ -5,7 +5,6 @@
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Configuration
 {

--- a/Snowflake.Data.Tests/UnitTests/FastMemoryStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FastMemoryStreamTest.cs
@@ -7,7 +7,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using Snowflake.Data.Core;
     using System.Linq;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class FastMemoryStreamTest

--- a/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Core;
     using System;
     using System.Text;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     [SetCulture("en-US")]

--- a/Snowflake.Data.Tests/UnitTests/FileBackedOutputStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FileBackedOutputStreamTest.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Snowflake.Data.Core.FileTransfer;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests
 {

--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -12,7 +12,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Threading.Tasks;
     using System.Net;
     using System;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class HttpUtilTest

--- a/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
@@ -10,14 +10,13 @@ using NUnit.Framework;
 using Snowflake.Data.Configuration;
 using Snowflake.Data.Core;
 using Snowflake.Data.Log;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Logger
 {
     [TestFixture, NonParallelizable]
     public class EasyLoggerManagerTest
     {
-
+        
         private const string InfoMessage = "Easy logging Info message";
         private const string DebugMessage = "Easy logging Debug message";
         private const string WarnMessage = "Easy logging Warn message";

--- a/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
@@ -8,8 +8,7 @@ namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;
     using Snowflake.Data.Log;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
-
+    
     [TestFixture, NonParallelizable]
     class SFLoggerTest
     {

--- a/Snowflake.Data.Tests/UnitTests/Logger/UnixFilePermissionsConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/UnixFilePermissionsConverterTest.cs
@@ -6,7 +6,6 @@ using Mono.Unix;
 using NUnit.Framework;
 using Snowflake.Data.Log;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Logger
 {

--- a/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Core;
     using System;
     using System.Collections.Generic;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class QueryContextCacheTest

--- a/Snowflake.Data.Tests/UnitTests/SFAuthenticatorFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAuthenticatorFactoryTest.cs
@@ -8,7 +8,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Client;
     using Snowflake.Data.Core;
     using Snowflake.Data.Core.Authenticator;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFAuthenticatorFactoryTest

--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -20,7 +20,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Moq;
     using Azure;
     using Azure.Storage.Blobs.Models;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFAzureClientTest : SFBaseTest

--- a/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
@@ -5,7 +5,6 @@
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Core;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests
 {

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -11,7 +11,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using System.Threading;
     using System.Globalization;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     [SetCulture("en-US")]

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
@@ -6,7 +6,6 @@ namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;
     using Snowflake.Data.Client;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbCommandBuilderTest

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbCommandTest

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests
     using Snowflake.Data.Core;
     using System;
     using System.Collections;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbParameterCollectionTest

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
@@ -10,7 +10,6 @@ namespace Snowflake.Data.Tests
     using System;
     using System.Data;
     using System.Text;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFDbParameterTest

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -16,7 +16,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.IO;
     using System.Text;
     using System;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFFileTransferAgentTest : SFBaseTest

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -17,7 +17,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Threading;
     using Snowflake.Data.Tests.Mock;
     using Moq;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFGCSClientTest : SFBaseTest

--- a/Snowflake.Data.Tests/UnitTests/SFOktaTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFOktaTest.cs
@@ -4,7 +4,6 @@ using Snowflake.Data.Core;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests
 {
@@ -100,7 +99,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 sfSession.Open();
             } catch (SnowflakeDbException e)
             {
-                Assert.Fail($"Should pass without exception {e}");
+                Assert.Fail("Should pass without exception", e);
             }
         }
 
@@ -122,7 +121,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 connectTask.Wait();
             } catch (SnowflakeDbException e)
             {
-                Assert.Fail($"Should pass without exception {e}");
+                Assert.Fail("Should pass without exception", e);
             }
         }
 

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -17,7 +17,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.Text;
     using System.Net;
     using Moq;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFRemoteStorageClientTest : SFBaseTest

--- a/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
@@ -13,7 +13,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Core;
     using Snowflake.Data.Client;
     using System.Threading.Tasks;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFReusableChunkTest

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -20,7 +20,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using System.IO;
     using Moq;
     using Amazon.S3.Model;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFS3ClientTest : SFBaseTest

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -8,8 +8,6 @@ using System.Security;
 using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core.Authenticator;
-using NUnit.Framework.Legacy;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests
 {

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -9,7 +9,6 @@ namespace Snowflake.Data.Tests.UnitTests
 {
     using Snowflake.Data.Core;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFSessionTest

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -7,7 +7,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Core;
     using NUnit.Framework;
     using System;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     /**
      * Mock rest request test

--- a/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
@@ -7,7 +7,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using NUnit.Framework;
     using System;
     using Snowflake.Data.Core;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SFUriUpdaterTest

--- a/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
@@ -11,7 +11,6 @@ namespace Snowflake.Data.Tests.UnitTests
     using Snowflake.Data.Tests.Mock;
     using System;
     using System.Collections.Generic;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     class SecretDetectorTest

--- a/Snowflake.Data.Tests/UnitTests/Session/EasyLoggingStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/EasyLoggingStarterTest.cs
@@ -13,7 +13,6 @@ using Snowflake.Data.Configuration;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Session
 {

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -7,7 +7,6 @@ using Moq;
 using NUnit.Framework;
 using Snowflake.Data.Core;
 using Snowflake.Data.Tests.Util;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Session
 {

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientProxyPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientProxyPropertiesTest.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Snowflake.Data.Core;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.UnitTests.Session
 {

--- a/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
@@ -5,7 +5,6 @@ using Mono.Unix;
 using Mono.Unix.Native;
 using NUnit.Framework;
 using Snowflake.Data.Core.Tools;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 using static Snowflake.Data.Tests.UnitTests.Configuration.EasyLoggingConfigGenerator;
 
 namespace Snowflake.Data.Tests.Tools

--- a/Snowflake.Data.Tests/Util/DedicatedThreadSynchronisationContext.cs
+++ b/Snowflake.Data.Tests/Util/DedicatedThreadSynchronisationContext.cs
@@ -2,7 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using NUnit.Framework;
 
 namespace Snowflake.Data.Tests.Util
 {

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -5,7 +5,7 @@ using System.Net;
 using System.Net.Http;
 using Snowflake.Data.Core;
 using Snowflake.Data.Client;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using NUnit.Framework;
 
 namespace Snowflake.Data.Tests.Util
 {

--- a/Snowflake.Data.Tests/Util/TableTypeExtensions.cs
+++ b/Snowflake.Data.Tests/Util/TableTypeExtensions.cs
@@ -1,10 +1,9 @@
 using System;
 using NUnit.Framework;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Snowflake.Data.Tests.Util
 {
-    public enum SFTableType
+    public enum SFTableType 
     {
         Standard,
         Hybrid,


### PR DESCRIPTION
This reverts commit 0e7a4adaea8b0f9d3e72bd1e8e65bfaa9d89b40e.

### Description
Reverting switching to newer NUnit since it does not support .netstandard.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
