### PR TITLE
SNOW-1640968 Make connection finaliser a not blocking operation

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -2310,6 +2310,55 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.AreEqual(ConnectionState.Closed, connection.State);
             }
         }
+
+        [Test]
+        public void TestCloseSessionWhenGarbageCollectorFinalizesConnection()
+        {
+            // arrange
+            var session = GetSessionFromForgottenConnection();
+            Assert.NotNull(session);
+            Assert.NotNull(session.sessionId);
+            Assert.NotNull(session.sessionToken);
+
+            // act
+            GC.Collect();
+            Awaiter.WaitUntilConditionOrTimeout(() => session.sessionToken == null, TimeSpan.FromSeconds(15));
+
+            // assert
+            Assert.IsNull(session.sessionToken);
+        }
+
+        private SFSession GetSessionFromForgottenConnection()
+        {
+            var connection = new SnowflakeDbConnection(ConnectionString + ";poolingEnabled=false;application=TestGarbageCollectorCloseSession");
+            connection.Open();
+            return connection.SfSession;
+        }
+
+        [Test]
+        public void TestHangingCloseIsNotBlocking()
+        {
+            // arrange
+            var restRequester = new MockCloseHangingRestRequester();
+            var session = new SFSession("account=test;user=test;password=test", null, restRequester);
+            session.Open();
+            var watch = new Stopwatch();
+
+            // act
+            watch.Start();
+            session.closeNonBlocking();
+            watch.Stop();
+            var closeDuration = watch.Elapsed.Duration();
+            watch.Restart();
+            Awaiter.WaitUntilConditionOrTimeout(() => restRequester.CloseRequests.Count > 0, TimeSpan.FromSeconds(15));
+            watch.Stop();
+            var backgroundTaskDuration = watch.Elapsed.Duration();
+
+            // assert
+            Assert.AreEqual(1, restRequester.CloseRequests.Count);
+            Assert.Less(closeDuration, TimeSpan.FromSeconds(5)); // close executed immediately
+            Assert.GreaterOrEqual(backgroundTaskDuration, TimeSpan.FromSeconds(10)); // while background task took more time
+        }
     }
 }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -2342,22 +2342,21 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var restRequester = new MockCloseHangingRestRequester();
             var session = new SFSession("account=test;user=test;password=test", null, restRequester);
             session.Open();
-            var watch = new Stopwatch();
+            var watchClose = new Stopwatch();
+            var watchClosedFinished = new Stopwatch();
 
             // act
-            watch.Start();
-            session.closeNonBlocking();
-            watch.Stop();
-            var closeDuration = watch.Elapsed.Duration();
-            watch.Restart();
+            watchClose.Start();
+            watchClosedFinished.Start();
+            session.CloseNonBlocking();
+            watchClose.Stop();
             Awaiter.WaitUntilConditionOrTimeout(() => restRequester.CloseRequests.Count > 0, TimeSpan.FromSeconds(15));
-            watch.Stop();
-            var backgroundTaskDuration = watch.Elapsed.Duration();
+            watchClosedFinished.Stop();
 
             // assert
             Assert.AreEqual(1, restRequester.CloseRequests.Count);
-            Assert.Less(closeDuration, TimeSpan.FromSeconds(5)); // close executed immediately
-            Assert.GreaterOrEqual(backgroundTaskDuration, TimeSpan.FromSeconds(10)); // while background task took more time
+            Assert.Less(watchClose.Elapsed.Duration(), TimeSpan.FromSeconds(5)); // close executed immediately
+            Assert.GreaterOrEqual(watchClosedFinished.Elapsed.Duration(), TimeSpan.FromSeconds(10)); // while background task took more time
         }
     }
 }

