### PR TITLE
SNOW-1739483 Fix S3 exception casting and flaky tests

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -514,8 +514,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                         // Should timeout after the default timeout (300 sec)
                         Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, conn.ConnectionTimeout * 1000 - delta);
-                        // But never more because there's no connection timeout remaining
-                        Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (conn.ConnectionTimeout + 1) * 1000);
+                        // But never more because there's no connection timeout remaining (with 2 seconds margin)
+                        Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (conn.ConnectionTimeout + 2) * 1000);
                     }
                 }
             }
@@ -2015,8 +2015,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Should timeout after the default timeout (300 sec)
                 Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, conn.ConnectionTimeout * 1000 - delta);
-                // But never more because there's no connection timeout remaining
-                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (conn.ConnectionTimeout + 1) * 1000);
+                // But never more because there's no connection timeout remaining (with 2 seconds margin)
+                Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, (conn.ConnectionTimeout + 2) * 1000);
 
                 Assert.AreEqual(ConnectionState.Closed, conn.State);
                 Assert.AreEqual(SFSessionHttpClientProperties.DefaultRetryTimeout.TotalSeconds, conn.ConnectionTimeout);

--- a/Snowflake.Data.Tests/Mock/MockS3Client.cs
+++ b/Snowflake.Data.Tests/Mock/MockS3Client.cs
@@ -35,22 +35,23 @@ namespace Snowflake.Data.Tests.Mock
         internal const int ContentLength = 9999;
 
         // Create AWS exception for mock requests
-        static Exception CreateMockAwsResponseError(string errorCode, bool isAsync)
+        static Exception CreateMockAwsResponseError(string awsErrorCode, bool isAsync)
         {
-            AmazonS3Exception awsError = new AmazonS3Exception(S3ErrorMessage);
-            awsError.ErrorCode = errorCode;
+             Exception exception = awsErrorCode.Length > 0
+                ? new AmazonS3Exception(S3ErrorMessage) { ErrorCode = awsErrorCode }
+                : new Exception("Non-AWS exception");
 
             if (isAsync)
             {
-                return awsError; // S3 throws the AmazonS3Exception on async calls
+                return exception; // S3 throws the AmazonS3Exception on async calls
             }
 
-            Exception exceptionContainingS3Error = new Exception(S3ErrorMessage, awsError);
+            Exception exceptionContainingS3Error = new Exception(S3ErrorMessage, exception);
             return exceptionContainingS3Error;  // S3 places the AmazonS3Exception on the InnerException property on non-async calls
         }
 
         // Create mock response for GetFileHeader
-        static internal Task<GetObjectResponse> CreateResponseForGetFileHeader(string statusCode, bool isAsync)
+        internal static Task<GetObjectResponse> CreateResponseForGetFileHeader(string statusCode, bool isAsync)
         {
             if (statusCode == HttpStatusCode.OK.ToString())
             {
@@ -70,20 +71,20 @@ namespace Snowflake.Data.Tests.Mock
         }
 
         // Create mock response for UploadFile
-        static internal Task<PutObjectResponse> CreateResponseForUploadFile(string statusCode, bool isAsync)
+        internal static Task<PutObjectResponse> CreateResponseForUploadFile(string awsStatusCode, bool isAsync)
         {
-            if (statusCode == HttpStatusCode.OK.ToString())
+            if (awsStatusCode == AwsStatusOk)
             {
                 return Task.FromResult(new PutObjectResponse());
             }
             else
             {
-                throw CreateMockAwsResponseError(statusCode, isAsync);
+                throw CreateMockAwsResponseError(awsStatusCode, isAsync);
             }
         }
 
         // Create mock response for DownloadFile
-        static internal Task<GetObjectResponse> CreateResponseForDownloadFile(string statusCode, bool isAsync)
+        internal static Task<GetObjectResponse> CreateResponseForDownloadFile(string statusCode, bool isAsync)
         {
             if (statusCode == HttpStatusCode.OK.ToString())
             {

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -127,18 +127,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(SFS3Client.NO_SUCH_KEY, ResultStatus.NOT_FOUND_FILE)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.ERROR)] // Any error that isn't the above will return ResultStatus.ERROR
-        public void TestGetFileHeader(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.ERROR)] // For non-AWS exception will return ResultStatus.ERROR
+        public void TestGetFileHeader(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<GetObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForGetFileHeader(request.BucketName, false);
-                });
+                .Returns(() => MockS3Client.CreateResponseForGetFileHeader(awsStatusCode, false));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
 
             // Act
             FileHeader fileHeader = _client.GetFileHeader(_fileMetadata);
@@ -152,18 +149,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(SFS3Client.NO_SUCH_KEY, ResultStatus.NOT_FOUND_FILE)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.ERROR)] // Any error that isn't the above will return ResultStatus.ERROR
-        public async Task TestGetFileHeaderAsync(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.ERROR)] // For non-AWS exception will return ResultStatus.ERROR
+        public async Task TestGetFileHeaderAsync(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<GetObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForGetFileHeader(request.BucketName, true);
-                });
+                .Returns(() => MockS3Client.CreateResponseForGetFileHeader(awsStatusCode, true));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
 
             // Act
             FileHeader fileHeader = await _client.GetFileHeaderAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false);
