### PR TITLE
SNOW-1917171 use client secret provided externally and recognise hosts

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
@@ -356,7 +356,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var sessionContext = new SessionPropertiesContext
             {
                 AllowHttpForIdp = true,
-                ClientSecret = clientSecretInConnectionString ? null : SecureStringHelper.Encode(ClientSecret)
+                OAuthClientSecret = clientSecretInConnectionString ? null : SecureStringHelper.Encode(ClientSecret)
             };
             var session = new SFSession(connectionString, sessionContext);
             var challengeProvider = new Mock<ChallengeProvider>();
@@ -368,7 +368,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             return session;
         }
 
-        private string GetAuthorizationCodeConnectionString(bool addClientSecret)
+        private string GetAuthorizationCodeConnectionString(bool addOAuthClientSecret)
         {
             var authenticator = OAuthAuthorizationCodeAuthenticator.AuthName;
             var account = "testAccount";
@@ -386,7 +386,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
                 .Append($"oauthClientId={clientId};oauthScope={AuthorizationScope};")
                 .Append($"oauthRedirectUri={redirectUri};")
                 .Append($"oauthAuthorizationUrl={s_externalAuthorizationUrl};oauthTokenRequestUrl={s_externalTokenRequestUrl};");
-            if (addClientSecret)
+            if (addOAuthClientSecret)
                 connectionStringBuilder.Append($"oauthClientSecret={ClientSecret};");
             return connectionStringBuilder.ToString();
         }

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
@@ -39,6 +39,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         private const string User = "testUser";
         private const string AuthorizationScope = "session:role:ANALYST";
         private const string TokenHost = "localhost";
+        private const string ClientSecret = "123";
         private static readonly string s_externalAuthorizationUrl = $"http://localhost:{WiremockRunner.DefaultHttpPort}/oauth/authorize";
         private static readonly string s_externalTokenRequestUrl = $"http://localhost:{WiremockRunner.DefaultHttpPort}/oauth/token-request";
 
@@ -134,6 +135,26 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
                 RemoveTokenFromCache(TokenType.OAuthAccessToken);
                 RemoveTokenFromCache(TokenType.OAuthRefreshToken);
             }
+        }
+
+        [Test]
+        public void TestSuccessfulAuthorizationCodeFlowWithClientSecretProvidedExternally()
+        {
+            // arrange
+            _runner.AddMappings(s_authorizationCodeSuccessfulMappingPath);
+            _runner.AddMappings(s_oauthSnowflakeLoginSuccessMappingPath);
+            var session = PrepareSession(false);
+            var authenticator = (OAuthAuthorizationCodeAuthenticator) session.GetAuthenticator();
+
+            // act
+            session.Open();
+
+            // assert
+            Assert.NotNull(authenticator.AccessToken);
+            Assert.AreEqual(AccessToken, SecureStringHelper.Decode(authenticator.AccessToken));
+            Assert.AreEqual(AccessToken, ExtractTokenFromCache(TokenType.OAuthAccessToken));
+            Assert.AreEqual(RefreshToken, ExtractTokenFromCache(TokenType.OAuthRefreshToken));
+            AssertSessionSuccessfullyCreated(session);
         }
 
         [Test]
@@ -329,10 +350,14 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             Assert.AreEqual(SessionToken, session.sessionToken);
         }
 
-        private SFSession PrepareSession()
+        private SFSession PrepareSession(bool clientSecretInConnectionString = true)
         {
-            var connectionString = GetAuthorizationCodeConnectionString();
-            var sessionContext = new SessionPropertiesContext { AllowHttpForIdp = true };
+            var connectionString = GetAuthorizationCodeConnectionString(clientSecretInConnectionString);
+            var sessionContext = new SessionPropertiesContext
+            {
+                AllowHttpForIdp = true,
+                ClientSecret = clientSecretInConnectionString ? null : SecureStringHelper.Encode(ClientSecret)
+            };
             var session = new SFSession(connectionString, sessionContext);
             var challengeProvider = new Mock<ChallengeProvider>();
             challengeProvider.Setup(c => c.GenerateState())
@@ -343,7 +368,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             return session;
         }
 
-        private string GetAuthorizationCodeConnectionString()
+        private string GetAuthorizationCodeConnectionString(bool addClientSecret)
         {
             var authenticator = OAuthAuthorizationCodeAuthenticator.AuthName;
             var account = "testAccount";
@@ -354,15 +379,16 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var port = WiremockRunner.DefaultHttpPort;
             var scheme = "http";
             var clientId = "123";
-            var clientSecret = "123";
             var redirectUri = "http://localhost:8009/snowflake/oauth-redirect";
-            return new StringBuilder()
+            var connectionStringBuilder = new StringBuilder()
                 .Append($"authenticator={authenticator};user={User};account={account};")
                 .Append($"db={db};role={role};warehouse={warehouse};host={host};port={port};scheme={scheme};")
-                .Append($"oauthClientId={clientId};oauthClientSecret={clientSecret};oauthScope={AuthorizationScope};")
+                .Append($"oauthClientId={clientId};oauthScope={AuthorizationScope};")
                 .Append($"oauthRedirectUri={redirectUri};")
-                .Append($"oauthAuthorizationUrl={s_externalAuthorizationUrl};oauthTokenRequestUrl={s_externalTokenRequestUrl};")
-                .ToString();
+                .Append($"oauthAuthorizationUrl={s_externalAuthorizationUrl};oauthTokenRequestUrl={s_externalTokenRequestUrl};");
+            if (addClientSecret)
+                connectionStringBuilder.Append($"oauthClientSecret={ClientSecret};");
+            return connectionStringBuilder.ToString();
         }
 
         private string ExtractTokenFromCache(TokenType tokenType)

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -242,17 +242,17 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         [TestCase("ACCOUNT=test;USER=test;PASSWORD=test;")]
         [TestCase("ACCOUNT=test;USER=test;PASSWORD=test;OAUTHCLIENTSECRET=ignored_value;")]
