### PR TITLE
Allow SFDataConverter to convert from AnsiString to TEXT

### DIFF
--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -270,6 +270,7 @@ namespace Snowflake.Data.Core
                     break;
 
                 case DbType.Guid:
+                case DbType.AnsiString:
                 case DbType.String:
                 case DbType.StringFixedLength:
                     destType = SFDataType.TEXT;


### PR DESCRIPTION
The following error is observed when trying to insert or update a TEXT column with a DbParameter of type AnsiString whose value is DBNull. "No corresponding Snowflake type for type AnsiString."

To reproduce this with the Dapper ORM library, set Dapper to use DbType.AnsiString for .NET strings with this "SqlMapper.AddTypeMap(typeof(string), System.Data.DbType.AnsiString);". Try to insert or update a TEXT column with a null value for a string and the exception will be thrown. Alternatively, without Dapper, create a SnowflakeDbParameter and set the DbType to AnsiString and the Value to DBNull.Value.

Using AnsiString with an actual value works because the DbType property in SnowflakeDbParameter knows there is a value, calls GetType(), which returns System.String, and then uses the TypeToDbTypeMap which maps to DbType.String.

When the value is DBNull the DbType property checks for DBNull and simply returns DbType.AnsiString. CSharpTypeValToSfTypeVal() then throws the exception due to the AnsiString type not being in the switch statement.