### PR TITLE
SNOW-1657238: Fix incorrect row count for rows loaded

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1691,18 +1691,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
-                    var prefix = $"{Path.GetTempPath()}{Guid.NewGuid()}";
+                    var tempFolder = $"{Path.GetTempPath()}Temp_{Guid.NewGuid()}";
 
                     try
                     {
                         // Arrange
+                        Directory.CreateDirectory(tempFolder);
                         var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                         for (int i = 0; i < NumberOfFiles; i++)
                         {
-                            File.WriteAllText(prefix + $"_{i}.csv", data);
+                            File.WriteAllText(Path.Combine(tempFolder, $"{i}.csv"), data);
                         }
                         CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
-                        cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
+                        cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{TableName} AUTO_COMPRESS=FALSE";
                         var reader = cmd.ExecuteReader();
 
                         // Act
@@ -1714,10 +1715,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                     finally
                     {
-                        for (int i = 0; i < NumberOfRows; i++)
-                        {
-                            File.Delete(prefix + $"_{i}.csv");
-                        }
+                        Directory.Delete(tempFolder, true);
                     }
                 }
             }
@@ -1737,18 +1735,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
-                    var prefix = $"{Path.GetTempPath()}{Guid.NewGuid()}";
+                    var tempFolder = $"{Path.GetTempPath()}Temp_{Guid.NewGuid()}";
 
                     try
                     {
                         // Arrange
+                        Directory.CreateDirectory(tempFolder);
                         var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                         for (int i = 0; i < NumberOfFiles; i++)
                         {
-                            File.WriteAllText(prefix + $"_{i}.csv", data);
+                            File.WriteAllText(Path.Combine(tempFolder, $"{i}.csv"), data);
                         }
                         CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
-                        cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
+                        cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{TableName} AUTO_COMPRESS=FALSE";
                         var reader = cmd.ExecuteReader();
 
                         // Act
@@ -1760,10 +1759,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                     finally
                     {
-                        for (int i = 0; i < NumberOfRows; i++)
-                        {
-                            File.Delete(prefix + $"_{i}.csv");
-                        }
+                        Directory.Delete(tempFolder, true);
                     }
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1691,27 +1691,33 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
-                    // Arrange
-                    var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                     var prefix = $"{Path.GetTempPath()}{Guid.NewGuid()}";
-                    for (int i = 0; i < NumberOfFiles; i++)
+
+                    try
                     {
-                        File.WriteAllText(prefix + $"_{i}.csv", data);
+                        // Arrange
+                        var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
+                        for (int i = 0; i < NumberOfFiles; i++)
+                        {
+                            File.WriteAllText(prefix + $"_{i}.csv", data);
+                        }
+                        CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
+                        cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
+                        var reader = cmd.ExecuteReader();
+
+                        // Act
+                        cmd.CommandText = $"COPY INTO {TableName} FROM @%{TableName} PATTERN='.*.csv' FILE_FORMAT=(TYPE=CSV)";
+                        int actualRowCount = cmd.ExecuteNonQuery();
+
+                        // Assert
+                        Assert.AreEqual(ExpectedRowCount, actualRowCount);
                     }
-                    CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
-                    cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
-                    var reader = cmd.ExecuteReader();
-
-                    // Act
-                    cmd.CommandText = $"COPY INTO {TableName} FROM @%{TableName} PATTERN='.*.csv' FILE_FORMAT=(TYPE=CSV)";
-                    int actualRowCount = cmd.ExecuteNonQuery();
-
-                    // Assert
-                    Assert.AreEqual(ExpectedRowCount, actualRowCount);
-
-                    for (int i = 0; i < NumberOfRows; i++)
+                    finally
                     {
-                        File.Delete(prefix + $"_{i}.csv");
+                        for (int i = 0; i < NumberOfRows; i++)
+                        {
+                            File.Delete(prefix + $"_{i}.csv");
+                        }
                     }
                 }
             }
