### PR TITLE
SNOW-1276398 Fix not thrown exception when OpenAsync http request fails

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -2284,7 +2284,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 var thrown = Assert.Throws<AggregateException>(() => connection.OpenAsync().Wait());
 
                 // assert
-                SnowflakeDbExceptionAssert.HasErrorCode(thrown.InnerException, SFError.INTERNAL_ERROR);
+                Assert.IsTrue(thrown.InnerException is TaskCanceledException || thrown.InnerException is SnowflakeDbException);
+                if (thrown.InnerException is SnowflakeDbException)
+                    SnowflakeDbExceptionAssert.HasErrorCode(thrown.InnerException, SFError.INTERNAL_ERROR);
                 Assert.AreEqual(ConnectionState.Closed, connection.State);
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -2273,11 +2273,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
-        public void TestOpenAsyncThrowExceptionWhenConnectToUnreachableHost()
+        [TestCase("connection_timeout=5;")]
+        [TestCase("")]
+        public void TestOpenAsyncThrowExceptionWhenConnectToUnreachableHost(string extraParameters)
         {
             // arrange
-            var connectionString = "account=testAccount;user=testUser;password=testPassword;useProxy=true;proxyHost=no.such.pro.xy;proxyPort=8080;"
-                                   + "connection_timeout=5;";
+            var connectionString = "account=testAccount;user=testUser;password=testPassword;useProxy=true;proxyHost=no.such.pro.xy;proxyPort=8080;" +
+                                   extraParameters;
             using (var connection = new SnowflakeDbConnection(connectionString))
             {
                 // act
@@ -2298,7 +2300,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connectionString = "account=testAccount;user=testUser;password=testPassword;useProxy=true;proxyHost=no.such.pro.xy;proxyPort=8080;";
             using (var connection = new SnowflakeDbConnection(connectionString))
             {
-                var shortCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                var shortCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(10));
 
                 // act
                 var thrown = Assert.Throws<AggregateException>(() => connection.OpenAsync(shortCancellation.Token).Wait());

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -2300,7 +2300,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connectionString = "account=testAccount;user=testUser;password=testPassword;useProxy=true;proxyHost=no.such.pro.xy;proxyPort=8080;";
             using (var connection = new SnowflakeDbConnection(connectionString))
             {
-                var shortCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(10));
+                var shortCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
                 // act
                 var thrown = Assert.Throws<AggregateException>(() => connection.OpenAsync(shortCancellation.Token).Wait());

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -318,6 +318,12 @@ namespace Snowflake.Data.Client
                            SFError.INTERNAL_ERROR,
                            "Unable to connect");
                     }
+                    else if (previousTask.IsCanceled)
+                    {
+                        _connectionState = ConnectionState.Closed;
+                        logger.Debug("Connection canceled");
+                        throw new TaskCanceledException("Connecting was cancelled");
+                    }
                     else
                     {
                         // Only continue if the session was opened successfully
@@ -325,8 +331,7 @@ namespace Snowflake.Data.Client
                         logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
                         OnSessionEstablished();
                     }
-                },
-                TaskContinuationOptions.NotOnCanceled);
+                }, TaskContinuationOptions.None);
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -331,7 +331,7 @@ namespace Snowflake.Data.Client
                         logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
                         OnSessionEstablished();
                     }
-                }, TaskContinuationOptions.None);
+                }, TaskContinuationOptions.None); // this continuation should be executed always (even if the whole operation was canceled) because it sets the proper state of the connection
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -318,11 +318,6 @@ namespace Snowflake.Data.Client
                            SFError.INTERNAL_ERROR,
                            "Unable to connect");
                     }
-                    else if (previousTask.IsCanceled)
-                    {
-                        _connectionState = ConnectionState.Closed;
-                        logger.Debug("Connection canceled");
-                    }
                     else
                     {
                         // Only continue if the session was opened successfully
@@ -331,7 +326,7 @@ namespace Snowflake.Data.Client
                         OnSessionEstablished();
                     }
                 },
-                cancellationToken);
+                TaskContinuationOptions.NotOnCanceled);
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -13,7 +13,6 @@ using System.Collections.Specialized;
 using System.Web;
 using System.Security.Authentication;
 using System.Linq;
