### PR TITLE
SNOW-1672654 Support for empty encryptionMaterial

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -527,8 +527,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [Test]
         [IgnoreOnEnvIs("snowflake_cloud_env", new [] { "GCP", "AZURE" })]
         public void TestPutGetCommandForNamedStageWithoutClientSideEncryption(
-            [Values("none", "gzip", "bzip2", "brotli", "deflate", "raw_deflate", "zstd")] string sourceFileCompressionType,
-            [Values("", "/TEST_PATH", "/DEEP/TEST_PATH")] string stagePath,
+            [Values("none", "gzip")] string sourceFileCompressionType,
+            [Values("", "/DEEP/TEST_PATH")] string stagePath,
             [Values] bool autoCompress)
         {
             PrepareTest(sourceFileCompressionType, StageType.NAMED, stagePath, autoCompress, false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -510,7 +510,26 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [Test]
         public void TestPutGetCommand(
             [Values("none", "gzip", "bzip2", "brotli", "deflate", "raw_deflate", "zstd")] string sourceFileCompressionType,
-            [Values] StageType stageType,
+            [Values(StageType.USER, StageType.TABLE, StageType.NAMED)] StageType stageType,
+            [Values("", "/TEST_PATH", "/DEEP/TEST_PATH")] string stagePath,
+            [Values] bool autoCompress)
+        {
+            PrepareTest(sourceFileCompressionType, stageType, stagePath, autoCompress);
+
+            using (var conn = new SnowflakeDbConnection(ConnectionString))
+            {
+                conn.Open();
+                PutFile(conn);
+                CopyIntoTable(conn);
+                GetFile(conn);
+            }
+        }
+
+        [Test]
+        [IgnoreOnEnvIs("snowflake_cloud_env", new [] { "GCP", "AZURE" })]
+        public void TestPutGetCommandWithoutClientSideEncryption(
+            [Values("none", "gzip", "bzip2", "brotli", "deflate", "raw_deflate", "zstd")] string sourceFileCompressionType,
+            [Values(StageType.NAMED_SSE)] StageType stageType,
             [Values("", "/TEST_PATH", "/DEEP/TEST_PATH")] string stagePath,
             [Values] bool autoCompress)
         {

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -525,7 +525,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
         }
 
         [Test]
-        [IgnoreOnEnvIs("snowflake_cloud_env", new [] { "GCP", "AZURE" })]
         public void TestPutGetCommandForNamedStageWithoutClientSideEncryption(
             [Values("none", "gzip")] string sourceFileCompressionType,
             [Values("", "/DEEP/TEST_PATH")] string stagePath,

--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -69,7 +69,6 @@ namespace Snowflake.Data.Tests.UnitTests
                 stageInfo = new PutGetStageInfo()
                 {
                     endPoint = EndPoint,
-                    isClientSideEncrypted = true,
                     location = Location,
                     locationType = SFRemoteStorageUtil.AZURE_FS,
                     path = LocationPath,

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -62,7 +62,6 @@ namespace Snowflake.Data.Tests.UnitTests
                 stageInfo = new PutGetStageInfo()
                 {
                     endPoint = null,
-                    isClientSideEncrypted = true,
                     location = Location,
                     locationType = SFRemoteStorageUtil.GCS_FS,
                     path = LocationPath,

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -87,7 +87,6 @@ namespace Snowflake.Data.Tests.UnitTests
                 stageInfo = new PutGetStageInfo()
                 {
                     endPoint = EndPoint,
-                    isClientSideEncrypted = true,
                     location = Location,
                     locationType = SFRemoteStorageUtil.GCS_FS,
                     path = LocationPath,

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -87,7 +87,6 @@ namespace Snowflake.Data.Tests.UnitTests
                 stageInfo = new PutGetStageInfo()
                 {
                     endPoint = Endpoint,
-                    isClientSideEncrypted = true,
                     location = Location,
                     locationType = SFRemoteStorageUtil.S3_FS,
                     path = LocationPath,

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -544,7 +544,7 @@ namespace Snowflake.Data.Core
         {
             if (CommandTypes.UPLOAD == CommandType)
             {
-                if (TransferMetadata.encryptionMaterial.Count > 0)
+                if (TransferMetadata.stageInfo.isClientSideEncrypted)
                 {
                     EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
                 }

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -468,7 +468,7 @@ namespace Snowflake.Data.Core
 
                         fileMeta.stageInfo = response.data.stageInfo;
                         fileMeta.presignedUrl = response.data.stageInfo.presignedUrl;
-                    }                    
+                    }
                 }
                 else if (CommandTypes.DOWNLOAD == CommandType)
                 {
@@ -477,7 +477,7 @@ namespace Snowflake.Data.Core
                         FilesMetas[index].presignedUrl = TransferMetadata.presignedUrls[index];
                     }
                 }
-            }            
+            }
         }
 
         /// <summary>
@@ -544,7 +544,10 @@ namespace Snowflake.Data.Core
         {
             if (CommandTypes.UPLOAD == CommandType)
             {
-                EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
+                if (TransferMetadata.isClientSideEncrypted)
+                {
+                    EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
+                }
             }
         }
 
@@ -670,7 +673,9 @@ namespace Snowflake.Data.Core
                         overwrite = TransferMetadata.overwrite,
                         presignedUrl = TransferMetadata.stageInfo.presignedUrl,
                         parallel = TransferMetadata.parallel,
-                        encryptionMaterial = TransferMetadata.encryptionMaterial[index],
+                        encryptionMaterial = TransferMetadata.isClientSideEncrypted
+                            ? TransferMetadata.encryptionMaterial[index]
+                            : null,
                         MaxBytesInMemory = GetFileTransferMaxBytesInMemory(),
                         _operationType = CommandTypes.DOWNLOAD
                     };
@@ -715,7 +720,7 @@ namespace Snowflake.Data.Core
                 return FileTransferConfiguration.DefaultMaxBytesInMemory;
             }
         }