@@ -194,18 +188,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(MockS3Client.AwsStatusOk, ResultStatus.UPLOADED)]
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.NEED_RETRY)] // Any error that isn't the above will return ResultStatus.NEED_RETRY
-        public void TestUploadFile(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.NEED_RETRY)] // For non-AWS exception will return ResultStatus.NEED_RETRY
+        public void TestUploadFile(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<PutObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForUploadFile(request.BucketName, false);
-                });
+                .Returns(() => MockS3Client.CreateResponseForUploadFile(awsStatusCode, false));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
             _fileMetadata.uploadSize = UploadFileSize;
 
             // Act
@@ -254,18 +245,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(MockS3Client.AwsStatusOk, ResultStatus.UPLOADED)]
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.NEED_RETRY)] // Any error that isn't the above will return ResultStatus.NEED_RETRY
-        public async Task TestUploadFileAsync(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.NEED_RETRY)] // For non-AWS exception will return ResultStatus.NEED_RETRY
+        public async Task TestUploadFileAsync(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<PutObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForUploadFile(request.BucketName, true);
-                });
+                .Returns(() => MockS3Client.CreateResponseForUploadFile(awsStatusCode, true));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
             _fileMetadata.uploadSize = UploadFileSize;
 
             // Act
@@ -295,18 +283,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(MockS3Client.AwsStatusOk, ResultStatus.DOWNLOADED)]
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.NEED_RETRY)] // Any error that isn't the above will return ResultStatus.NEED_RETRY
-        public void TestDownloadFile(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.NEED_RETRY)] // For non-AWS exception will return ResultStatus.NEED_RETRY
+        public void TestDownloadFile(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<GetObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForDownloadFile(request.BucketName, false);
-                });
+                .Returns(() => MockS3Client.CreateResponseForDownloadFile(awsStatusCode, false));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
 
             // Act
             _client.DownloadFile(_fileMetadata, t_downloadFileName, Parallel);
@@ -319,18 +304,15 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase(MockS3Client.AwsStatusOk, ResultStatus.DOWNLOADED)]
         [TestCase(SFS3Client.EXPIRED_TOKEN, ResultStatus.RENEW_TOKEN)]
         [TestCase(MockS3Client.AwsStatusError, ResultStatus.NEED_RETRY)] // Any error that isn't the above will return ResultStatus.NEED_RETRY
-        public async Task TestDownloadFileAsync(string requestKey, ResultStatus expectedResultStatus)
+        [TestCase("", ResultStatus.NEED_RETRY)] // For non-AWS exception will return ResultStatus.NEED_RETRY
+        public async Task TestDownloadFileAsync(string awsStatusCode, ResultStatus expectedResultStatus)
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
-                .Returns<GetObjectRequest, CancellationToken>((request, cancellationToken) =>
-                {
-                    return MockS3Client.CreateResponseForDownloadFile(request.BucketName, true);
-                });
+                .Returns(() => MockS3Client.CreateResponseForDownloadFile(awsStatusCode, true));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
-            _fileMetadata.stageInfo.location = requestKey;
 
             // Act
             await _client.DownloadFileAsync(_fileMetadata, t_downloadFileName, Parallel, _cancellationToken).ConfigureAwait(false);

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -525,12 +525,12 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
             switch (ex)
             {
-                case AmazonS3Exception err:
-                    if (err.ErrorCode == EXPIRED_TOKEN || err.ErrorCode == HttpStatusCode.BadRequest.ToString())
+                case AmazonS3Exception exAws:
+                    if (exAws.ErrorCode == EXPIRED_TOKEN || exAws.ErrorCode == HttpStatusCode.BadRequest.ToString())
                     {
                         fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
                     }
-                    else if (err.ErrorCode == NO_SUCH_KEY)
+                    else if (exAws.ErrorCode == NO_SUCH_KEY)
                     {
                         fileMetadata.resultStatus = ResultStatus.NOT_FOUND_FILE.ToString();
                     }
@@ -541,7 +541,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
                     break;
                 default:
-                    fileMetadata.resultStatus = ResultStatus.ERROR.ToString();;
+                    fileMetadata.resultStatus = ResultStatus.ERROR.ToString();
                     break;
             }
         }
@@ -557,20 +557,21 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
             switch (ex)
             {
-                case AmazonS3Exception err:
-                    if (err.ErrorCode == EXPIRED_TOKEN)
+                case AmazonS3Exception exAws:
+                    if (exAws.ErrorCode == EXPIRED_TOKEN)
                     {
                         fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
                     }
                     else
                     {
-                        fileMetadata.lastError = err;
+                        fileMetadata.lastError = exAws;
                         fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
                     }
                     break;
 
-                default:
-                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();;
+                case Exception exOther:
+                    fileMetadata.lastError = exOther;
+                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
                     break;
             }
         }
