### PR TITLE
add null check to initEncryptionMaterial

### DIFF
--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -544,7 +544,10 @@ namespace Snowflake.Data.Core
         {
             if (CommandTypes.UPLOAD == CommandType)
             {
-                EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
+                if (TransferMetadata.encryptionMaterial?.Any() ?? false)
+                {
+                    EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
+                }
             }
         }
 


### PR DESCRIPTION
### Description
when attempting to upload files using PUT, lack of encryption material causes generic "object reference not set to an instance of an object"

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
