### PR TITLE
Disable connection cache for ClientCredentials and PAT

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -262,7 +262,9 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         [TestCase("authenticator=oauth_authorization_code;account=test;role=ANALYST;oauthClientId=abc;oauthClientSecret=def;user=testUser;poolingEnabled=false;")]
         [TestCase("authenticator=oauth_authorization_code;account=test;role=ANALYST;oauthClientId=abc;oauthClientSecret=def;user=testUser;")]
         [TestCase("authenticator=oauth_authorization_code;account=test;role=ANALYST;oauthClientId=abc;oauthClientSecret=def;")]
-        public void TestConnectionCachePoolingDisabledOAuthAuthorizationCode(string connectionString)
+        [TestCase("authenticator=oauth_client_credentials;account=test;role=ANALYST;oauthClientId=abc;oauthClientSecret=def;oauthTokenRequestUrl=https://okta.com/token-request;")]
+        [TestCase("authenticator=programmatic_access_token;account=test;token=patToken")]
+        public void TestConnectionCachePoolingDisabledForNewAuthenticators(string connectionString)
         {
             // arrange
             var session = CreateSessionWithCurrentStartTime(connectionString);

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -242,7 +242,13 @@ namespace Snowflake.Data.Core
         internal bool IsPoolingEnabledForConnectionCache()
         {
             var authenticator = properties[SFSessionProperty.AUTHENTICATOR];
-            return !OAuthAuthorizationCodeAuthenticator.IsOAuthAuthorizationCodeAuthenticator(authenticator);
+            var forbiddenAuthenticators = new Func<string, bool>[]
+            {
+                OAuthAuthorizationCodeAuthenticator.IsOAuthAuthorizationCodeAuthenticator,
+                OAuthClientCredentialsAuthenticator.IsOAuthClientCredentialsAuthenticator,
+                ProgrammaticAccessTokenAuthenticator.IsProgrammaticAccessTokenAuthenticator
+            };
+            return !forbiddenAuthenticators.Any(f => f.Invoke(authenticator));
         }
 
         private void ValidateApplicationName(SFSessionProperties properties)


### PR DESCRIPTION
### Description
Disable old pool for new authenticators.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
