### PR TITLE
Fix: Removing the self-invoking call from KeyPairAuthenticator.SetSpecializedAuthenticatorData method

### DIFF
--- a/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
@@ -75,6 +75,7 @@ namespace Snowflake.Data.Core.Authenticator
         {
             // Add the token to the Data attribute
             data.Token = jwtToken;
+            SetSecondaryAuthenticationData(ref data);
         }
 
         /// <summary>

--- a/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
  */
 
@@ -75,7 +75,6 @@ namespace Snowflake.Data.Core.Authenticator
         {
             // Add the token to the Data attribute
             data.Token = jwtToken;
-            SetSpecializedAuthenticatorData(ref data);
         }
 
         /// <summary>


### PR DESCRIPTION
The SetSpecializedAuthenticatorData method override, implemented in KeyPairAuthenticator, has a self-invoking call in the second line of the method's body. This results in the connectors hanging up anytime when KeyPairAuthenticator is configured to be used for authentication.

A new method, SetSecondaryAuthenticationData, was introduced in the previous commitment "SNOW-715504: MFA token cache support (#988)" by Juan Martinez Ramires. This method is probably meant to be called from SetSpecializedAuthenticatorData implementation instead of using a self-invoking call by mistake. I suggest changing the called method name from  SetSpecializedAuthenticatorData to SetSecondaryAuthenticationData.

