### PR TITLE
Proposed fix for #981

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -389,6 +389,11 @@ namespace Snowflake.Data.Core
                         response = await base.SendAsync(requestMessage, childCts == null ?
                             cancellationToken : childCts.Token).ConfigureAwait(false);
                     }
+                    catch (HttpRequestException e) when (e.InnerException is AuthenticationException)
+                    {
+                        // Consider HttpRequestException/AuthenticationException to be nonrecoverable.
+                        throw;
+                    }
                     catch (Exception e)
                     {
                         if (cancellationToken.IsCancellationRequested)
@@ -403,7 +408,7 @@ namespace Snowflake.Data.Core
                         }
                         else
                         {
-                            //TODO: Should probably check to see if the error is recoverable or transient.
+                            //TODO: Should definitly check to see if the error is recoverable or transient; AuthenticationExceptions are treated as nonrecoverable, but there may be more.
                             logger.Warn("Error occurred during request, retrying...", e);
                         }
                     }


### PR DESCRIPTION
### Description
HttpRequestException with an AuthenticationException is nonrecoverable and should be treated as such.  Burying this exception just means we can't tell why our requests are failing.

### Checklist
- [ x] Code compiles correctly
- [ x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ x] Created tests which fail without the change (if possible)
- [ x] All tests passing (`dotnet test`)
- [ x] Extended the README / documentation, if necessary
- [x ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
