### PR TITLE
SNOW-1524245 Set initialisation vector length for Gcm encryption to 12 bytes

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/GcmEncryptionProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/GcmEncryptionProviderTest.cs
@@ -14,7 +14,7 @@ namespace Snowflake.Data.Tests.UnitTests
     {
         private const string PlainText = "there is no rose without thorns";
         private static readonly byte[] s_plainTextBytes = Encoding.UTF8.GetBytes(PlainText);
-        private static readonly byte[] s_qsmkBytes = TestDataGenarator.NextBytes(GcmEncryptionProvider.BlockSizeInBytes);
+        private static readonly byte[] s_qsmkBytes = TestDataGenarator.NextBytes(GcmEncryptionProvider.TagSizeInBytes);
         private static readonly string s_qsmk = Convert.ToBase64String(s_qsmkBytes);
         private static readonly string s_queryId = Guid.NewGuid().ToString();
         private const long SmkId = 1234L;

--- a/Snowflake.Data/Core/FileTransfer/GcmEncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/GcmEncryptionProvider.cs
@@ -10,8 +10,9 @@ namespace Snowflake.Data.Core.FileTransfer
 {
     internal class GcmEncryptionProvider
     {
-        private const int AesBlockSize = 128;
-        internal const int BlockSizeInBytes = AesBlockSize / 8;
+        private const int AesTagSizeInBits = 128;
+        internal const int TagSizeInBytes = AesTagSizeInBits / 8;
+        private const int InitVectorSizeInBytes = 12;
         private const string AesGcmNoPaddingCipher = "AES/GCM/NoPadding";
 
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<GcmEncryptionProvider>();
@@ -57,8 +58,8 @@ namespace Snowflake.Data.Core.FileTransfer
             int masterKeySize = decodedMasterKey.Length;
             s_logger.Debug($"Master key size : {masterKeySize}");
 
-            var contentIV = new byte[BlockSizeInBytes];
-            var keyIV = new byte[BlockSizeInBytes];
+            var contentIV = new byte[InitVectorSizeInBytes];
+            var keyIV = new byte[InitVectorSizeInBytes];
             var fileKeyBytes = new byte[masterKeySize]; // we choose a random fileKey to encrypt it with qsmk key with GCM
             s_random.NextBytes(contentIV);
             s_random.NextBytes(keyIV);
@@ -179,8 +180,8 @@ namespace Snowflake.Data.Core.FileTransfer
             var cipher = CipherUtilities.GetCipher(AesGcmNoPaddingCipher);
             KeyParameter keyParameter = new KeyParameter(keyBytes);
             var keyParameterAead = aadData == null
-                ? new AeadParameters(keyParameter, AesBlockSize, initialisationVector)
-                : new AeadParameters(keyParameter, AesBlockSize, initialisationVector, aadData);
+                ? new AeadParameters(keyParameter, AesTagSizeInBits, initialisationVector)
+                : new AeadParameters(keyParameter, AesTagSizeInBits, initialisationVector, aadData);
             cipher.Init(forEncryption, keyParameterAead);
             return cipher;
         }

--- a/Snowflake.Data/Core/FileTransfer/GcmEncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/GcmEncryptionProvider.cs
@@ -10,8 +10,8 @@ namespace Snowflake.Data.Core.FileTransfer
 {
     internal class GcmEncryptionProvider
     {
-        private const int AesTagSizeInBits = 128;
-        internal const int TagSizeInBytes = AesTagSizeInBits / 8;
+        private const int TagSizeInBits = 128;
+        internal const int TagSizeInBytes = TagSizeInBits / 8;
         private const int InitVectorSizeInBytes = 12;
         private const string AesGcmNoPaddingCipher = "AES/GCM/NoPadding";
 
@@ -180,8 +180,8 @@ namespace Snowflake.Data.Core.FileTransfer
             var cipher = CipherUtilities.GetCipher(AesGcmNoPaddingCipher);
             KeyParameter keyParameter = new KeyParameter(keyBytes);
             var keyParameterAead = aadData == null
-                ? new AeadParameters(keyParameter, AesTagSizeInBits, initialisationVector)
-                : new AeadParameters(keyParameter, AesTagSizeInBits, initialisationVector, aadData);
+                ? new AeadParameters(keyParameter, TagSizeInBits, initialisationVector)
+                : new AeadParameters(keyParameter, TagSizeInBits, initialisationVector, aadData);
             cipher.Init(forEncryption, keyParameterAead);
             return cipher;
         }


### PR DESCRIPTION
### Description
SNOW-1524245 Set initialisation vector length for Gcm encryption to 12 bytes

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