@@ -1731,27 +1737,33 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
-                    // Arrange
-                    var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                     var prefix = $"{Path.GetTempPath()}{Guid.NewGuid()}";
-                    for (int i = 0; i < NumberOfFiles; i++)
+
+                    try
                     {
-                        File.WriteAllText(prefix + $"_{i}.csv", data);
+                        // Arrange
+                        var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
+                        for (int i = 0; i < NumberOfFiles; i++)
+                        {
+                            File.WriteAllText(prefix + $"_{i}.csv", data);
+                        }
+                        CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
+                        cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
+                        var reader = cmd.ExecuteReader();
+
+                        // Act
+                        cmd.CommandText = $"COPY INTO {TableName} FROM @%{TableName} PATTERN='.*.csv' FILE_FORMAT=(TYPE=CSV)";
+                        int actualRowCount = await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+                        // Assert
+                        Assert.AreEqual(ExpectedRowCount, actualRowCount);
                     }
-                    CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
-                    cmd.CommandText = $"PUT file://{prefix + "_*.csv"} @%{TableName} AUTO_COMPRESS=FALSE";
-                    var reader = cmd.ExecuteReader();
-
-                    // Act
-                    cmd.CommandText = $"COPY INTO {TableName} FROM @%{TableName} PATTERN='.*.csv' FILE_FORMAT=(TYPE=CSV)";
-                    int actualRowCount = await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-
-                    // Assert
-                    Assert.AreEqual(ExpectedRowCount, actualRowCount);
-
-                    for (int i = 0; i < NumberOfRows; i++)
+                    finally
                     {
-                        File.Delete(prefix + $"_{i}.csv");
+                        for (int i = 0; i < NumberOfRows; i++)
+                        {
+                            File.Delete(prefix + $"_{i}.csv");
+                        }
                     }
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1700,7 +1700,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                         for (int i = 0; i < NumberOfFiles; i++)
                         {
-                            File.WriteAllText(Path.Combine(tempFolder, $"{i}.csv"), data);
+                            File.WriteAllText(Path.Combine(tempFolder, $"{TestContext.CurrentContext.Test.Name}_{i}.csv"), data);
                         }
                         CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
                         cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{TableName} AUTO_COMPRESS=FALSE";
@@ -1744,7 +1744,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         var data = string.Concat(Enumerable.Repeat(string.Join(",", "TestData") + "\n", NumberOfRows));
                         for (int i = 0; i < NumberOfFiles; i++)
                         {
-                            File.WriteAllText(Path.Combine(tempFolder, $"{i}.csv"), data);
+                            File.WriteAllText(Path.Combine(tempFolder, $"{TestContext.CurrentContext.Test.Name}_{i}.csv"), data);
                         }
                         CreateOrReplaceTable(conn, TableName, new[] { "COL1 STRING" });
                         cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{TableName} AUTO_COMPRESS=FALSE";

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -36,18 +36,11 @@ namespace Snowflake.Data.Core
                     var index = resultSet.sfResultSetMetaData.GetColumnIndexByName("rows_loaded");
                     if (index >= 0)
                     {
-                        int rewindCount = 1;
                         while (resultSet.Next())
                         {
                             updateCount += resultSet.GetInt64(index);
-                            rewindCount++;
                         }
-
-                        while (rewindCount > 0)
-                        {
-                            resultSet.Rewind();
-                            rewindCount--;
-                        }
+                        while (resultSet.Rewind()) {}
                     }
                     break;
                 case SFStatementType.COPY_UNLOAD:

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -36,9 +36,18 @@ namespace Snowflake.Data.Core
                     var index = resultSet.sfResultSetMetaData.GetColumnIndexByName("rows_loaded");
                     if (index >= 0)
                     {
-                        resultSet.Next();
-                        updateCount = resultSet.GetInt64(index);
-                        resultSet.Rewind();
+                        int rewindCount = 1;
+                        while (resultSet.Next())
+                        {
+                            updateCount += resultSet.GetInt64(index);
+                            rewindCount++;
+                        }
+
+                        while (rewindCount > 0)
+                        {
+                            resultSet.Rewind();
+                            rewindCount--;
+                        }
                     }
                     break;
                 case SFStatementType.COPY_UNLOAD:


### PR DESCRIPTION
### Description
Fix incorrect row count when executing a COPY INTO command for ExecuteNonQuery and ExecuteNonQueryAsync

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
