### PR TITLE
SNOW-1989063: Fix reading tokens in Windows Credential Manager implementation

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
@@ -105,5 +105,19 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
             // assert
             Assert.IsTrue(string.IsNullOrEmpty(_credentialManager.GetCredentials(key)));
         }
+
+        [Test]
+        public void TestGetCredentialsForCredentialsThatDoesNotExist()
+        {
+            // arrange
+            var key = "fakeKey";
+
+            // act
+            _credentialManager.RemoveCredentials(key);
+            var token = _credentialManager.GetCredentials(key);
+
+            // assert
+            Assert.IsTrue(string.IsNullOrEmpty(token));
+        }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFBaseCredentialManagerTest.cs
@@ -85,5 +85,25 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
             // assert
             Assert.AreEqual(token, result);
         }
+
+        [Test]
+        public void TestGetCredentialsForTokenWithManyCharacters()
+        {
+            // arrange
+            var key = "mockKey";
+            var expectedToken = "access-token-123";
+
+            // act
+            _credentialManager.SaveCredentials(key, expectedToken);
+
+            // assert
+            Assert.AreEqual(expectedToken, _credentialManager.GetCredentials(key));
+
+            // act
+            _credentialManager.RemoveCredentials(key);
+
+            // assert
+            Assert.IsTrue(string.IsNullOrEmpty(_credentialManager.GetCredentials(key)));
+        }
     }
 }

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
@@ -46,6 +46,10 @@ namespace Snowflake.Data.Core.CredentialManager.Infrastructure
             using (var critCred = new CriticalCredentialHandle(nCredPtr))
             {
                 var cred = critCred.GetCredential();
+                if (cred.CredentialBlob.Length > cred.CredentialBlobSize / 2)
+                {
+                    return cred.CredentialBlob.Substring(0, (int)(cred.CredentialBlobSize / 2));
+                }
                 return cred.CredentialBlob;
             }
         }

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerWindowsNativeImpl.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Data.Core.CredentialManager.Infrastructure
             using (var critCred = new CriticalCredentialHandle(nCredPtr))
             {
                 var cred = critCred.GetCredential();
-                if (cred.CredentialBlob.Length > cred.CredentialBlobSize / 2)
+                if (cred.CredentialBlob.Length > (int)cred.CredentialBlobSize / 2)
                 {
                     return cred.CredentialBlob.Substring(0, (int)(cred.CredentialBlobSize / 2));
                 }


### PR DESCRIPTION
### Description
Fixes reading too many chars from Windows native secret store tokens

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