--- a/Snowflake.Data.Tests/Mock/MockCloseHangingRestRequester.cs
+++ b/Snowflake.Data.Tests/Mock/MockCloseHangingRestRequester.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Data.Core;
+
+namespace Snowflake.Data.Tests.Mock
+{
+    internal class MockCloseHangingRestRequester: IMockRestRequester
+    {
+        internal List<SFRestRequest> CloseRequests { get; } = new();
+
+        public T Get<T>(IRestRequest request)
+        {
+            return Task.Run(async () => await (GetAsync<T>(request, CancellationToken.None)).ConfigureAwait(false)).Result;
+        }
+
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<T>((T)(object)null);
+        }
+
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<HttpResponseMessage>(null);
+        }
+
+        public HttpResponseMessage Get(IRestRequest request)
+        {
+            return null;
+        }
+
+        public T Post<T>(IRestRequest postRequest)
+        {
+            return Task.Run(async () => await (PostAsync<T>(postRequest, CancellationToken.None)).ConfigureAwait(false)).Result;
+        }
+
+        public Task<T> PostAsync<T>(IRestRequest postRequest, CancellationToken cancellationToken)
+        {
+            SFRestRequest sfRequest = (SFRestRequest)postRequest;
+            if (sfRequest.jsonBody is LoginRequest)
+            {
+                LoginResponse authnResponse = new LoginResponse
+                {
+                    data = new LoginResponseData()
+                    {
+                        sessionId = "123456789",
+                        token = "session_token",
+                        masterToken = "master_token",
+                        authResponseSessionInfo = new SessionInfo(),
+                        nameValueParameter = new List<NameValueParameter>()
+                    },
+                    success = true
+                };
+
+                // login request return success
+                return Task.FromResult<T>((T)(object)authnResponse);
+            }
+
+            if (sfRequest.Url.Query.StartsWith("?delete=true"))
+            {
+                var closeResponse = new CloseResponse()
+                {
+                    code = 390111,
+                    message = "Session no longer exists. New login required to access the service",
+                    success = false
+                };
+                Thread.Sleep(TimeSpan.FromSeconds(10));
+                CloseRequests.Add(sfRequest);
+                return Task.FromResult<T>((T)(object)closeResponse);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public void setHttpClient(HttpClient httpClient)
+        {
+            // Nothing to do
+        }
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var restRequester = new MockCloseSessionGone();
             SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
             sfSession.Open();
-            Assert.DoesNotThrow(() => sfSession.closeNonBlocking());
+            Assert.DoesNotThrow(() => sfSession.CloseNonBlocking());
         }
 
         [Test]

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -16,10 +16,19 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestSessionGoneWhenClose()
         {
-            Mock.MockCloseSessionGone restRequester = new Mock.MockCloseSessionGone();
+            var restRequester = new MockCloseSessionGone();
             SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
             sfSession.Open();
             Assert.DoesNotThrow(() => sfSession.close());
+        }
+
+        [Test]
+        public void TestSessionGoneWhenCloseNonBlocking()
+        {
+            var restRequester = new MockCloseSessionGone();
+            SFSession sfSession = new SFSession("account=test;user=test;password=test", null, restRequester);
+            sfSession.Open();
+            Assert.DoesNotThrow(() => sfSession.closeNonBlocking());
         }
 
         [Test]

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -397,7 +397,7 @@ namespace Snowflake.Data.Client
                 }
                 else
                 {
-                    SfSession?.close();
+                    SfSession?.closeNonBlocking();
                     SfSession = null;
                     _connectionState = ConnectionState.Closed;
                 }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -397,7 +397,7 @@ namespace Snowflake.Data.Client
                 }
                 else
                 {
-                    SfSession?.closeNonBlocking();
+                    SfSession?.CloseNonBlocking();
                     SfSession = null;
                     _connectionState = ConnectionState.Closed;
                 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -310,7 +310,7 @@ namespace Snowflake.Data.Core
             var response = await restRequester.PostAsync<CloseResponse>(closeSessionRequest, cancellationToken).ConfigureAwait(false);
             if (!response.success)
             {
-                logger.Debug($"Failed to delete session {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
+                logger.Error($"Failed to delete session {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
             }
 
             logger.Debug($"Session closed: {sessionId}");

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -281,11 +281,10 @@ namespace Snowflake.Data.Core
             stopHeartBeatForThisSession();
             var closeSessionRequest = PrepareCloseSessionRequest();
             PostCloseSession(closeSessionRequest, restRequester);
-            // Just in case the session won't be closed twice
             sessionToken = null;
         }
 
-        internal void closeNonBlocking()
+        internal void CloseNonBlocking()
         {
             // Nothing to do if the session is not open
             if (!IsEstablished()) return;
@@ -293,7 +292,6 @@ namespace Snowflake.Data.Core
             stopHeartBeatForThisSession();
             var closeSessionRequest = PrepareCloseSessionRequest();
             Task.Run(() => PostCloseSession(closeSessionRequest, restRequester));
-            // Just in case the session won't be closed twice
             sessionToken = null;
         }
 
@@ -306,15 +304,14 @@ namespace Snowflake.Data.Core
 
             var closeSessionRequest = PrepareCloseSessionRequest();
 
-            logger.Debug($"Send async closeSessionRequest");
+            logger.Debug($"Closing session async");
             var response = await restRequester.PostAsync<CloseResponse>(closeSessionRequest, cancellationToken).ConfigureAwait(false);
             if (!response.success)
             {
-                logger.Error($"Failed to delete session {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
+                logger.Error($"Failed to close session {sessionId}, error ignored. Code: {response.code} Message: {response.message}");
             }
 
             logger.Debug($"Session closed: {sessionId}");
-            // Just in case the session won't be closed twice
             sessionToken = null;
         }
 
@@ -322,18 +319,18 @@ namespace Snowflake.Data.Core
         {
             try
             {
-                logger.Debug($"Send closeSessionRequest");
+                logger.Debug($"Closing session");
                 var response = restRequester.Post<CloseResponse>(closeSessionRequest);
                 if (!response.success)
                 {
-                    logger.Error($"Failed to delete session: {closeSessionRequest.sid}, error ignored. Code: {response.code} Message: {response.message}");
+                    logger.Error($"Failed to close session: {closeSessionRequest.sid}, error ignored. Code: {response.code} Message: {response.message}");
                 }
 
                 logger.Debug($"Session closed: {closeSessionRequest.sid}");
             }
             catch (Exception)
             {
-                logger.Error($"Failed to delete session: {closeSessionRequest.sid}, because of exception.");
+                logger.Error($"Failed to close session: {closeSessionRequest.sid}, because of exception.");
                 throw;
             }
         }


### PR DESCRIPTION
### Description
SNOW-1640968 Make connection finaliser a not blocking operation to avoid blocking garbage collector which could lead to massive memory consumption.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
