### PR TITLE
SNOW-1952746: Rename wiremock property names

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Tools/WiremockRunnerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/WiremockRunnerTest.cs
@@ -43,7 +43,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             _runner.AddMappings("wiremock/test_mapping.json");
 
             //act
-            var response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseUrl + "/test")).Result;
+            var response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test")).Result;
 
             // assert
             Assert.True(response.IsSuccessStatusCode);
@@ -54,12 +54,12 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         {
             // arrange
             _runner.AddMappings("wiremock/test_mapping.json");
-            var response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseUrl + "/test")).Result;
+            var response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test")).Result;
             Assert.True(response.IsSuccessStatusCode);
 
             // act
             _runner.ResetMapping();
-            response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseAdminUrl + "/__admin/mappings")).Result;
+            response = Task.Run(async() => await _httpClient.GetAsync(_runner.WiremockBaseHttpUrl + "/__admin/mappings")).Result;
 
             // assert
             Assert.True(response.IsSuccessStatusCode);

--- a/Snowflake.Data.Tests/Util/WiremockRunner.cs
+++ b/Snowflake.Data.Tests/Util/WiremockRunner.cs
@@ -27,13 +27,7 @@ namespace Snowflake.Data.Tests.Util
                                                            "--ca-keystore ./wiremock/ca-cert.jks";
         private static readonly string s_wiremockUrl =
             $"https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/{WiremockVersion}/wiremock-standalone-{WiremockVersion}.jar";
-        private static readonly HttpClient s_httpClient = new(
-                new HttpClientHandler
-                {
-                    ClientCertificateOptions = ClientCertificateOption.Manual,
-                    ServerCertificateCustomValidationCallback = (_, _, _, _) => true
-                }
-            );
+        private static readonly HttpClient s_httpClient = new();
         private static readonly object s_lock = new ();
 
         private static string Host => "127.0.0.1";


### PR DESCRIPTION
### Description
Rename wiremock port property names and URLs.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