-        public void TestParseClientSecretProvidedExternally(string connectionString)
+        public void TestParseOAuthClientSecretProvidedExternally(string connectionString)
         {
             // arrange
-            var clientSecret = "abc";
-            var secureClientSecret = SecureStringHelper.Encode(clientSecret);
+            var oauthClientSecret = "abc";
+            var secureOAuthClientSecret = SecureStringHelper.Encode(oauthClientSecret);
 
             // act
-            var properties = SFSessionProperties.ParseConnectionString(connectionString, new SessionPropertiesContext { ClientSecret = secureClientSecret });
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, new SessionPropertiesContext { OAuthClientSecret = secureOAuthClientSecret });
 
             // assert
-            Assert.AreEqual(clientSecret, properties[SFSessionProperty.OAUTHCLIENTSECRET]);
+            Assert.AreEqual(oauthClientSecret, properties[SFSessionProperty.OAUTHCLIENTSECRET]);
         }
 
         [Test]

--- a/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
@@ -232,6 +232,9 @@ namespace Snowflake.Data.Tests.UnitTests
             // passcode
             BasicMasking(@"passcode:aaaaaaaa", @"passcode:****");
 
+            // client_secret
+            BasicMasking(@"client_secret:aaaaaaaa", @"client_secret:****");
+
             // Delimiters before start of value to mask
             BasicMasking(@"password""aaaaaaaa", @"password""****"); // "
             BasicMasking(@"password'aaaaaaaa", @"password'****"); // '
@@ -277,6 +280,14 @@ namespace Snowflake.Data.Tests.UnitTests
             BasicMasking(@"somethingBefore=cccc;passcode=", @"somethingBefore=cccc;passcode=****");
             BasicMasking(@"somethingBefore=cccc;passcode     =aa;somethingNext=bbbb", @"somethingBefore=cccc;passcode     =****");
             BasicMasking(@"somethingBefore=cccc;passcode="" 'aa", @"somethingBefore=cccc;passcode=****");
+
+            BasicMasking(@"somethingBefore=cccc;client_secret=aa", @"somethingBefore=cccc;client_secret=****");
+            BasicMasking(@"somethingBefore=cccc;client_secret=aa;somethingNext=bbbb", @"somethingBefore=cccc;client_secret=****");
+            BasicMasking(@"somethingBefore=cccc;client_secret=""aa"";somethingNext=bbbb", @"somethingBefore=cccc;client_secret=****");
+            BasicMasking(@"somethingBefore=cccc;client_secret=;somethingNext=bbbb", @"somethingBefore=cccc;client_secret=****");
+            BasicMasking(@"somethingBefore=cccc;client_secret=", @"somethingBefore=cccc;client_secret=****");
+            BasicMasking(@"somethingBefore=cccc;client_secret     =aa;somethingNext=bbbb", @"somethingBefore=cccc;client_secret     =****");
+            BasicMasking(@"somethingBefore=cccc;client_secret="" 'aa", @"somethingBefore=cccc;client_secret=****");
         }
 
         [Test]
@@ -387,6 +398,12 @@ namespace Snowflake.Data.Tests.UnitTests
             mask = SecretDetector.MaskSecrets(randomPwdWithPrefix);
             Assert.IsTrue(mask.isMasked);
             Assert.AreEqual(@"pwd:****", mask.maskedText);
+            Assert.IsNull(mask.errStr);
+
+            string randomClientSecretUppercaseWithPrefix = "CLIENT_SECRET:" + randomPassword;
+            mask = SecretDetector.MaskSecrets(randomClientSecretUppercaseWithPrefix);
+            Assert.IsTrue(mask.isMasked);
+            Assert.AreEqual(@"CLIENT_SECRET:****", mask.maskedText);
             Assert.IsNull(mask.errStr);
         }
 

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -152,14 +152,14 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         [TestCase(null)]
         [TestCase("")]
         [TestCase("anySecret")]
-        public void TestValidateValidSecureClientCredentials(string clientSecret)
+        public void TestValidateValidSecureClientCredentials(string oauthClientSecret)
         {
             // arrange
-            var secureClientSecret = clientSecret == null ? null : SecureStringHelper.Encode(clientSecret);
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null, secureClientSecret);
+            var secureOAuthClientSecret = oauthClientSecret == null ? null : SecureStringHelper.Encode(oauthClientSecret);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, secureOAuthClientSecret);
 
             // act
