### PR TITLE
SNOW-1887537 Get file without SFC_DIGEST

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -410,5 +410,37 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.AreEqual("key", fileHeader.encryptionMetadata.key);
             Assert.AreEqual("description", fileHeader.encryptionMetadata.matDesc);
         }
+
+        [Test]
+        public void TestEncryptionMetadataReadingSucceedsWithoutSfcDigest()
+        {
+            // arrange
+            var metadata = new Dictionary<string, string>
+            {
+                {
+                    "encryptiondata",
+                    @"{
+                        ""ContentEncryptionIV"": ""initVector"",
+                        ""WrappedContentKey"": {
+                            ""EncryptedKey"": ""key""
+                        }
+                    }"
+                },
+                { "matdesc", "description" }
+            };
+            var blobProperties = BlobsModelFactory.BlobProperties(metadata: metadata, contentLength: 10);
+            var mockBlobServiceClient = new Mock<BlobServiceClient>();
+            _client = new SFSnowflakeAzureClient(_fileMetadata.stageInfo, mockBlobServiceClient.Object);
+
+            // act
+            var fileHeader = _client.HandleFileHeaderResponse(ref _fileMetadata, blobProperties);
+
+            // assert
+            Assert.AreEqual(ResultStatus.UPLOADED.ToString(), _fileMetadata.resultStatus);
+            Assert.IsNull(fileHeader.digest);
+            Assert.AreEqual("initVector", fileHeader.encryptionMetadata.iv);
+            Assert.AreEqual("key", fileHeader.encryptionMetadata.key);
+            Assert.AreEqual("description", fileHeader.encryptionMetadata.matDesc);
+        }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -444,7 +444,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
-        public void TestEncryptionMetadataReadingFailsWhenNoMandatoryProperty()
+        public void TestEncryptionMetadataReadingFailsWhenMandatoryPropertyIsMissing()
         {
             // arrange
             var metadataWithoutMatDesc = new Dictionary<string, string>

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -410,6 +410,27 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.AreEqual(HeaderValue, header.First());
         }
 
+        [Test]
+        public void TestHandleGetFileHeaderResponseWithoutSfcDigest()
+        {
+            // arrange
+            var headers = new WebHeaderCollection();
+            headers.Add("content-length", "123");
+            var stageInfo = new PutGetStageInfo() { stageCredentials = new Dictionary<string, string>() };
+            var client = new SFGCSClient(stageInfo);
+            var response = new Mock<HttpWebResponse>();
+            response.Setup(r => r.Headers).Returns(headers);
+            var fileMetadata = new SFFileMetadata();
+
+            // act
+            var fileHeader = client.handleGetFileHeaderResponse(response.Object, fileMetadata);
+
+            // assert
+            Assert.AreEqual(ResultStatus.UPLOADED.ToString(), fileMetadata.resultStatus);
+            Assert.IsNull(fileHeader.digest);
+            Assert.AreEqual(123, fileHeader.contentLength);
+        }
+
         private void AssertForDownloadFileTests(ResultStatus expectedResultStatus)
         {
             if (expectedResultStatus == ResultStatus.DOWNLOADED)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
@@ -168,16 +168,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
                 using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
                 {
-                    var digest = response.Headers.GetValues(GCS_METADATA_SFC_DIGEST);
-                    var contentLength = response.Headers.GetValues("content-length");
-
-                    fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
-
-                    return new FileHeader
-                    {
-                        digest = digest[0],
-                        contentLength = Convert.ToInt64(contentLength[0])
-                    };
+                    return handleGetFileHeaderResponse(response, fileMetadata);
                 }
             }
             catch (WebException ex)
@@ -217,16 +208,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
                 using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync().ConfigureAwait(false))
                 {
-                    var digest = response.Headers.GetValues(GCS_METADATA_SFC_DIGEST);
-                    var contentLength = response.Headers.GetValues("content-length");
-
-                    fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
-
-                    return new FileHeader
-                    {
-                        digest = digest[0],
-                        contentLength = Convert.ToInt64(contentLength[0])
-                    };
+                    return handleGetFileHeaderResponse(response, fileMetadata);
                 }
             }
             catch (WebException ex)
@@ -238,6 +220,20 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             }
 
             return null;
+        }
+
+        internal FileHeader handleGetFileHeaderResponse(HttpWebResponse response, SFFileMetadata fileMetadata)
+        {
+            var digest = response.Headers.GetValues(GCS_METADATA_SFC_DIGEST);
+            var contentLength = response.Headers.GetValues("content-length");
+
+            fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
+
+            return new FileHeader
+            {
+                digest = digest?[0],
+                contentLength = Convert.ToInt64(contentLength[0])
+            };
         }
 
         internal string generateFileURL(PutGetStageInfo stageInfo, string fileName)

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -173,7 +173,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
             return new FileHeader
             {
-                digest = GetMetadataValueCaseInsensitive(response, "sfcdigest"),
+                digest = GetMetadataValueCaseInsensitive(response, "sfcdigest", false),
                 contentLength = response.ContentLength,
                 encryptionMetadata = encryptionMetadata
             };
@@ -190,11 +190,15 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             return keysCaseInsensitive.Any() ? properties.Metadata.TryGetValue(keysCaseInsensitive.First(), out metadataValue) : false;
         }
 
-        private string GetMetadataValueCaseInsensitive(BlobProperties properties, string metadataKey)
+        private string GetMetadataValueCaseInsensitive(BlobProperties properties, string metadataKey, bool failIfNotFound = true)
         {
             if (TryGetMetadataValueCaseInsensitive(properties, metadataKey, out var metadataValue))
                 return metadataValue;
-            throw new KeyNotFoundException($"The given key '{metadataKey}' was not present in the dictionary.");
+            if (failIfNotFound)
+            {
+                throw new KeyNotFoundException($"The given key '{metadataKey}' was not present in the dictionary.");
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
SNOW-1887537 Get file without SFC_DIGEST

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
