### PR TITLE
SNOW-1569293 Read encryption headers in a case insensitive way

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -21,7 +21,7 @@ namespace Snowflake.Data.Tests.UnitTests
     using Azure;
     using Azure.Storage.Blobs.Models;
 
-    [TestFixture]
+    [TestFixture, NonParallelizable]
     class SFAzureClientTest : SFBaseTest
     {
         // Mock data for file metadata
@@ -376,6 +376,39 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.AreEqual(expectedResultStatus.ToString(), _fileMetadata.resultStatus);
+        }
+
+        [Test]
+        public void TestEncryptionMetadataReadingIsCaseInsensitive()
+        {
+            // arrange
+            var metadata = new Dictionary<string, string>
+            {
+                {
+                    "ENCRYPTIONDATA",
+                    @"{
+                        ""ContentEncryptionIV"": ""initVector"",
+                        ""WrappedContentKey"": {
+                            ""EncryptedKey"": ""key""
+                        }
+                    }"
+                },
+                { "MATDESC", "description" },
+                { "SFCDIGEST", "something"}
+            };
+            var blobProperties = BlobsModelFactory.BlobProperties(metadata: metadata, contentLength: 10);
+            var mockBlobServiceClient = new Mock<BlobServiceClient>();
+            _client = new SFSnowflakeAzureClient(_fileMetadata.stageInfo, mockBlobServiceClient.Object);
+
+            // act
+            var fileHeader = _client.HandleFileHeaderResponse(ref _fileMetadata, blobProperties);
+
+            // assert
+            Assert.AreEqual(ResultStatus.UPLOADED.ToString(), _fileMetadata.resultStatus);
+            Assert.AreEqual("something", fileHeader.digest);
+            Assert.AreEqual("initVector", fileHeader.encryptionMetadata.iv);
+            Assert.AreEqual("key", fileHeader.encryptionMetadata.key);
+            Assert.AreEqual("description", fileHeader.encryptionMetadata.matDesc);
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -3,21 +3,22 @@
  */
 
 using System;
+using NUnit.Framework;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.FileTransfer.StorageClient;
+using Snowflake.Data.Core.FileTransfer;
+using System.Collections.Generic;
+using System.Net;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+using Snowflake.Data.Tests.Mock;
+using Moq;
 
 namespace Snowflake.Data.Tests.UnitTests
 {
-    using NUnit.Framework;
-    using Snowflake.Data.Core;
-    using Snowflake.Data.Core.FileTransfer.StorageClient;
-    using Snowflake.Data.Core.FileTransfer;
-    using System.Collections.Generic;
-    using System.Net;
-    using System.IO;
-    using System.Threading.Tasks;
-    using System.Threading;
-    using Snowflake.Data.Tests.Mock;
-    using Moq;
-
     [TestFixture, NonParallelizable]
     class SFGCSClientTest : SFBaseTest
     {
@@ -369,6 +370,44 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // assert
             Assert.AreEqual(expectedRequestUri, uri);
+        }
+
+        [Test]
+        [TestCase("some-header-name", "SOME-HEADER-NAME")]
+        [TestCase("SOME-HEADER-NAME", "some-header-name")]
+        public void TestGcsHeadersAreCaseInsensitiveForHttpResponseMessage(string headerNameToAdd, string headerNameToGet)
+        {
+            // arrange
+            const string HeaderValue = "someValue";
+            var responseMessage = new HttpResponseMessage( HttpStatusCode.OK ) {Content =  new StringContent( "Response content" ) };
+            responseMessage.Headers.Add(headerNameToAdd, HeaderValue);
+
+            // act
+            var header = responseMessage.Headers.GetValues(headerNameToGet);
+
+            // assert
+            Assert.NotNull(header);
+            Assert.AreEqual(1, header.Count());
+            Assert.AreEqual(HeaderValue, header.First());
+        }
+
+        [Test]
+        [TestCase("some-header-name", "SOME-HEADER-NAME")]
+        [TestCase("SOME-HEADER-NAME", "some-header-name")]
+        public void TestGcsHeadersAreCaseInsensitiveForWebHeaderCollection(string headerNameToAdd, string headerNameToGet)
+        {
+            // arrange
+            const string HeaderValue = "someValue";
+            var headers = new WebHeaderCollection();
+            headers.Add(headerNameToAdd, HeaderValue);
+
+            // act
+            var header = headers.GetValues(headerNameToGet);
+
+            // assert
+            Assert.NotNull(header);
+            Assert.AreEqual(1, header.Count());
+            Assert.AreEqual(HeaderValue, header.First());
         }
 
         private void AssertForDownloadFileTests(ResultStatus expectedResultStatus)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -9,6 +9,7 @@ using Amazon.S3.Model;
 using Snowflake.Data.Log;
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -266,24 +267,36 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <param name="fileMetadata">The S3 file metadata.</param>
         /// <param name="response">The Amazon S3 response.</param>
         /// <returns>The file header of the S3 file.</returns>
-        private FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, GetObjectResponse response)
+        internal FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, GetObjectResponse response)
         {
             // Update the result status of the file metadata
             fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
 
             SFEncryptionMetadata encryptionMetadata = new SFEncryptionMetadata
             {
-                iv = response.Metadata[AMZ_IV],
-                key = response.Metadata[AMZ_KEY],
-                matDesc = response.Metadata[AMZ_MATDESC]
+                iv = GetMetadataCaseInsensitive(response.Metadata, AMZ_IV),
+                key = GetMetadataCaseInsensitive(response.Metadata, AMZ_KEY),
+                matDesc = GetMetadataCaseInsensitive(response.Metadata, AMZ_MATDESC)
             };
 
             return new FileHeader
             {
-                digest = response.Metadata[SFC_DIGEST],
+                digest = GetMetadataCaseInsensitive(response.Metadata, SFC_DIGEST),
                 contentLength = response.ContentLength,
                 encryptionMetadata = encryptionMetadata
             };
+        }
+
+        private string GetMetadataCaseInsensitive(MetadataCollection metadataCollection, string metadataKey)
+        {
+            var value = metadataCollection[metadataKey];
+            if (value != null)
+                return value;
+            if (string.IsNullOrEmpty(metadataKey))
+                return null;
+            var keysCaseInsensitive = metadataCollection.Keys
+                .Where(key => $"x-amz-meta-{metadataKey}".Equals(key, StringComparison.OrdinalIgnoreCase));
+            return keysCaseInsensitive.Any() ? metadataCollection[keysCaseInsensitive.First()] : null;
         }
 
         /// <summary>

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -7,6 +7,7 @@ using Snowflake.Data.Log;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Azure;
 using Azure.Storage.Blobs.Models;
 using Newtonsoft.Json;