-            Assert.DoesNotThrow(() => pool.ValidateSecureClientSecret(secureClientSecret));
+            Assert.DoesNotThrow(() => pool.ValidateSecureOAuthClientSecret(secureOAuthClientSecret));
         }
 
         [Test]
@@ -188,18 +188,18 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         [TestCase("someSecret", "anotherSecret")]
         [TestCase("", "anotherSecret")]
         [TestCase(null, "anotherSecret")]
-        public void TestFailToValidateNotMatchingSecureClientCredentials(string poolClientSecret, string notMatchingClientSecret)
+        public void TestFailToValidateNotMatchingSecureClientCredentials(string poolOAuthClientSecret, string notMatchingOAuthClientSecret)
         {
             // arrange
-            var poolSecureClientSecret = poolClientSecret == null ? null : SecureStringHelper.Encode(poolClientSecret);
-            var notMatchingSecureClientSecret = notMatchingClientSecret == null ? null : SecureStringHelper.Encode(notMatchingClientSecret);
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null, poolSecureClientSecret);
+            var poolSecureOAuthClientSecret = poolOAuthClientSecret == null ? null : SecureStringHelper.Encode(poolOAuthClientSecret);
+            var notMatchingSecureOAuthClientSecret = notMatchingOAuthClientSecret == null ? null : SecureStringHelper.Encode(notMatchingOAuthClientSecret);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, poolSecureOAuthClientSecret);
 
             // act
-            var thrown = Assert.Throws<Exception>(() => pool.ValidateSecureClientSecret(notMatchingSecureClientSecret));
+            var thrown = Assert.Throws<Exception>(() => pool.ValidateSecureOAuthClientSecret(notMatchingSecureOAuthClientSecret));
 
             // assert
-            Assert.That(thrown.Message, Does.Contain("Could not get a pool because of client secret mismatch"));
+            Assert.That(thrown.Message, Does.Contain("Could not get a pool because of oauth client secret mismatch"));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         public void TestPoolParametersAreNotOverriden()
         {
             // act
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, null);
 
             // assert
             Assert.IsFalse(pool.IsConfigOverridden());
@@ -29,7 +29,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         public void TestOverrideMaxPoolSize()
         {
             // arrange
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, null);
             var newMaxPoolSize = 15;
 
             // act
@@ -44,7 +44,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         public void TestOverrideExpirationTimeout()
         {
             // arrange
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, null);
             var newExpirationTimeoutSeconds = 15;
 
             // act
@@ -59,7 +59,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         public void TestOverrideSetPooling()
         {
             // arrange
-            var pool = SessionPool.CreateSessionPool(ConnectionString, null);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, null);
 
             // act
             pool.SetPooling(false);
@@ -70,19 +70,20 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         }
 
         [Test]
