### PR TITLE
SNOW-2102617 Enable result sets for DML

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -79,7 +79,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 conn.Close();
             }
         }
-        
+
         [Test]
         public async Task TestSelectAsync()
         {
@@ -120,7 +120,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 conn.Close();
             }
         }
-        
+
         [Test]
         public void TestSelectWithBinding()
         {
@@ -526,6 +526,62 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     cmd.CommandText = "select 1; select 2; select 3";
                     cmd.ExecuteNonQuery();
+                }
+
+                conn.Close();
+            }
+        }
+
+        [Test]
+        public void TestResultSetReturnedForAllQueryTypes()
+        {
+            using (DbConnection conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                using (DbCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "set query_tag = (select 'dummy_tag');" +
+                                      "alter session set query_tag='dummy_tag';" +
+                                      "select 1;" +
+                                      $"create or replace temporary table {TableName}(c1 varchar);" +
+                                      $"explain using text select * from {TableName};" +
+                                      "show parameters;" +
+                                      $"insert into {TableName} values ('str1');" +
+                                      $"update {TableName} set c1 = 'str2';" +
+                                      $"select * from {TableName};" +
+                                      $"desc table {TableName};" +
+                                      $"copy into @%{TableName} from {TableName};" +
+                                      $"list @%{TableName};" +
+                                      $"remove @%{TableName};" +
+                                      "create or replace temporary procedure P1() returns varchar language javascript as $$ return ''; $$;" +
+                                      "call p1();" +
+                                      $"use role {testConfig.role}";
+
+                    var stmtCount = 16;
+
+                    // Set statement count
+                    var stmtCountParam = cmd.CreateParameter();
+                    stmtCountParam.ParameterName = "MULTI_STATEMENT_COUNT";
+                    stmtCountParam.DbType = DbType.Int16;
+                    stmtCountParam.Value = stmtCount;
+                    cmd.Parameters.Add(stmtCountParam);
+
+                    DbDataReader reader = cmd.ExecuteReader();
+
+                    // at least one row in the first result set
+                    Assert.IsTrue(reader.Read());
+
+                    for (int i = 1; i < stmtCount; i++)
+                    {
+                        Assert.IsTrue(reader.NextResult());
+
+                        // at least one row in subsequent result sets
+                        Assert.IsTrue(reader.Read());
+                    }
+                    Assert.IsFalse(reader.NextResult());
+                    reader.Close();
                 }
 
                 conn.Close();

--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -236,17 +236,17 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     DbDataReader reader = cmd.ExecuteReader();
 
                     // result of create
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(0, reader.RecordsAffected);
 
                     // result of insert #1
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(1, reader.RecordsAffected);
 
                     // result of insert #2
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(2, reader.RecordsAffected);
 
                     // result of select
@@ -266,7 +266,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // result of drop
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(0, reader.RecordsAffected);
 
                     Assert.IsFalse(reader.NextResult());
@@ -382,7 +382,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // result of create
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(0, reader.RecordsAffected);
 
                     // result of explain
@@ -400,7 +400,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // result of insert
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(1, reader.RecordsAffected);
 
                     // result of describe
@@ -420,7 +420,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // result of create
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(0, reader.RecordsAffected);
 
                     // result of call
@@ -434,7 +434,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // result of use
                     Assert.IsTrue(reader.NextResult());
-                    Assert.IsFalse(reader.HasRows);
+                    Assert.IsTrue(reader.HasRows);
                     Assert.AreEqual(0, reader.RecordsAffected);
 
                     Assert.IsFalse(reader.NextResult());
@@ -571,6 +571,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     DbDataReader reader = cmd.ExecuteReader();
 
                     // at least one row in the first result set
+                    Assert.IsTrue(reader.HasRows);
                     Assert.IsTrue(reader.Read());
 
                     for (int i = 1; i < stmtCount; i++)
@@ -578,6 +579,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         Assert.IsTrue(reader.NextResult());
 
                         // at least one row in subsequent result sets
+                        Assert.IsTrue(reader.HasRows);
                         Assert.IsTrue(reader.Read());
                     }
                     Assert.IsFalse(reader.NextResult());

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -166,7 +166,7 @@ namespace Snowflake.Data.Client
             long total = 0;
             do
             {
-                if (resultSet.HasResultSet()) continue;
+                if (resultSet.IsDQL()) continue;
                 int count = resultSet.CalculateUpdateCount();
                 if (count < 0)
                 {
@@ -193,7 +193,7 @@ namespace Snowflake.Data.Client
             long total = 0;
             do
             {
-                if (resultSet.HasResultSet()) continue;
+                if (resultSet.IsDQL()) continue;
                 int count = resultSet.CalculateUpdateCount();
                 if (count < 0)
                 {

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -75,7 +75,7 @@ namespace Snowflake.Data.Client
         {
             get
             {
-                return resultSet.HasResultSet() && resultSet.HasRows();
+                return !resultSet.isClosed && resultSet.HasRows();
             }
         }
 

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -49,6 +49,7 @@ namespace Snowflake.Data.Core
                     }
                     break;
                 case SFStatementType.SELECT:
+                    // DbDataReader.RecordsAffected returns -1 for SELECT statement
                     updateCount = -1;
                     break;
                 default:
@@ -62,7 +63,7 @@ namespace Snowflake.Data.Core
             return (int)updateCount;
         }
 
-        internal static bool HasResultSet(this SFBaseResultSet resultSet)
+        internal static bool IsDQL(this SFBaseResultSet resultSet)
         {
             if (resultSet.isClosed) return false;
 

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Data.Core
                     {
                         updateCount += resultSet.GetInt64(i);
                     }
-
+                    resultSet.Rewind();
                     break;
                 case SFStatementType.COPY:
                     var index = resultSet.sfResultSetMetaData.GetColumnIndexByName("rows_loaded");


### PR DESCRIPTION
### Description
Enable result sets for DML.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