-            
+
         /// <summary>
         /// Expand the wildcards if any to generate the list of paths for all files matched by the wildcards.
         /// Also replace the relative paths to the absolute paths for the files if needed.
@@ -731,7 +736,7 @@ namespace Snowflake.Data.Core
             var directoryName = Path.GetDirectoryName(location);
             var foundDirectories = ExpandDirectories(directoryName);
             var filePaths = new List<string>();
-            
+
             if (ContainsWildcard(fileName))
             {
                 foreach (var directory in foundDirectories)
@@ -756,8 +761,8 @@ namespace Snowflake.Data.Core
                     {
                         filePaths.AddRange(
                             Directory.GetFiles(
-                                directory, 
-                                fileName, 
+                                directory,
+                                fileName,
                                 SearchOption.TopDirectoryOnly));
                     }
                 }
@@ -788,7 +793,7 @@ namespace Snowflake.Data.Core
 
             return filePaths;
         }
-        
+
         /// <summary>
         /// Expand the wildcards in the directory path to generate the list of directories to be searched for the files.
         /// </summary>
@@ -803,7 +808,7 @@ namespace Snowflake.Data.Core
             {
                 return new List<string> { Path.GetFullPath(directoryPath) + Path.DirectorySeparatorChar };
             }
-            
+
             var pathParts = directoryPath.Split(Path.DirectorySeparatorChar);
             var resolvedPaths = new List<string>();
 
@@ -863,7 +868,7 @@ namespace Snowflake.Data.Core
         private static string ExpandHomeDirectoryIfNeeded(string directoryPath)
         {
             if (!directoryPath.Contains('~')) return directoryPath;
-            
+
             var homePath = (Environment.OSVersion.Platform == PlatformID.Unix ||
                             Environment.OSVersion.Platform == PlatformID.MacOSX)
                 ? Environment.GetEnvironmentVariable("HOME")
@@ -1036,7 +1041,7 @@ namespace Snowflake.Data.Core
               {
                   await updatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
               }
-              
+
               // Break out of loop if file is successfully uploaded or already exists
               if (fileMetadata.resultStatus == ResultStatus.UPLOADED.ToString() ||
                   fileMetadata.resultStatus == ResultStatus.SKIPPED.ToString())
@@ -1429,7 +1434,7 @@ namespace Snowflake.Data.Core
                 throw new ArgumentException("No file found for: " + TransferMetadata.src_locations[0].ToString());
             }
         }