-        [TestCase("account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443", "somePassword", " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;port=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;private_key=SomePrivateKey;port=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;token=someToken;port=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;private_key_pwd=somePrivateKeyPwd;port=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;proxyPassword=someProxyPassword;port=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("ACCOUNT=someAccount;DB=someDb;HOST=someHost;PASSWORD=somePassword;passcode=123;USER=SomeUser;PORT=443", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        [TestCase("ACCOUNT=\"someAccount\";DB=\"someDb\";HOST=\"someHost\";PASSWORD=\"somePassword\";PASSCODE=\"123\";USER=\"SomeUser\";PORT=\"443\"", null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
-        public void TestPoolIdentificationBasedOnConnectionString(string connectionString, string password, string expectedPoolIdentification)
+        [TestCase("account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443", "somePassword", "someSecret", " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;port=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;private_key=SomePrivateKey;port=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;token=someToken;port=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;private_key_pwd=somePrivateKeyPwd;port=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("account=someAccount;db=someDb;host=someHost;password=somePassword;passcode=123;user=SomeUser;proxyPassword=someProxyPassword;port=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("ACCOUNT=someAccount;DB=someDb;HOST=someHost;PASSWORD=somePassword;passcode=123;USER=SomeUser;PORT=443", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        [TestCase("ACCOUNT=\"someAccount\";DB=\"someDb\";HOST=\"someHost\";PASSWORD=\"somePassword\";PASSCODE=\"123\";USER=\"SomeUser\";PORT=\"443\"", null, null, " [pool: account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443;]")]
+        public void TestPoolIdentificationBasedOnConnectionString(string connectionString, string password, string clientSecret, string expectedPoolIdentification)
         {
             // arrange
             var securePassword = password == null ? null : SecureStringHelper.Encode(password);
-            var pool = SessionPool.CreateSessionPool(connectionString, securePassword);
+            var secureClientSecret = clientSecret == null ? null : SecureStringHelper.Encode(clientSecret);
+            var pool = SessionPool.CreateSessionPool(connectionString, securePassword, secureClientSecret);
 
             // act
             var poolIdentification = pool.PoolIdentificationBasedOnConnectionString;
@@ -98,7 +99,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var invalidConnectionString = "account=someAccount;db=someDb;host=someHost;user=SomeUser;port=443"; // invalid because password is not provided
 
             // act
-            var exception = Assert.Throws<SnowflakeDbException>(() => SessionPool.CreateSessionPool(invalidConnectionString, null));
+            var exception = Assert.Throws<SnowflakeDbException>(() => SessionPool.CreateSessionPool(invalidConnectionString, null, null));
 
             // assert
             SnowflakeDbExceptionAssert.HasErrorCode(exception, SFError.MISSING_CONNECTION_PROPERTY);
@@ -110,7 +111,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         {
             // arrange
             var connectionString = "account=someAccount;db=someDb;host=someHost;password=somePassword;user=SomeUser;port=443";
-            var pool = SessionPool.CreateSessionPool(connectionString, null);
+            var pool = SessionPool.CreateSessionPool(connectionString, null, null);
             var poolIdRegex = new Regex(@"^ \[pool: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]$");
 
             // act
@@ -141,10 +142,24 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         {
             // arrange
             var securePassword = password == null ? null : SecureStringHelper.Encode(password);
-            var pool = SessionPool.CreateSessionPool(ConnectionString, securePassword);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, securePassword, null);
 
             // act
             Assert.DoesNotThrow(() => pool.ValidateSecurePassword(securePassword));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("anySecret")]
+        public void TestValidateValidSecureClientCredentials(string clientSecret)
+        {
+            // arrange
+            var secureClientSecret = clientSecret == null ? null : SecureStringHelper.Encode(clientSecret);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, secureClientSecret);
+
+            // act
+            Assert.DoesNotThrow(() => pool.ValidateSecureClientSecret(secureClientSecret));
         }
 
         [Test]
@@ -158,13 +173,33 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             // arrange
             var poolSecurePassword = poolPassword == null ? null : SecureStringHelper.Encode(poolPassword);
             var notMatchingSecurePassword = notMatchingPassword == null ? null : SecureStringHelper.Encode(notMatchingPassword);
-            var pool = SessionPool.CreateSessionPool(ConnectionString, poolSecurePassword);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, poolSecurePassword, null);
 
             // act
             var thrown = Assert.Throws<Exception>(() => pool.ValidateSecurePassword(notMatchingSecurePassword));
 
             // assert
             Assert.That(thrown.Message, Does.Contain("Could not get a pool because of password mismatch"));
+        }
+
+        [Test]
+        [TestCase("someSecret", null)]
+        [TestCase("someSecret", "")]
+        [TestCase("someSecret", "anotherSecret")]
+        [TestCase("", "anotherSecret")]
+        [TestCase(null, "anotherSecret")]
+        public void TestFailToValidateNotMatchingSecureClientCredentials(string poolClientSecret, string notMatchingClientSecret)
+        {
+            // arrange
+            var poolSecureClientSecret = poolClientSecret == null ? null : SecureStringHelper.Encode(poolClientSecret);
+            var notMatchingSecureClientSecret = notMatchingClientSecret == null ? null : SecureStringHelper.Encode(notMatchingClientSecret);
+            var pool = SessionPool.CreateSessionPool(ConnectionString, null, poolSecureClientSecret);
+
+            // act
+            var thrown = Assert.Throws<Exception>(() => pool.ValidateSecureClientSecret(notMatchingSecureClientSecret));
+
+            // assert
+            Assert.That(thrown.Message, Does.Contain("Could not get a pool because of client secret mismatch"));
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
@@ -1,17 +1,19 @@
-
-
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Mono.Unix;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Tests.UnitTests
 {
-    using Core;
-    using Core.Tools;
-    using Moq;
-    using NUnit.Framework;
-    using Snowflake.Data.Client;
 
+    [TestFixture, NonParallelizable]
     public class SnowflakeDbConnectionTest
     {
         [Test]
@@ -55,6 +57,97 @@ namespace Snowflake.Data.Tests.UnitTests
                 conn.FillConnectionStringFromTomlConfigIfNotSet();
                 // Assert
                 Assert.AreEqual(connectionTest, conn.ConnectionString);
+            }
+        }
+
+        [Test]
+        public void TestUseConfigurationProvidedOutsideOfConnectionString()
+        {
+            // arrange
+            var connectionManager = new Mock<IConnectionManager>();
+            var oldConnectionManager = SnowflakeDbConnectionPool.ReplaceConnectionManager(connectionManager.Object);
+            try
+            {
+                var connectionString = "account=user1account;user=user1;";
+                var password = "testpassword";
+                var passcode = "testpasscode";
+                var clientSecret = "testclientsecret";
+                var sessionProperties = new SessionPropertiesContext
+                {
+                    Password = SecureStringHelper.Encode(password),
+                    Passcode = SecureStringHelper.Encode(passcode),
+                    ClientSecret = SecureStringHelper.Encode(clientSecret)
+                };
+                connectionManager
+                    .Setup(m => m.GetSession(connectionString, It.IsAny<SessionPropertiesContext>()))
+                    .Returns(new SFSession(connectionString, sessionProperties));
+
+                using (var connection = new SnowflakeDbConnection(connectionString))
+                {
+                    connection.Password = SecureStringHelper.Encode(password);
+                    connection.Passcode = SecureStringHelper.Encode(passcode);
+                    connection.ClientSecret = SecureStringHelper.Encode(clientSecret);
+
+                    // act
+                    connection.Open();
+
+                    // assert
+                    connectionManager.Verify(m => m.GetSession(connectionString,
+                        It.Is<SessionPropertiesContext>(context =>
+                            SecureStringHelper.Decode(context.Password) == password &&
+                            SecureStringHelper.Decode(context.Passcode) == passcode &&
+                            SecureStringHelper.Decode(context.ClientSecret) == clientSecret)));
+                }
+            }
+            finally
+            {
+                SnowflakeDbConnectionPool.ReplaceConnectionManager(oldConnectionManager);
+            }
+        }
+
+        [Test]
+        public void TestUseConfigurationProvidedOutsideOfConnectionStringAsync()
+        {
+            // arrange
+            var connectionManager = new Mock<IConnectionManager>();
+            var oldConnectionManager = SnowflakeDbConnectionPool.ReplaceConnectionManager(connectionManager.Object);
+            try
+            {
+                var connectionString = "account=user1account;user=user1;";
+                var password = "testpassword";
+                var passcode = "testpasscode";
+                var clientSecret = "testclientsecret";
+                var sessionProperties = new SessionPropertiesContext
+                {
+                    Password = SecureStringHelper.Encode(password),
+                    Passcode = SecureStringHelper.Encode(passcode),
+                    ClientSecret = SecureStringHelper.Encode(clientSecret)
+                };
+                connectionManager
+                    .Setup(m => m.GetSessionAsync(connectionString, It.IsAny<SessionPropertiesContext>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new SFSession(connectionString, sessionProperties)));
+
+                using (var connection = new SnowflakeDbConnection(connectionString))
+                {
+                    connection.Password = SecureStringHelper.Encode(password);
+                    connection.Passcode = SecureStringHelper.Encode(passcode);
+                    connection.ClientSecret = SecureStringHelper.Encode(clientSecret);
+
+                    // act
+                    connection.OpenAsync(CancellationToken.None).Wait();
+
+                    // assert
+                    connectionManager.Verify(m => m.GetSessionAsync(connectionString,
+                        It.Is<SessionPropertiesContext>(context =>
+                            SecureStringHelper.Decode(context.Password) == password &&
+                            SecureStringHelper.Decode(context.Passcode) == passcode &&
+                            SecureStringHelper.Decode(context.ClientSecret) == clientSecret),
+                        It.IsAny<CancellationToken>()));
+                }
+            }
+            finally
+            {
+                SnowflakeDbConnectionPool.ReplaceConnectionManager(oldConnectionManager);
             }
         }
     }

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
@@ -71,12 +71,12 @@ namespace Snowflake.Data.Tests.UnitTests
                 var connectionString = "account=user1account;user=user1;";
                 var password = "testpassword";
                 var passcode = "testpasscode";
-                var clientSecret = "testclientsecret";
+                var oauthClientSecret = "testoauthclientsecret";
                 var sessionProperties = new SessionPropertiesContext
                 {
                     Password = SecureStringHelper.Encode(password),
                     Passcode = SecureStringHelper.Encode(passcode),
-                    ClientSecret = SecureStringHelper.Encode(clientSecret)
+                    OAuthClientSecret = SecureStringHelper.Encode(oauthClientSecret)
                 };
                 connectionManager
                     .Setup(m => m.GetSession(connectionString, It.IsAny<SessionPropertiesContext>()))
@@ -86,7 +86,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 {
                     connection.Password = SecureStringHelper.Encode(password);
                     connection.Passcode = SecureStringHelper.Encode(passcode);
-                    connection.ClientSecret = SecureStringHelper.Encode(clientSecret);
+                    connection.OAuthClientSecret = SecureStringHelper.Encode(oauthClientSecret);
 
                     // act
                     connection.Open();
@@ -96,7 +96,7 @@ namespace Snowflake.Data.Tests.UnitTests
                         It.Is<SessionPropertiesContext>(context =>
                             SecureStringHelper.Decode(context.Password) == password &&
                             SecureStringHelper.Decode(context.Passcode) == passcode &&
-                            SecureStringHelper.Decode(context.ClientSecret) == clientSecret)));
+                            SecureStringHelper.Decode(context.OAuthClientSecret) == oauthClientSecret)));
                 }
             }
             finally
