### PR TITLE
Disable pooling by default for oauth authorization code flow

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -361,6 +361,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [TestCase("AUTHENTICATOR=oauth_authorization_code;ACCOUNT=test;oauthClientId=abc;oauthClientSecret=def;oauthScope=ghi;oauthTokenRequestUrl=https://okta.com/token-request", "Required property OAUTHAUTHORIZATIONURL is not provided")]
         [TestCase("AUTHENTICATOR=oauth_authorization_code;ACCOUNT=test;oauthClientId=abc;oauthClientSecret=def;oauthScope=ghi;oauthAuthorizationUrl=http://okta.com/authorize;oauthTokenRequestUrl=https://okta.com/token-request", "Invalid parameter value  for OAUTHAUTHORIZATIONURL")]
         [TestCase("AUTHENTICATOR=oauth_authorization_code;ACCOUNT=test;oauthClientId=abc;oauthClientSecret=def;oauthScope=ghi;oauthAuthorizationUrl=https://okta.com/authorize;oauthTokenRequestUrl=http://okta.com/token-request", "Invalid parameter value  for OAUTHTOKENREQUESTURL")]
+        [TestCase("AUTHENTICATOR=oauth_authorization_code;ACCOUNT=test;ROLE=ANALYST;oauthClientId=abc;oauthClientSecret=def;poolingEnabled=true;", "You cannot enable pooling for oauth authorization code authentication without specifying a user in the connection string.")]
         public void TestOAuthAuthorizationCodeMissingOrInvalidParameters(string connectionString, string errorMessage)
         {
             // act

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -239,6 +239,12 @@ namespace Snowflake.Data.Core
             this.restRequester = restRequester;
         }
 
+        internal bool IsPoolingEnabledForConnectionCache()
+        {
+            var authenticator = properties[SFSessionProperty.AUTHENTICATOR];
+            return !OAuthAuthorizationCodeAuthenticator.IsOAuthAuthorizationCodeAuthenticator(authenticator);
+        }
+
         private void ValidateApplicationName(SFSessionProperties properties)
         {
             // If there is an "application" setting, verify that it matches the expect pattern
@@ -684,6 +690,11 @@ namespace Snowflake.Data.Core
         }
 
         internal long GetStartTime() => _startTime;
+
+        internal void SetStartTime(long startTime)
+        {
+            _startTime = startTime;
+        }
 
         internal void ReplaceAuthenticator(IAuthenticator authenticator)
         {

--- a/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
+++ b/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
@@ -62,6 +62,10 @@ namespace Snowflake.Data.Core
             {
                 DisablePoolingIfNotExplicitlyEnabled(properties, "key pair with private key in a file");
             }
+            else if (OAuthAuthorizationCodeAuthenticator.IsOAuthAuthorizationCodeAuthenticator(authenticator))
+            {
+                DisablePoolingIfNotExplicitlyEnabled(properties, "oauth authorization code");
+            }
         }
 
         private void DisablePoolingIfNotExplicitlyEnabled(SFSessionProperties properties, string authenticationDescription)

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -501,11 +501,18 @@ namespace Snowflake.Data.Core.Session
             if (!GetPooling() || _underDestruction)
                 return false;
 
-            if (IsMultiplePoolsVersion() &&
+            var isMultiplePoolsVersion = IsMultiplePoolsVersion();
+            if (isMultiplePoolsVersion &&
                 session.SessionPropertiesChanged &&
                 _poolConfig.ChangedSession == ChangedSessionBehavior.Destroy)
             {
                 s_logger.Debug($"Session returning to pool was changed. Destroying the session: {session.sessionId}.");
+                session.SetPooling(false);
+            }
+
+            if (!isMultiplePoolsVersion && !session.IsPoolingEnabledForConnectionCache())
+            {
+                s_logger.Debug($"Session not allowed to be used in connection cache. Destroying the session: {session.sessionId}.");
                 session.SetPooling(false);
             }
 


### PR DESCRIPTION
### Description
Disable pooling by default for oauth authorization code flow.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
