### PR TITLE
SNOW-2070718 move BLOCKED querystatus to the Running ones to conform JDBC and Python

### DIFF
--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -40,6 +40,7 @@ namespace Snowflake.Data.Core
         QueuedReparingWarehouse,
         [StringAttr(value = "RESTARTED")]
         Restarted,
+        // The state when a statement is waiting on a lock on resource held by another statement.
         [StringAttr(value = "BLOCKED")]
         Blocked,
     }
@@ -68,6 +69,7 @@ namespace Snowflake.Data.Core
                 case QueryStatus.Queued:
                 case QueryStatus.QueuedReparingWarehouse:
                 case QueryStatus.NoData:
+                case QueryStatus.Blocked:
                     return true;
                 default:
                     return false;
@@ -83,7 +85,6 @@ namespace Snowflake.Data.Core
                 case QueryStatus.Aborted:
                 case QueryStatus.FailedWithIncident:
                 case QueryStatus.Disconnected:
-                case QueryStatus.Blocked:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
### Description
Currently, we consider BLOCKED querystatus as an Error; which is a weird divergence from other Snowflake drivers, which consider it still Running.

Some examples:
* [JDBC considers it Running](https://github.com/snowflakedb/snowflake-jdbc/blob/v3.24.0/src/main/java/net/snowflake/client/core/QueryStatus.java#L77-L114) (although in a very weird way; as it’s listed under BOTH Running and Error; I think we still return it as Running due to [getQueryStatusFromString](https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/QueryStatus.java#L124-L126))
* [Python considers it Running](https://github.com/snowflakedb/snowflake-connector-python/blob/v3.15.0/src/snowflake/connector/connection.py#L2134-L2154)

On the other hand, Go, Node.js, and libsnowflakeclient (= ODBC) drivers doesn't consider it as Running, so we might want to fix those too - or, make JDBC and Python consider BLOCKED as Error, to stop the drivers being divergent on this. 
Traditionally, I think JDBC came first and perhaps the weird implementation which led to this divergence.

Anyhow. The definition of BLOCKED status:
> The state when a statement is waiting on a lock on resource held by another statement.

which by definition, if it's _waiting_ on something, then it's still running and not in an end state. 

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