@@ -116,12 +116,12 @@ namespace Snowflake.Data.Tests.UnitTests
                 var connectionString = "account=user1account;user=user1;";
                 var password = "testpassword";
                 var passcode = "testpasscode";
-                var clientSecret = "testclientsecret";
+                var oauthClientSecret = "testoauthclientsecret";
                 var sessionProperties = new SessionPropertiesContext
                 {
                     Password = SecureStringHelper.Encode(password),
                     Passcode = SecureStringHelper.Encode(passcode),
-                    ClientSecret = SecureStringHelper.Encode(clientSecret)
+                    OAuthClientSecret = SecureStringHelper.Encode(oauthClientSecret)
                 };
                 connectionManager
                     .Setup(m => m.GetSessionAsync(connectionString, It.IsAny<SessionPropertiesContext>(), It.IsAny<CancellationToken>()))
@@ -131,7 +131,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 {
                     connection.Password = SecureStringHelper.Encode(password);
                     connection.Passcode = SecureStringHelper.Encode(passcode);
-                    connection.ClientSecret = SecureStringHelper.Encode(clientSecret);
+                    connection.OAuthClientSecret = SecureStringHelper.Encode(oauthClientSecret);
 
                     // act
                     connection.OpenAsync(CancellationToken.None).Wait();
@@ -141,7 +141,7 @@ namespace Snowflake.Data.Tests.UnitTests
                         It.Is<SessionPropertiesContext>(context =>
                             SecureStringHelper.Decode(context.Password) == password &&
                             SecureStringHelper.Decode(context.Passcode) == passcode &&
-                            SecureStringHelper.Decode(context.ClientSecret) == clientSecret),
+                            SecureStringHelper.Decode(context.OAuthClientSecret) == oauthClientSecret),
                         It.IsAny<CancellationToken>()));
                 }
             }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -75,7 +75,7 @@ namespace Snowflake.Data.Client
 
         public SecureString Passcode { get; set; }
 
