### PR TITLE
NOW-2027569: Move signing process to self service job

### DIFF
--- a/deploy.bat
+++ b/deploy.bat
@@ -17,12 +17,4 @@ dotnet build Snowflake.Data\Snowflake.Data.csproj -c Release --force -v n /p:Sig
 
 dotnet pack Snowflake.Data\Snowflake.Data.csproj -c Release --force -v n --no-build  --output %ROOT_DIR%
 
-aws s3 cp s3://sfc-eng-jenkins/repository/net/sign-artifact.exe .
-@For /F Delims^= %%G In ('""certutil.exe" -HashFile "sign-artifact.exe" SHA512|"find.exe" /V ":""')Do @Set "SHA=%%G"
-if not %SHA%==94f0b4a78979ded42f7f8c8ce2534691f9f874888bcf7963876f5be881cf6d0ce00e6f8d3e656492249fcfcb890ad656745f2cf68f98e828eb02ded6189a87d4 (
-  echo "Failed to verify the sha for the signing script"
-  exit 1
-)
-sign-artifact.exe sign-artifact -o snowflakedb -r snowflake-connector-net -t v%VERSION%  -l 20 -v -u -f Snowflake.Data.%VERSION%.nupkg
-
 dotnet nuget push Snowflake.Data.%VERSION%.nupkg -k %API_KEY% -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
### Description
Currently artifacts are signed after they are build. However, for some reason, when the artifacts are published to nuged some how they are updated and the signature files are not valid. In order to workaround this, the signing process is going to be in the self service job. This PR removes the signing step from the build.bat script.
The signing step is added in this PR: https://github.com/snowflakedb/jenkins_utils/pull/17283

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