-        
+
         private static bool IsDirectory(string path)
         {
             var attr = File.GetAttributes(path);

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -544,7 +544,7 @@ namespace Snowflake.Data.Core
         {
             if (CommandTypes.UPLOAD == CommandType)
             {
-                if (TransferMetadata.isClientSideEncrypted)
+                if (TransferMetadata.encryptionMaterial.Count > 0)
                 {
                     EncryptionMaterials.Add(TransferMetadata.encryptionMaterial[0]);
                 }
@@ -673,7 +673,7 @@ namespace Snowflake.Data.Core
                         overwrite = TransferMetadata.overwrite,
                         presignedUrl = TransferMetadata.stageInfo.presignedUrl,
                         parallel = TransferMetadata.parallel,
-                        encryptionMaterial = TransferMetadata.isClientSideEncrypted
+                        encryptionMaterial = index < TransferMetadata.encryptionMaterial.Count
                             ? TransferMetadata.encryptionMaterial[index]
                             : null,
                         MaxBytesInMemory = GetFileTransferMaxBytesInMemory(),

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -422,10 +422,13 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 ContentType = HTTP_HEADER_VALUE_OCTET_STREAM
             };
 
-            // Populate the S3 Request Metadata
-            putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_IV, encryptionMetadata.iv);
-            putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_KEY, encryptionMetadata.key);
-            putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_MATDESC, encryptionMetadata.matDesc);
+            if (stageInfo.isClientSideEncrypted)
+            {
+                // Populate the S3 Request Metadata
+                putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_IV, encryptionMetadata.iv);
+                putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_KEY, encryptionMetadata.key);
+                putObjectRequest.Metadata.Add(AMZ_META_PREFIX + AMZ_MATDESC, encryptionMetadata.matDesc);
+            }
 
             return putObjectRequest;
         }

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -158,13 +158,17 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         {
             fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
 
-            dynamic encryptionData = JsonConvert.DeserializeObject(response.Metadata["encryptiondata"]);
-            SFEncryptionMetadata encryptionMetadata = new SFEncryptionMetadata
+            SFEncryptionMetadata encryptionMetadata = null;
+            if (response.Metadata.TryGetValue("encryptiondata", out var encryptionDataStr))
             {
-                iv = encryptionData["ContentEncryptionIV"],
-                key = encryptionData.WrappedContentKey["EncryptedKey"],
-                matDesc = response.Metadata["matdesc"]
-            };
+                dynamic encryptionData = JsonConvert.DeserializeObject(encryptionDataStr);
+                encryptionMetadata = new SFEncryptionMetadata
+                {
+                    iv = encryptionData["ContentEncryptionIV"],
+                    key = encryptionData.WrappedContentKey["EncryptedKey"],
+                    matDesc = response.Metadata["matdesc"]
+                };
+            }
 
             return new FileHeader
             {
@@ -242,31 +246,35 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
         private BlobClient GetUploadFileBlobClient(ref IDictionary<string, string>metadata, SFFileMetadata fileMetadata, SFEncryptionMetadata encryptionMetadata)
         {
-            // Create the JSON for the encryption data header
-            string encryptionData = JsonConvert.SerializeObject(new EncryptionData
+            if (fileMetadata.stageInfo.isClientSideEncrypted)
             {
-                EncryptionMode = "FullBlob",
-                WrappedContentKey = new WrappedContentInfo
+                // Create the JSON for the encryption data header
+                string encryptionData = JsonConvert.SerializeObject(new EncryptionData
                 {
-                    KeyId = "symmKey1",
-                    EncryptedKey = encryptionMetadata.key,
-                    Algorithm = "AES_CBC_256"
-                },
-                EncryptionAgent = new EncryptionAgentInfo
-                {
-                    Protocol = "1.0",
-                    EncryptionAlgorithm = "AES_CBC_256"
-                },
-                ContentEncryptionIV = encryptionMetadata.iv,
-                KeyWrappingMetadata = new KeyWrappingMetadataInfo
-                {
-                    EncryptionLibrary = "Java 5.3.0"
-                }
-            });
+                    EncryptionMode = "FullBlob",
+                    WrappedContentKey = new WrappedContentInfo
+                    {
+                        KeyId = "symmKey1",
+                        EncryptedKey = encryptionMetadata.key,
+                        Algorithm = "AES_CBC_256"
+                    },
+                    EncryptionAgent = new EncryptionAgentInfo
+                    {
+                        Protocol = "1.0",
+                        EncryptionAlgorithm = "AES_CBC_256"
+                    },
+                    ContentEncryptionIV = encryptionMetadata.iv,
+                    KeyWrappingMetadata = new KeyWrappingMetadataInfo
+                    {
+                        EncryptionLibrary = "Java 5.3.0"
+                    }
+                });
 
-            // Create the metadata to use for the header
-            metadata.Add("encryptiondata", encryptionData);
-            metadata.Add("matdesc", encryptionMetadata.matDesc);
+                // Create the metadata to use for the header
+                metadata.Add("encryptiondata", encryptionData);
+                metadata.Add("matdesc", encryptionMetadata.matDesc);
+            }
+
             metadata.Add("sfcdigest", fileMetadata.sha256Digest);
 
             PutGetStageInfo stageInfo = fileMetadata.stageInfo;

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -382,6 +382,9 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "stageInfo", NullValueHandling = NullValueHandling.Ignore)]
         internal PutGetStageInfo stageInfo { get; set; }
 