-        public SecureString ClientSecret { get; set; }
+        public SecureString OAuthClientSecret { get; set; }
 
         public bool IsOpen()
         {
@@ -282,7 +282,7 @@ namespace Snowflake.Data.Client
                 {
                     Password = Password,
                     Passcode = Passcode,
-                    ClientSecret = ClientSecret
+                    OAuthClientSecret = OAuthClientSecret
                 };
                 SfSession = SnowflakeDbConnectionPool.GetSession(ConnectionString, sessionContext);
                 if (SfSession == null)
@@ -330,7 +330,7 @@ namespace Snowflake.Data.Client
             {
                 Password = Password,
                 Passcode = Passcode,
-                ClientSecret = ClientSecret
+                OAuthClientSecret = OAuthClientSecret
             };
             return SnowflakeDbConnectionPool
                 .GetSessionAsync(ConnectionString, sessionContext, cancellationToken)

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -75,6 +75,8 @@ namespace Snowflake.Data.Client
 
         public SecureString Passcode { get; set; }
 
+        public SecureString ClientSecret { get; set; }
+
         public bool IsOpen()
         {
             return _connectionState == ConnectionState.Open && SfSession != null;
@@ -279,7 +281,8 @@ namespace Snowflake.Data.Client
                 var sessionContext = new SessionPropertiesContext
                 {
                     Password = Password,
-                    Passcode = Passcode
+                    Passcode = Passcode,
+                    ClientSecret = ClientSecret
                 };
                 SfSession = SnowflakeDbConnectionPool.GetSession(ConnectionString, sessionContext);
                 if (SfSession == null)
@@ -326,7 +329,8 @@ namespace Snowflake.Data.Client
             var sessionContext = new SessionPropertiesContext
             {
                 Password = Password,
-                Passcode = Passcode
+                Passcode = Passcode,
+                ClientSecret = ClientSecret
             };
             return SnowflakeDbConnectionPool
                 .GetSessionAsync(ConnectionString, sessionContext, cancellationToken)

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -39,13 +39,13 @@ namespace Snowflake.Data.Client
             return ConnectionManager.GetSessionAsync(connectionString, sessionContext, cancellationToken);
         }
 
-        public static SnowflakeDbSessionPool GetPool(string connectionString, SecureString password, SecureString clientSecret = null)
+        public static SnowflakeDbSessionPool GetPool(string connectionString, SecureString password, SecureString oauthClientSecret = null)
         {
             s_logger.Debug($"SnowflakeDbConnectionPool::GetPool");
             var sessionContext = new SessionPropertiesContext
             {
                 Password = password,
-                ClientSecret = clientSecret
+                OAuthClientSecret = oauthClientSecret
             };
             return new SnowflakeDbSessionPool(ConnectionManager.GetPool(connectionString, sessionContext));
         }

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -39,10 +39,14 @@ namespace Snowflake.Data.Client
             return ConnectionManager.GetSessionAsync(connectionString, sessionContext, cancellationToken);
         }
 
-        public static SnowflakeDbSessionPool GetPool(string connectionString, SecureString password)
+        public static SnowflakeDbSessionPool GetPool(string connectionString, SecureString password, SecureString clientSecret = null)
         {
             s_logger.Debug($"SnowflakeDbConnectionPool::GetPool");
-            var sessionContext = new SessionPropertiesContext { Password = password };
+            var sessionContext = new SessionPropertiesContext
+            {
+                Password = password,
+                ClientSecret = clientSecret
+            };
             return new SnowflakeDbSessionPool(ConnectionManager.GetPool(connectionString, sessionContext));
         }
 
@@ -160,6 +164,13 @@ namespace Snowflake.Data.Client
                 }
             }
             return DefaultConnectionPoolType;
