### PR TITLE
SNOW-1739583 Fix of rounding issue

### DIFF
--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -523,8 +523,7 @@ namespace Snowflake.Data.Core
                         // No need to wait more than necessary if it can be avoided.
                         // If the rest timeout will be reached before the next back-off,
                         // then use the remaining connection timeout.
-                        // Math.Max with 0 in case totalRetryTime > restTimeout.TotalSeconds
-                        backOffInSec = Math.Max(Math.Min(backOffInSec, (int)restTimeout.TotalSeconds - totalRetryTime), 0);
+                        backOffInSec = Math.Min(backOffInSec, (int)restTimeout.TotalSeconds - totalRetryTime + 1);
                     }
                 }
             }


### PR DESCRIPTION
### Description
Fix of rounding issue, to avoid the situation with `backOffInSec == 0`:

```
 2024-10-24 12:57:16,009 [35] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 1 sec.
 2024-10-24 12:57:17,020 [36] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 1 sec.
 2024-10-24 12:57:18,036 [36] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 3 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
 2024-10-24 12:57:21,403 [41] [WARN ] [Snowflake.Data.Log.Log4NetImpllassName:61] - Http request timeout. Retry the request after 0 sec.
...
```

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
