### PR TITLE
Fix ConstraintException when calling DataTable.Load

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
@@ -415,7 +415,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             row = dataTable.Rows[2];
             Assert.AreEqual(s_colName[2], row[SchemaTableColumn.ColumnName]);
             Assert.AreEqual(2, row[SchemaTableColumn.ColumnOrdinal]);
-            Assert.AreEqual(0, row[SchemaTableColumn.ColumnSize]);
+            Assert.AreEqual(-1, row[SchemaTableColumn.ColumnSize]);
             Assert.AreEqual(SFDataType.FIXED, (SFDataType)row[SchemaTableColumn.ProviderType]);
         }
 

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -122,7 +122,7 @@ namespace Snowflake.Data.Client
 
                 row[SchemaTableColumn.ColumnName] = rowType.name;
                 row[SchemaTableColumn.ColumnOrdinal] = columnOrdinal;
-                row[SchemaTableColumn.ColumnSize] = (int)rowType.length;
+                row[SchemaTableColumn.ColumnSize] = rowType.length == 0 ? -1 : (int)rowType.length;
                 row[SchemaTableColumn.NumericPrecision] = (int)rowType.precision;
                 row[SchemaTableColumn.NumericScale] = (int)rowType.scale;
                 row[SchemaTableColumn.AllowDBNull] = rowType.nullable;


### PR DESCRIPTION
### Description
Fix the `System.Data.ConstraintException` error that occurs when querying a VARIANT column with `DataTable.Load`

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