+        }
+
+        internal static IConnectionManager ReplaceConnectionManager(IConnectionManager connectionManager)
+        {
+            var oldConnectionManager = s_connectionManager;
+            s_connectionManager = connectionManager;
+            return oldConnectionManager;
         }
     }
 }

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -120,13 +120,13 @@ namespace Snowflake.Data.Core.Session
         {
             s_logger.Debug("ConnectionPoolManager::GetPool with connection string and secure password");
             var password = sessionContext.Password;
-            var clientSecret = sessionContext.ClientSecret;
-            var poolKey = GetPoolKey(connectionString, password, clientSecret);
+            var oauthClientSecret = sessionContext.OAuthClientSecret;
+            var poolKey = GetPoolKey(connectionString, password, oauthClientSecret);
 
             if (_pools.TryGetValue(poolKey, out var item))
             {
                 item.ValidateSecurePassword(password);
-                item.ValidateSecureClientSecret(clientSecret);
+                item.ValidateSecureOAuthClientSecret(oauthClientSecret);
                 return item;
             }
 
@@ -135,11 +135,11 @@ namespace Snowflake.Data.Core.Session
                 if (_pools.TryGetValue(poolKey, out var poolCreatedWhileWaitingOnLock))
                 {
                     poolCreatedWhileWaitingOnLock.ValidateSecurePassword(password);
-                    poolCreatedWhileWaitingOnLock.ValidateSecureClientSecret(clientSecret);
+                    poolCreatedWhileWaitingOnLock.ValidateSecureOAuthClientSecret(oauthClientSecret);
                     return poolCreatedWhileWaitingOnLock;
                 }
                 s_logger.Info($"Creating new pool");
-                var pool = SessionPool.CreateSessionPool(connectionString, password, clientSecret);
+                var pool = SessionPool.CreateSessionPool(connectionString, password, oauthClientSecret);
                 _pools.Add(poolKey, pool);
                 return pool;
             }

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -263,16 +263,7 @@ namespace Snowflake.Data.Core
                 }
             }
 
-            if (propertiesContext.Password != null && propertiesContext.Password.Length > 0)
-            {
-                properties[SFSessionProperty.PASSWORD] = SecureStringHelper.Decode(propertiesContext.Password);
-            }
-
-            if (propertiesContext.Passcode != null && propertiesContext.Passcode.Length > 0)
-            {
-                properties[SFSessionProperty.PASSCODE] = SecureStringHelper.Decode(propertiesContext.Passcode);
-            }
-
+            propertiesContext.FillSecrets(properties);
             ValidateAuthenticator(properties);
             ValidatePasscodeInPassword(properties);
             properties.IsPoolingEnabledValueProvided = properties.IsNonEmptyValueProvided(SFSessionProperty.POOLINGENABLED);
@@ -387,7 +378,7 @@ namespace Snowflake.Data.Core
 
         private static string GetHost(string url)
         {
-            return ""; // TODO: implement it !!!
+            return new Uri(url).Host;
         }
 
         internal string ExtractPropertyOrEmptyString(SFSessionProperty property) => ExtractPropertyOrDefault(property, string.Empty);
@@ -670,6 +661,13 @@ namespace Snowflake.Data.Core
             }
 
             return allowUnderscoresInHost;
+        }
+
+        internal static SFLogger ReplaceLogger(SFLogger newLogger)
+        {
+            var oldLogger = logger;
+            logger = newLogger;
+            return oldLogger;
         }
     }
 

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -25,6 +25,7 @@ namespace Snowflake.Data.Core.Session
         private readonly ISessionCreationTokenCounter _noPoolingSessionCreationTokenCounter = new NonCountingSessionCreationTokenCounter();
         internal string ConnectionString { get; }
         internal SecureString Password { get; }
+        internal SecureString ClientSecret { get; }
         private readonly string _connectionStringWithoutSecrets;
         private readonly ICounter _busySessionsCounter;
         private ISessionPoolEventHandler _sessionPoolEventHandler = new SessionPoolEventHandler(); // a way to inject some additional behaviour after certain events. Can be used for example to measure time of given steps.
@@ -44,13 +45,14 @@ namespace Snowflake.Data.Core.Session
             _poolConfig = new ConnectionPoolConfig();
         }
 