@@ -154,28 +155,46 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <param name="fileMetadata">The S3 file metadata.</param>
         /// <param name="response">The Amazon S3 response.</param>
         /// <returns>The file header of the S3 file.</returns>
-        private FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, BlobProperties response)
+        internal FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, BlobProperties response)
         {
             fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
 
             SFEncryptionMetadata encryptionMetadata = null;
-            if (response.Metadata.TryGetValue("encryptiondata", out var encryptionDataStr))
+            if (TryGetMetadataValueCaseInsensitive(response, "encryptiondata", out var encryptionDataStr))
             {
                 dynamic encryptionData = JsonConvert.DeserializeObject(encryptionDataStr);
                 encryptionMetadata = new SFEncryptionMetadata
                 {
                     iv = encryptionData["ContentEncryptionIV"],
                     key = encryptionData.WrappedContentKey["EncryptedKey"],
-                    matDesc = response.Metadata["matdesc"]
+                    matDesc = GetMetadataValueCaseInsensitive(response, "matdesc")
                 };
             }
 
             return new FileHeader
             {
-                digest = response.Metadata["sfcdigest"],
+                digest = GetMetadataValueCaseInsensitive(response, "sfcdigest"),
                 contentLength = response.ContentLength,
                 encryptionMetadata = encryptionMetadata
             };
+        }
+
+        private bool TryGetMetadataValueCaseInsensitive(BlobProperties properties, string metadataKey, out string metadataValue)
+        {
+            if (properties.Metadata.TryGetValue(metadataKey, out metadataValue))
+                return true;
+            if (string.IsNullOrEmpty(metadataKey))
+                return false;
+            var keysCaseInsensitive = properties.Metadata.Keys
+                .Where(key => metadataKey.Equals(key, StringComparison.OrdinalIgnoreCase));
+            return keysCaseInsensitive.Any() ? properties.Metadata.TryGetValue(keysCaseInsensitive.First(), out metadataValue) : false;
+        }
+
+        private string GetMetadataValueCaseInsensitive(BlobProperties properties, string metadataKey)
+        {
+            if (TryGetMetadataValueCaseInsensitive(properties, metadataKey, out var metadataValue))
+                return metadataValue;
+            throw new KeyNotFoundException($"The given key '{metadataKey}' was not present in the dictionary.");
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
SNOW-1569293 Read encryption headers in a case insensitive way

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