+        [JsonProperty(PropertyName = "isClientSideEncrypted", NullValueHandling = NullValueHandling.Ignore)]
+        internal bool isClientSideEncrypted { get; set; }
+
         [JsonProperty(PropertyName = "encryptionMaterial", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(SingleOrArrayConverter<PutGetEncryptionMaterial>))]
         internal List<PutGetEncryptionMaterial> encryptionMaterial { get; set; }
@@ -427,9 +430,6 @@ namespace Snowflake.Data.Core
 
         [JsonProperty(PropertyName = "storageAccount", NullValueHandling = NullValueHandling.Ignore)]
         internal string storageAccount { get; set; }
-
-        [JsonProperty(PropertyName = "isClientSideEncrypted", NullValueHandling = NullValueHandling.Ignore)]
-        internal bool isClientSideEncrypted { get; set; }
 
         [JsonProperty(PropertyName = "creds", NullValueHandling = NullValueHandling.Ignore)]
         internal Dictionary<string, string> stageCredentials { get; set; }

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -428,6 +428,9 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "storageAccount", NullValueHandling = NullValueHandling.Ignore)]
         internal string storageAccount { get; set; }
 
+        [JsonProperty(PropertyName = "isClientSideEncrypted", NullValueHandling = NullValueHandling.Ignore)]
+        internal bool isClientSideEncrypted { get; set; }
+
         [JsonProperty(PropertyName = "creds", NullValueHandling = NullValueHandling.Ignore)]
         internal Dictionary<string, string> stageCredentials { get; set; }
 

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -382,9 +382,6 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "stageInfo", NullValueHandling = NullValueHandling.Ignore)]
         internal PutGetStageInfo stageInfo { get; set; }
 
-        [JsonProperty(PropertyName = "isClientSideEncrypted", NullValueHandling = NullValueHandling.Ignore)]
-        internal bool isClientSideEncrypted { get; set; }
-
         [JsonProperty(PropertyName = "encryptionMaterial", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(SingleOrArrayConverter<PutGetEncryptionMaterial>))]
         internal List<PutGetEncryptionMaterial> encryptionMaterial { get; set; }


### PR DESCRIPTION
### Description
If an internal stage is created with SNOWLFAKE_SSE encryption, `encryptionMaterial` isn't returned from Snowflake.
We need to support empty `encryptionMaterial` when client side encryption is disabled and `isClientSideEncrypted` is false.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