-        private SessionPool(string connectionString, SecureString password, ConnectionPoolConfig poolConfig, string connectionStringWithoutSecrets)
+        private SessionPool(string connectionString, SecureString password, SecureString clientSecret, ConnectionPoolConfig poolConfig, string connectionStringWithoutSecrets)
         {
             // acquiring a lock not needed because one is already acquired in ConnectionPoolManager
             _idleSessions = new List<SFSession>();
             _busySessionsCounter = new NonNegativeCounter();
             ConnectionString = connectionString;
             Password = password;
+            ClientSecret = clientSecret;
             _connectionStringWithoutSecrets = connectionStringWithoutSecrets;
             _waitingForIdleSessionQueue = new WaitingQueue();
             _poolConfig = poolConfig;
@@ -59,13 +61,13 @@ namespace Snowflake.Data.Core.Session
 
         internal static SessionPool CreateSessionCache() => new SessionPool();
 
-        internal static SessionPool CreateSessionPool(string connectionString, SecureString password)
+        internal static SessionPool CreateSessionPool(string connectionString, SecureString password, SecureString clientSecret)
         {
             s_logger.Debug("Creating a connection pool");
-            var propertiesContext = new SessionPropertiesContext { Password = password };
+            var propertiesContext = new SessionPropertiesContext { Password = password, ClientSecret = clientSecret };
             var extracted = ExtractConfig(connectionString, propertiesContext);
             s_logger.Debug("Creating a connection pool identified by: " + extracted.Item2);
-            return new SessionPool(connectionString, password, extracted.Item1, extracted.Item2);
+            return new SessionPool(connectionString, password, clientSecret, extracted.Item1, extracted.Item2);
         }
 
         ~SessionPool()
@@ -121,7 +123,7 @@ namespace Snowflake.Data.Core.Session
 
         internal void ValidateSecurePassword(SecureString password)
         {
-            if (!ExtractPassword(Password).Equals(ExtractPassword(password)))
+            if (!ExtractSecureString(Password).Equals(ExtractSecureString(password)))
             {
                 var errorMessage = "Could not get a pool because of password mismatch";
                 s_logger.Error(errorMessage + PoolIdentification());
@@ -129,7 +131,17 @@ namespace Snowflake.Data.Core.Session
             }
         }
 
-        private string ExtractPassword(SecureString password) =>
+        internal void ValidateSecureClientSecret(SecureString clientSecret)
+        {
+            if (!ExtractSecureString(ClientSecret).Equals(ExtractSecureString(clientSecret)))
+            {
+                var errorMessage = "Could not get a pool because of client secret mismatch";
+                s_logger.Error(errorMessage + PoolIdentification());
+                throw new Exception(errorMessage);
+            }
+        }
+
+        private string ExtractSecureString(SecureString password) =>
             password == null ? string.Empty : SecureStringHelper.Decode(password);
 
         internal SFSession GetSession(string connStr, SessionPropertiesContext sessionContext)

--- a/Snowflake.Data/Core/Session/SessionPropertiesContext.cs
+++ b/Snowflake.Data/Core/Session/SessionPropertiesContext.cs
@@ -1,4 +1,5 @@
 using System.Security;
+using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Core.Session
 {
@@ -11,5 +12,20 @@ namespace Snowflake.Data.Core.Session
         public SecureString ClientSecret { get; set; } = null;
 
         public bool AllowHttpForIdp { get; set; } = false;
+
+        public void FillSecrets(SFSessionProperties properties)
+        {
+            FillSecret(properties, SFSessionProperty.PASSWORD, Password);
+            FillSecret(properties, SFSessionProperty.OAUTHCLIENTSECRET, ClientSecret);
+            FillSecret(properties, SFSessionProperty.PASSCODE, Passcode);
+        }
+
+        private void FillSecret(SFSessionProperties properties, SFSessionProperty property, SecureString secret)
+        {
+            if (secret != null && secret.Length > 0)
+            {
+                properties[property] = SecureStringHelper.Decode(secret);
+            }
+        }
     }
 }

--- a/Snowflake.Data/Core/Session/SessionPropertiesContext.cs
+++ b/Snowflake.Data/Core/Session/SessionPropertiesContext.cs
@@ -9,14 +9,14 @@ namespace Snowflake.Data.Core.Session
 
         public SecureString Passcode { get; set; } = null;
 
-        public SecureString ClientSecret { get; set; } = null;
+        public SecureString OAuthClientSecret { get; set; } = null;
 
         public bool AllowHttpForIdp { get; set; } = false;
 
         public void FillSecrets(SFSessionProperties properties)
         {
             FillSecret(properties, SFSessionProperty.PASSWORD, Password);
-            FillSecret(properties, SFSessionProperty.OAUTHCLIENTSECRET, ClientSecret);
+            FillSecret(properties, SFSessionProperty.OAUTHCLIENTSECRET, OAuthClientSecret);
             FillSecret(properties, SFSessionProperty.PASSCODE, Passcode);
         }
 

--- a/Snowflake.Data/Logger/SecretDetector.cs
+++ b/Snowflake.Data/Logger/SecretDetector.cs
@@ -87,8 +87,8 @@ namespace Snowflake.Data.Log
         private const string PrivateKeyPropertyPrefixPattern = @"(private_key\s*=)";
         private const string ConnectionTokenPattern = @"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})";
         private const string TokenPropertyPattern = @"(token)(\s*=)(.*)";
-        private const string PasswordPattern = @"(password|passcode|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})";
-        private const string PasswordPropertyPattern = @"(password|passcode|proxypassword|private_key_pwd)(\s*=)(.*)";
+        private const string PasswordPattern = @"(password|passcode|client_secret|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})";
+        private const string PasswordPropertyPattern = @"(password|passcode|client_secret|proxypassword|private_key_pwd)(\s*=)(.*)";
 
         private static readonly Func<string, string>[] s_maskFunctions = {
             MaskAWSServerSide,


### PR DESCRIPTION
### Description
SNOW-1917171 use client secret provided externally and recognise hosts

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
