### PR TITLE
SNOW-1612981 loglevel for errors Debug -> Error

### DIFF
--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -118,7 +118,7 @@ namespace Snowflake.Data.Core
                             .ConfigureAwait(false);
                         if (!response.IsSuccessStatusCode)
                         {
-                            logger.Debug($"Failed Response: {sid} {message.Method} {message.RequestUri} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
+                            logger.Error($"Failed Response: {sid} {message.Method} {message.RequestUri} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
                         }
                         else
                         {


### PR DESCRIPTION
### Description
Debugging https://github.com/snowflakedb/snowflake-connector-net/issues/1004 made apparent that it would be more helpful if the errors encountered during communicating with Snowflake would not be 'hidden' under `Debug` loglevel, as enabling `Debug` loglevel for the whole driver causes a lot of logs.

Exposing unsuccessful requests at `Error` loglevel could help see and catch them easier even without needing to enable Debug logs across all the driver.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
