### PR TITLE
SNOW-1729244: Replaced long data type with BigInteger, for TIMESTAMP_TZ and TIMESTAMP_LTZ

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
@@ -49,6 +49,8 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(SFDataType.TIMESTAMP_LTZ, "1341136800000000000", "2012-07-01T12:00:00.0000000+02:00")]
         [TestCase(SFDataType.TIMESTAMP_LTZ, "352245599987654000", "1981-02-28T23:59:59.9876540+02:00")]
         [TestCase(SFDataType.TIMESTAMP_LTZ, "1678868249207000000", "2023/03/15T13:17:29.207+05:00")]
+        [TestCase(SFDataType.TIMESTAMP_LTZ, "253402214400000000000", "9999-12-31T00:00:00.0000000+00:00")]
+        [TestCase(SFDataType.TIMESTAMP_LTZ, "-62135596800000000000", "0001-01-01T00:00:00.0000000+00:00")]
         public void TestCsvDataConversionForTimestampLtz(SFDataType dbType, string input, string expected)
         {
             // Arrange
@@ -63,6 +65,8 @@ namespace Snowflake.Data.Tests.UnitTests
         
         [TestCase(SFDataType.TIMESTAMP_TZ, "1341136800000000000 1560", "2012-07-01 12:00:00.000000 +02:00")]
         [TestCase(SFDataType.TIMESTAMP_TZ, "352245599987654000 1560", "1981-02-28 23:59:59.987654 +02:00")]
+        [TestCase(SFDataType.TIMESTAMP_TZ, "253402214400000000000 1440", "9999-12-31 00:00:00.000000 +00:00")]
+        [TestCase(SFDataType.TIMESTAMP_TZ, "-62135596800000000000 1440", "0001-01-01 00:00:00.000000 +00:00")]
         public void TestCsvDataConversionForTimestampTz(SFDataType dbType, string input, string expected)
         {
             // Arrange

--- a/Snowflake.Data/Core/SFBindUploader.cs
+++ b/Snowflake.Data/Core/SFBindUploader.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -259,8 +260,9 @@ namespace Snowflake.Data.Core
                     DateTime time = epoch.AddTicks(nsSinceMidnight/100);
                     return time.ToString("HH:mm:ss.fffffff");
                 case "TIMESTAMP_LTZ":
-                    long nsFromEpochLtz = long.Parse(sValue); // SFDateConverter.csharpValToSfVal provides in [ns] from Epoch
-                    DateTime ltz = epoch.AddTicks(nsFromEpochLtz/100);
+                    BigInteger nsFromEpochLtz = BigInteger.Parse(sValue); // SFDateConverter.csharpValToSfVal provides in [ns] from Epoch
+                    BigInteger ticksFromEpochLtz = nsFromEpochLtz/100;
+                    DateTime ltz = epoch.AddTicks((long)ticksFromEpochLtz);
                     return ltz.ToLocalTime().ToString("O"); // ISO 8601 format
                 case "TIMESTAMP_NTZ":
                     long nsFromEpochNtz = long.Parse(sValue); // SFDateConverter.csharpValToSfVal provides in [ns] from Epoch
@@ -268,9 +270,10 @@ namespace Snowflake.Data.Core
                     return ntz.ToString("yyyy-MM-dd HH:mm:ss.fffffff");
                 case "TIMESTAMP_TZ":
                     string[] tstzString = sValue.Split(' ');
-                    long nsFromEpochTz = long.Parse(tstzString[0]); // SFDateConverter provides in [ns] from Epoch
-                    int timeZoneOffset = int.Parse(tstzString[1]) - 1440; // SFDateConverter provides in minutes increased by 1440m
-                    DateTime timestamp = epoch.AddTicks(nsFromEpochTz/100).AddMinutes(timeZoneOffset);
+                    BigInteger nsFromEpochTz = BigInteger.Parse(tstzString[0]); // SFDateConverter provides in [ns] from Epoch
+                    int timeZoneOffset = int.Parse(tstzString[1])-1440; // SFDateConverter provides in minutes increased by 1440m
+                    BigInteger ticksFromEpoch = nsFromEpochTz/100;
+                    DateTime timestamp = epoch.AddTicks((long)ticksFromEpoch).AddMinutes(timeZoneOffset);
                     TimeSpan offset = TimeSpan.FromMinutes(timeZoneOffset);
                     DateTimeOffset tzDateTimeOffset = new DateTimeOffset(timestamp.Ticks, offset);
                     return tzDateTimeOffset.ToString("yyyy-MM-dd HH:mm:ss.fffffff zzz");

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using System.Numerics;
 using System.Text;
 using Snowflake.Data.Client;
 
@@ -152,7 +153,7 @@ namespace Snowflake.Data.Core
             {
                 case SFDataType.DATE:
                     long srcValLong = FastParser.FastParseInt64(srcVal.Buffer, srcVal.offset, srcVal.length);
-                    return DateTime.SpecifyKind(UnixEpoch.AddDays(srcValLong), DateTimeKind.Unspecified);;
+                    return DateTime.SpecifyKind(UnixEpoch.AddDays(srcValLong), DateTimeKind.Unspecified);
 
                 case SFDataType.TIME:
                 case SFDataType.TIMESTAMP_NTZ:
@@ -339,7 +340,14 @@ namespace Snowflake.Data.Core
                         }
                         else
                         {
-                            destVal = ((long)(((DateTimeOffset)srcVal).UtcTicks - UnixEpoch.Ticks) * 100).ToString();
+                            DateTimeOffset dtOffset = (DateTimeOffset)srcVal;
+
+                            BigInteger utcTicksBig = new BigInteger(dtOffset.UtcTicks);
+                            BigInteger unixEpochTicksBig = new BigInteger(UnixEpoch.Ticks);
+
+                            BigInteger tickDiffBig = (utcTicksBig - unixEpochTicksBig) * 100;
+
+                            destVal = tickDiffBig.ToString();
                         }
                         break;
 
@@ -404,7 +412,11 @@ namespace Snowflake.Data.Core
                         else
                         {
                             DateTimeOffset dtOffset = (DateTimeOffset)srcVal;
-                            destVal = String.Format("{0} {1}", (dtOffset.UtcTicks - UnixEpoch.Ticks) * 100L,
+                            BigInteger utcTicksBig = new BigInteger(dtOffset.UtcTicks);
+                            BigInteger unixEpochTicksBig = new BigInteger(UnixEpoch.Ticks);
+                            BigInteger tickDiffBig = (utcTicksBig - unixEpochTicksBig) * 100;
+
+                            destVal = String.Format("{0} {1}", tickDiffBig.ToString(),
                                 dtOffset.Offset.TotalMinutes + 1440);
                         }
                         break;


### PR DESCRIPTION
### Description
- Replaced long data type with BigInteger, for TIMESTAMP_TZ and TIMESTAMP_LTZ. Because for large dates long data type overflow occured and values became negative. 
- I also added test cases for big dates like 9999-12-31 to `SFBindUploaderTest.cs` class.


### Checklist
- [X] Code compiles correctly
- [X] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [X] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`) (Some were failing before I made changes)
- [ ] Extended the README / documentation, if necessary
- [X] Provide JIRA issue id (if possible) or GitHub issue id in PR name

 https://github.com/snowflakedb/snowflake-connector-net/issues/1036