@@ -586,20 +587,21 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
             switch (ex)
             {
-                case AmazonS3Exception err:
-                    if (err.ErrorCode == EXPIRED_TOKEN)
+                case AmazonS3Exception exAws:
+                    if (exAws.ErrorCode == EXPIRED_TOKEN)
                     {
                         fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
                     }
                     else
                     {
-                        fileMetadata.lastError = err;
+                        fileMetadata.lastError = exAws;
                         fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
                     }
                     break;
 
-                default:
-                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();;
+                case Exception exOther:
+                    fileMetadata.lastError = exOther;
+                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
                     break;
             }
         }

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -508,8 +508,9 @@ namespace Snowflake.Data.Core
                     {
                         // No need to wait more than necessary if it can be avoided.
                         // If the rest timeout will be reached before the next back-off,
-                        // then use the remaining connection timeout
-                        backOffInSec = Math.Min(backOffInSec, (int)restTimeout.TotalSeconds - totalRetryTime);
+                        // then use the remaining connection timeout.
+                        // Math.Max with 0 in case totalRetryTime > restTimeout.TotalSeconds
+                        backOffInSec = Math.Max(Math.Min(backOffInSec, (int)restTimeout.TotalSeconds - totalRetryTime), 0);
                     }
                 }
             }

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -378,9 +378,9 @@ namespace Snowflake.Data.Core
                 UriUpdater updater = new UriUpdater(requestMessage.RequestUri, includeRetryReason);
                 int retryCount = 0;
 
+                long startTimeInMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 while (true)
                 {
-
                     try
                     {
                         childCts = null;
@@ -401,13 +401,12 @@ namespace Snowflake.Data.Core
                         lastException = e;
                         if (cancellationToken.IsCancellationRequested)
                         {
-                            logger.Debug("SF rest request timeout or explicit cancel called.");
+                            logger.Info("SF rest request timeout or explicit cancel called.");
                             cancellationToken.ThrowIfCancellationRequested();
                         }
                         else if (childCts != null && childCts.Token.IsCancellationRequested)
                         {
                             logger.Warn("Http request timeout. Retry the request");
-                            totalRetryTime += (int)httpTimeout.TotalSeconds;
                         }
                         else
                         {
@@ -425,6 +424,8 @@ namespace Snowflake.Data.Core
                             }
                         }
                     }
+
+                    totalRetryTime = (int)((DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTimeInMilliseconds) / 1000);
 
                     if (childCts != null)
                     {
@@ -464,6 +465,19 @@ namespace Snowflake.Data.Core
                         logger.Info("Response returned was null.");
                     }
 
+                    if (restTimeout.TotalSeconds > 0 && totalRetryTime > restTimeout.TotalSeconds)
+                    {
+                        logger.Debug($"stop retry as connection_timeout {restTimeout.TotalSeconds} sec. reached");
+                        if (response != null)
+                        {
+                            return response;
+                        }
+                        var errorMessage = $"http request failed and connection_timeout {restTimeout.TotalSeconds} sec. reached.\n";
+                        errorMessage += $"Last exception encountered: {lastException}";
+                        logger.Error(errorMessage);
+                        throw new OperationCanceledException(errorMessage);
+                    }
+
                     retryCount++;
                     if ((maxRetryCount > 0) && (retryCount > maxRetryCount))
                     {
@@ -486,7 +500,6 @@ namespace Snowflake.Data.Core
                     logger.Debug($"Sleep {backOffInSec} seconds and then retry the request, retryCount: {retryCount}");
 
                     await Task.Delay(TimeSpan.FromSeconds(backOffInSec), cancellationToken).ConfigureAwait(false);
-                    totalRetryTime += backOffInSec;
 
                     var jitter = GetJitter(backOffInSec);
 
@@ -504,6 +517,7 @@ namespace Snowflake.Data.Core
                         backOffInSec *= 2;
                     }
 
+                    totalRetryTime = (int)((DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTimeInMilliseconds) / 1000);
                     if ((restTimeout.TotalSeconds > 0) && (totalRetryTime + backOffInSec > restTimeout.TotalSeconds))
                     {
                         // No need to wait more than necessary if it can be avoided.

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -406,7 +406,7 @@ namespace Snowflake.Data.Core
                         }
                         else if (childCts != null && childCts.Token.IsCancellationRequested)
                         {
-                            logger.Warn("Http request timeout. Retry the request");
+                            logger.Warn($"Http request timeout. Retry the request after {backOffInSec} sec.");
                         }
                         else
                         {


### PR DESCRIPTION
### Description
Fix S3 exception casting and flaky tests
We sometimes get `System.InvalidCastException : Unable to cast object of type 'System.Net.Sockets.SocketException' to type 'Amazon.S3.AmazonS3Exception'. `

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
