### PR TITLE
SNOW-1915375: Drop copyright header in comments

### DIFF
--- a/Snowflake.Data.Tests/App.config
+++ b/Snowflake.Data.Tests/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />

--- a/Snowflake.Data.Tests/App.config
+++ b/Snowflake.Data.Tests/App.config
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<!--
-Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
--->
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.Threading;

--- a/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -1,6 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
 #nullable enable
 
 using System;

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.IO;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.IntegrationTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Data;
 using System.Data.Common;
 using System;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderGetEnumeratorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderGetEnumeratorIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Linq;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Linq;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.IntegrationTests
 {
     using System.Data;

--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.IntegrationTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Client;
 using System.Data.Common;

--- a/Snowflake.Data.Tests/Mock/MockAzureClient.cs
+++ b/Snowflake.Data.Tests/Mock/MockAzureClient.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Azure;
 using Azure.Storage.Blobs.Models;
 using System.Collections.Generic;

--- a/Snowflake.Data.Tests/Mock/MockCloseSessionException.cs
+++ b/Snowflake.Data.Tests/Mock/MockCloseSessionException.cs
@@ -1,6 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
 using System.Collections.Generic;
 
 namespace Snowflake.Data.Tests.Mock

--- a/Snowflake.Data.Tests/Mock/MockCloseSessionGone.cs
+++ b/Snowflake.Data.Tests/Mock/MockCloseSessionGone.cs
@@ -1,6 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
 using System.Collections.Generic;
 
 namespace Snowflake.Data.Tests.Mock

--- a/Snowflake.Data.Tests/Mock/MockGCSClient.cs
+++ b/Snowflake.Data.Tests/Mock/MockGCSClient.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Moq;
 using Snowflake.Data.Core.FileTransfer.StorageClient;
 using System.IO;

--- a/Snowflake.Data.Tests/Mock/MockOkta.cs
+++ b/Snowflake.Data.Tests/Mock/MockOkta.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.Authenticator;
 using System.Net.Http;

--- a/Snowflake.Data.Tests/Mock/MockRemoteStorageClient.cs
+++ b/Snowflake.Data.Tests/Mock/MockRemoteStorageClient.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Moq;
 using Snowflake.Data.Core.FileTransfer.StorageClient;
 using System;

--- a/Snowflake.Data.Tests/Mock/MockRestSessionExpired.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestSessionExpired.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Snowflake.Data.Tests/Mock/MockRestSessionExpiredInQueryExec.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestSessionExpiredInQueryExec.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
+++ b/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Newtonsoft.Json;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/Mock/MockS3Client.cs
+++ b/Snowflake.Data.Tests/Mock/MockS3Client.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Amazon.S3;
 using Amazon.S3.Model;
 using Snowflake.Data.Core.FileTransfer.StorageClient;

--- a/Snowflake.Data.Tests/Mock/MockSecretDetector.cs
+++ b/Snowflake.Data.Tests/Mock/MockSecretDetector.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Snowflake.Data.Log;
 

--- a/Snowflake.Data.Tests/Mock/MockServiceName.cs
+++ b/Snowflake.Data.Tests/Mock/MockServiceName.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data.Tests/Mock/MockSnowflakeDbConnection.cs
+++ b/Snowflake.Data.Tests/Mock/MockSnowflakeDbConnection.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
 using Snowflake.Data.Log;

--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/Snowflake.Data.Tests/UnitTests/ArrowChunkParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowChunkParserTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Linq;
 using Apache.Arrow;
 using Apache.Arrow.Ipc;

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Snowflake.Data.Tests/UnitTests/ChunkDownloaderFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ChunkDownloaderFactoryTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/ChunkParserFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ChunkParserFactoryTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/ConcatenatedStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConcatenatedStreamTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Tests.Util;
 using NUnit.Framework;
 using System;

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigFinderTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigGenerator.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigGenerator.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 
 namespace Snowflake.Data.Tests.UnitTests.Configuration

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigProviderTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Moq;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingLogLevelTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingLogLevelTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Configuration;

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 
 
 namespace Snowflake.Data.Tests.UnitTests

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Security;
 using System.Threading;

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Client;
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileImplTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileImplTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Security;

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileStorageTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileStorageTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerInMemoryImplTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerInMemoryImplTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Core.CredentialManager.Infrastructure;
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerWindowsNativeImplTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerWindowsNativeImplTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Core.CredentialManager.Infrastructure;
 

--- a/Snowflake.Data.Tests/UnitTests/FastMemoryStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FastMemoryStreamTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FastParserTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/FileBackedOutputStreamTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/FileBackedOutputStreamTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using System.Text;
 using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Net.Http;
 
 namespace Snowflake.Data.Tests.UnitTests

--- a/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Linq;

--- a/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggingStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggingStarterTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Configuration;
 
 namespace Snowflake.Data.Tests.UnitTests

--- a/Snowflake.Data.Tests/UnitTests/Logger/UnixFilePermissionsConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/UnixFilePermissionsConverterTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Mono.Unix;
 using NUnit.Framework;
 using Snowflake.Data.Log;

--- a/Snowflake.Data.Tests/UnitTests/PutGetStageInfoTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/PutGetStageInfoTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using NUnit.Framework;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using Newtonsoft.Json;

--- a/Snowflake.Data.Tests/UnitTests/SFAuthenticatorFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAuthenticatorFactoryTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFAzureClientTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Tests.UnitTests

--- a/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFBindUploaderTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Text;
 using Snowflake.Data.Client;

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Client;
 using Snowflake.Data.Tests.Util;
 

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Tests.UnitTests

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using NUnit.Framework;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using Snowflake.Data.Core;
 using System.Security;

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Newtonsoft.Json;
 using Snowflake.Data.Core;
 using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Threading;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2019 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Tests.UnitTests
 {
     using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using NUnit.Framework;
 using Snowflake.Data.Log;
 using Snowflake.Data.Tests.Mock;

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientProxyPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientProxyPropertiesTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using NUnit.Framework;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeTomlConnectionBuilderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeTomlConnectionBuilderTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Mono.Unix;
 using Snowflake.Data.Client;
 

--- a/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using Mono.Unix;
 using NUnit.Framework;

--- a/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsTest.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.IO;
 using System.Security;

--- a/Snowflake.Data.Tests/Util/ConcatenatedStream.cs
+++ b/Snowflake.Data.Tests/Util/ConcatenatedStream.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Snowflake.Data.Tests/Util/PoolConfig.cs
+++ b/Snowflake.Data.Tests/Util/PoolConfig.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.Session;

--- a/Snowflake.Data.Tests/Util/RandomJsonGenerator.cs
+++ b/Snowflake.Data.Tests/Util/RandomJsonGenerator.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using System.Text;
 using Snowflake.Data.Tests.Util;

--- a/Snowflake.Data.Tests/Util/SessionParameterAlterer.cs
+++ b/Snowflake.Data.Tests/Util/SessionParameterAlterer.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Data;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;

--- a/Snowflake.Data.Tests/Util/TestDataGenarator.cs
+++ b/Snowflake.Data.Tests/Util/TestDataGenarator.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Linq;
 

--- a/Snowflake.Data/Client/ISnowflakeCredentialManager.cs
+++ b/Snowflake.Data/Client/ISnowflakeCredentialManager.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Client
 {
     public interface ISnowflakeCredentialManager

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Runtime.InteropServices;
 using Snowflake.Data.Core;

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Snowflake.Data.Core;
 using System.Data.Common;

--- a/Snowflake.Data/Client/SnowflakeDbCommandBuilder.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommandBuilder.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Data;
 using System.Data.Common;
 using System.Globalization;

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Security;
 using System.Threading;

--- a/Snowflake.Data/Client/SnowflakeDbConnectionStringBuilder.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionStringBuilder.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Data.Common;

--- a/Snowflake.Data/Client/SnowflakeDbDataAdapter.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataAdapter.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data.Common;
 using Snowflake.Data.Core;

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data.Common;
 using System.Collections;

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data.Common;
 using System.Resources;

--- a/Snowflake.Data/Client/SnowflakeDbFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeDbFactory.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Data.Common;
 
 namespace Snowflake.Data.Client

--- a/Snowflake.Data/Client/SnowflakeDbParameter.cs
+++ b/Snowflake.Data/Client/SnowflakeDbParameter.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Data.Common;
 using System;
 using System.Data;

--- a/Snowflake.Data/Client/SnowflakeDbParameterCollection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbParameterCollection.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Data.Common;

--- a/Snowflake.Data/Client/SnowflakeDbSessionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbSessionPool.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Snowflake.Data.Core.Session;
 

--- a/Snowflake.Data/Client/SnowflakeDbTransaction.cs
+++ b/Snowflake.Data/Client/SnowflakeDbTransaction.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Data;
 using System.Data.Common;

--- a/Snowflake.Data/Configuration/ClientConfig.cs
+++ b/Snowflake.Data/Configuration/ClientConfig.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Newtonsoft.Json;
 
 namespace Snowflake.Data.Configuration

--- a/Snowflake.Data/Configuration/ClientConfigCommonProps.cs
+++ b/Snowflake.Data/Configuration/ClientConfigCommonProps.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using Newtonsoft.Json;
 
 namespace Snowflake.Data.Configuration

--- a/Snowflake.Data/Configuration/EasyLoggingConfigFinder.cs
+++ b/Snowflake.Data/Configuration/EasyLoggingConfigFinder.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data/Configuration/EasyLoggingConfigParser.cs
+++ b/Snowflake.Data/Configuration/EasyLoggingConfigParser.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Snowflake.Data/Configuration/EasyLoggingConfigProvider.cs
+++ b/Snowflake.Data/Configuration/EasyLoggingConfigProvider.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Configuration
 {
     internal class EasyLoggingConfigProvider

--- a/Snowflake.Data/Configuration/EasyLoggingLogLevel.cs
+++ b/Snowflake.Data/Configuration/EasyLoggingLogLevel.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Configuration

--- a/Snowflake.Data/Configuration/SFConfiguration.cs
+++ b/Snowflake.Data/Configuration/SFConfiguration.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Configuration

--- a/Snowflake.Data/Configuration/SFConfigurationSectionHandler.cs
+++ b/Snowflake.Data/Configuration/SFConfigurationSectionHandler.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections;
 using System.Configuration;
 using System.Xml;

--- a/Snowflake.Data/Core/ArrowChunkParser.cs
+++ b/Snowflake.Data/Core/ArrowChunkParser.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Snowflake.Data/Core/ArrowResultChunk.cs
+++ b/Snowflake.Data/Core/ArrowResultChunk.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Snowflake.Data/Core/ArrowResultSet.cs
+++ b/Snowflake.Data/Core/ArrowResultSet.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Text;

--- a/Snowflake.Data/Core/Authenticator/BasicAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/BasicAuthenticator.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Log;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Diagnostics;
 using System.Net;

--- a/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/KeyPairAuthenticator.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Snowflake.Data/Core/Authenticator/MFACacheAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/MFACacheAuthenticator.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/Authenticator/OktaAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/OktaAuthenticator.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Newtonsoft.Json;
 using System.Net.Http;

--- a/Snowflake.Data/Core/BaseResultChunk.cs
+++ b/Snowflake.Data/Core/BaseResultChunk.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Core

--- a/Snowflake.Data/Core/ChunkDownloaderFactory.cs
+++ b/Snowflake.Data/Core/ChunkDownloaderFactory.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Threading;
 using Snowflake.Data.Configuration;

--- a/Snowflake.Data/Core/ChunkParserFactory.cs
+++ b/Snowflake.Data/Core/ChunkParserFactory.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using Snowflake.Data.Configuration;

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Mono.Unix;
 using Newtonsoft.Json;
 using Snowflake.Data.Client;

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileStorage.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileStorage.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using Snowflake.Data.Core.Tools;

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerInMemoryImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerInMemoryImpl.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Collections.Generic;
 using System.Security;
 using System.Threading;

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data/Core/CredentialManager/TokenType.cs
+++ b/Snowflake.Data/Core/CredentialManager/TokenType.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Core.CredentialManager
 {
     internal enum TokenType

--- a/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
+++ b/Snowflake.Data/Core/FileTransfer/EncryptionProvider.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using System;
 using Snowflake.Data.Log;

--- a/Snowflake.Data/Core/FileTransfer/FileBackedOutputStream.cs
+++ b/Snowflake.Data/Core/FileTransfer/FileBackedOutputStream.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 

--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Client;
 using System;
 using System.Collections.Generic;

--- a/Snowflake.Data/Core/FileTransfer/SFFileMetadata.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileMetadata.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using static Snowflake.Data.Core.FileTransfer.SFFileCompressionTypes;

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Client;
 using Snowflake.Data.Core.FileTransfer;
 using Snowflake.Data.Log;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/ISFRemoteStorageClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/ISFRemoteStorageClient.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Threading;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Threading;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFLocalStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFLocalStorageUtil.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using Snowflake.Data.Core.Tools;
 

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFRemoteStorageUtil.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Core.FileTransfer.StorageClient;
 using System;
 using System.IO;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFSnowflakeAzureClient.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Azure.Storage.Blobs;
 using Snowflake.Data.Log;
 using System;

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.Net;

--- a/Snowflake.Data/Core/IChunkDownloader.cs
+++ b/Snowflake.Data/Core/IChunkDownloader.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core

--- a/Snowflake.Data/Core/IChunkParser.cs
+++ b/Snowflake.Data/Core/IChunkParser.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Threading.Tasks;
 
 namespace Snowflake.Data.Core

--- a/Snowflake.Data/Core/IResultChunk.cs
+++ b/Snowflake.Data/Core/IResultChunk.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 
 namespace Snowflake.Data.Core

--- a/Snowflake.Data/Core/JsonUtils.cs
+++ b/Snowflake.Data/Core/JsonUtils.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/Snowflake.Data/Core/ParameterBinding.cs
+++ b/Snowflake.Data/Core/ParameterBinding.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/QueryResultsAwaiter.cs
+++ b/Snowflake.Data/Core/QueryResultsAwaiter.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Log;
 using System.Threading.Tasks;
 using System.Threading;

--- a/Snowflake.Data/Core/RestRequest.cs
+++ b/Snowflake.Data/Core/RestRequest.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System;

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Newtonsoft.Json;
 using System.Net.Http;

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/ReusableChunkParser.cs
+++ b/Snowflake.Data/Core/ReusableChunkParser.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Text;
 using System.Threading;

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO.Compression;
 using System.IO;

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/Snowflake.Data/Core/SFError.cs
+++ b/Snowflake.Data/Core/SFError.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/SFMultiStatementsResultSet.cs
+++ b/Snowflake.Data/Core/SFMultiStatementsResultSet.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/SFResultChunk.cs
+++ b/Snowflake.Data/Core/SFResultChunk.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Text;
 

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/SFResultSetMetaData.cs
+++ b/Snowflake.Data/Core/SFResultSetMetaData.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/Snowflake.Data/Core/SFReusableChunk.cs
+++ b/Snowflake.Data/Core/SFReusableChunk.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Snowflake.Data/Core/Session/ChangedSessionBehavior.cs
+++ b/Snowflake.Data/Core/Session/ChangedSessionBehavior.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Core.Session
 {
     /**

--- a/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/Session/EasyLoggingStarter.cs
+++ b/Snowflake.Data/Core/Session/EasyLoggingStarter.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data/Core/Session/IConnectionManager.cs
+++ b/Snowflake.Data/Core/Session/IConnectionManager.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/Session/SFSessionParameter.cs
+++ b/Snowflake.Data/Core/Session/SFSessionParameter.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 namespace Snowflake.Data.Core
 {
     internal enum SFSessionParameter

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Snowflake.Data/Core/TomlConnectionBuilder.cs
+++ b/Snowflake.Data/Core/TomlConnectionBuilder.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Snowflake.Data/Core/Tools/DirectoryInformation.cs
+++ b/Snowflake.Data/Core/Tools/DirectoryInformation.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 

--- a/Snowflake.Data/Core/Tools/DirectoryOperations.cs
+++ b/Snowflake.Data/Core/Tools/DirectoryOperations.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System.IO;
 using System.Runtime.InteropServices;
 using Mono.Unix;

--- a/Snowflake.Data/Core/Tools/DirectoryUnixInformation.cs
+++ b/Snowflake.Data/Core/Tools/DirectoryUnixInformation.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Mono.Unix;
 using Snowflake.Data.Log;
 

--- a/Snowflake.Data/Core/Tools/EnvironmentOperations.cs
+++ b/Snowflake.Data/Core/Tools/EnvironmentOperations.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using Snowflake.Data.Log;

--- a/Snowflake.Data/Core/Tools/FileOperations.cs
+++ b/Snowflake.Data/Core/Tools/FileOperations.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/Snowflake.Data/Core/Tools/HomeDirectoryProvider.cs
+++ b/Snowflake.Data/Core/Tools/HomeDirectoryProvider.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using Snowflake.Data.Log;
 using System;
 

--- a/Snowflake.Data/Core/Tools/StringUtils.cs
+++ b/Snowflake.Data/Core/Tools/StringUtils.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Security.Cryptography;
 

--- a/Snowflake.Data/Core/Tools/UnixOperations.cs
+++ b/Snowflake.Data/Core/Tools/UnixOperations.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 

--- a/Snowflake.Data/Logger/EasyLoggerManager.cs
+++ b/Snowflake.Data/Logger/EasyLoggerManager.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.IO;
 using System.Linq;

--- a/Snowflake.Data/Logger/EasyLoggingLevelMapper.cs
+++ b/Snowflake.Data/Logger/EasyLoggingLevelMapper.cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using log4net.Core;
 using Snowflake.Data.Configuration;

--- a/Snowflake.Data/Logger/Log4netImpl.cs
+++ b/Snowflake.Data/Logger/Log4netImpl.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using log4net;
 using System;
 

--- a/Snowflake.Data/Logger/SFLogger.cs
+++ b/Snowflake.Data/Logger/SFLogger.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Snowflake.Data/Logger/SFLoggerEmptyImpl.cs
+++ b/Snowflake.Data/Logger/SFLoggerEmptyImpl.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
- 
  using System;
 
 namespace Snowflake.Data.Log

--- a/Snowflake.Data/Logger/SFLoggerFactory.cs
+++ b/Snowflake.Data/Logger/SFLoggerFactory.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 using log4net;
 
 namespace Snowflake.Data.Log

--- a/Snowflake.Data/Logger/SecretDetector.cs
+++ b/Snowflake.Data/Logger/SecretDetector.cs
@@ -1,7 +1,3 @@
-﻿/*
- * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/Snowflake.Data/Logger/UnixFilePermissionsConverter .cs
+++ b/Snowflake.Data/Logger/UnixFilePermissionsConverter .cs
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
- */
-
 using System;
 using Mono.Unix;
 


### PR DESCRIPTION
### Description
Drop copyright header in comments from Snowflake repositories

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
