### PR TITLE
Fix database property name in the `Connecting.md` doc

### DIFF
--- a/doc/Connecting.md
+++ b/doc/Connecting.md
@@ -132,7 +132,7 @@ Snowflake supports using [double quote identifiers](https://docs.snowflake.com/e
   ```cs
   string connectionString = String.Format(
     "account=testaccount; " +
-    "database=\"testDB\";"
+    "db=\"testDB\";"
   );
   ```
 - To include a `"` character as part of the value should be escaped using `\"\"`.
@@ -140,7 +140,7 @@ Snowflake supports using [double quote identifiers](https://docs.snowflake.com/e
   ```cs
   string connectionString = String.Format(
     "account=testaccount; " +
-    "database=\"\"\"test\"\"user\"\"\";" // DATABASE => ""test"db""
+    "db=\"\"\"test\"\"user\"\"\";" // DATABASE => ""test"db""
   );
   ```
 


### PR DESCRIPTION

### Description
The property should be `db`, but examples in the docs misleadingly state `database`.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