-using Snowflake.Data.Client;
 using Snowflake.Data.Core.Authenticator;
 
 namespace Snowflake.Data.Core
@@ -88,7 +87,7 @@ namespace Snowflake.Data.Core
 
         private HttpUtil()
         {
-            // This value is used by AWS SDK and can cause deadlock,
+            // This value is used by AWS SDK and can cause deadlock, 
             // so we need to increase the default value of 2
             // See: https://github.com/aws/aws-sdk-net/issues/152
             ServicePointManager.DefaultConnectionLimit = 50;
@@ -182,15 +181,15 @@ namespace Snowflake.Data.Core
                     {
                         // Get the original entry
                         entry = bypassList[i].Trim();
-                        // . -> [.] because . means any char
+                        // . -> [.] because . means any char 
                         entry = entry.Replace(".", "[.]");
                         // * -> .*  because * is a quantifier and need a char or group to apply to
                         entry = entry.Replace("*", ".*");
-
+                        
                         entry = entry.StartsWith("^") ? entry : $"^{entry}";
-
+                        
                         entry = entry.EndsWith("$") ? entry : $"{entry}$";
-
+                        
                         // Replace with the valid entry syntax
                         bypassList[i] = entry;
 
@@ -374,6 +373,7 @@ namespace Snowflake.Data.Core
 
                 while (true)
                 {
+
                     try
                     {
                         childCts = null;
@@ -384,7 +384,7 @@ namespace Snowflake.Data.Core
                             if (httpTimeout.Ticks == 0)
                                 childCts.Cancel();
                             else
-                                childCts.CancelAfter(httpTimeout);
+                                childCts.CancelAfter(httpTimeout);                        
                         }
                         response = await base.SendAsync(requestMessage, childCts == null ?
                             cancellationToken : childCts.Token).ConfigureAwait(false);
@@ -454,8 +454,7 @@ namespace Snowflake.Data.Core
                         {
                             return response;
                         }
-                        throw new SnowflakeDbException(new OperationCanceledException($"http request failed and max retry {maxRetryCount} reached"),
-                            SFError.INTERNAL_ERROR, "Unable to connect");
+                        throw new OperationCanceledException($"http request failed and max retry {maxRetryCount} reached");
                     }
 
                     // Disposing of the response if not null now that we don't need it anymore

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -374,7 +374,6 @@ namespace Snowflake.Data.Core
 
                 while (true)
                 {
-                    TaskCanceledException cancelException = null;
                     try
                     {
                         childCts = null;
@@ -407,8 +406,6 @@ namespace Snowflake.Data.Core
                             //TODO: Should probably check to see if the error is recoverable or transient.
                             logger.Warn("Error occurred during request, retrying...", e);
                         }
-                        if (e is TaskCanceledException)
-                            cancelException = (TaskCanceledException) e;
                     }
 
                     if (childCts != null)
@@ -457,12 +454,8 @@ namespace Snowflake.Data.Core
                         {
                             return response;
                         }
-
-                        if (cancelException != null)
-                            throw cancelException;
-
-                        throw new SnowflakeDbException(cancelException, SFError.INTERNAL_ERROR,
-                            $"Http request failed and max retry {maxRetryCount} reached");
+                        throw new SnowflakeDbException(new OperationCanceledException($"http request failed and max retry {maxRetryCount} reached"),
+                            SFError.INTERNAL_ERROR, "Unable to connect");
                     }
 
                     // Disposing of the response if not null now that we don't need it anymore

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -458,15 +458,13 @@ namespace Snowflake.Data.Core
                             return response;
                         }
 
-
+                        if (toThrow is TaskCanceledException)
+                        {
+                            throw toThrow;
+                        }
                         throw new SnowflakeDbException(toThrow, SFError.INTERNAL_ERROR,
                             $"Http request failed and max retry {maxRetryCount} reached");
 
-                    }
-
-                    if (childCts.IsCancellationRequested)
-                    {
-                        throw new OperationCanceledException($"cancelado!!!");
                     }
 
                     // Disposing of the response if not null now that we don't need it anymore


### PR DESCRIPTION
### Description
Fix not thrown exception when OpenAsync http request fails

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
