### PR TITLE
SNOW-2139007 Clear query context cache before returning session to pool

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -288,7 +288,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var session = CreateSessionWithCurrentStartTime("account=testAccount;user=testUser;password=testPassword");
             var pool = SessionPool.CreateSessionCache();
             var contextElement = new QueryContextElement(123, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 1, "context");
-            var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new (contextElement) } };
+            var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new(contextElement) } };
             session.UpdateQueryContextCache(context);
             Assert.AreEqual(1, session.GetQueryContextRequest().Entries.Count);
 
@@ -308,7 +308,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var session = CreateSessionWithCurrentStartTime(connectionString);
             var pool = SessionPool.CreateSessionPool(connectionString, null, null, null);
             var contextElement = new QueryContextElement(123, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 1, "context");
-            var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new (contextElement) } };
+            var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new(contextElement) } };
             session.UpdateQueryContextCache(context);
             Assert.AreEqual(1, session.GetQueryContextRequest().Entries.Count);
 

--- a/Snowflake.Data/Core/QueryContextCache.cs
+++ b/Snowflake.Data/Core/QueryContextCache.cs
@@ -189,6 +189,14 @@ namespace Snowflake.Data.Core
             _logger.Debug($"clearCache() returns. Number of entries in cache now {_cacheSet.Count}");
         }
 
+        public void ClearCacheSafely()
+        {
+            lock (_qccLock)
+            {
+                ClearCache();
+            }
+        }
+
         public void SetCapacity(int cap)
         {
             // check without locking first for performance reason

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -528,6 +528,14 @@ namespace Snowflake.Data.Core
             }
         }
 
+        internal void ClearQueryContextCache()
+        {
+            if (!_disableQueryContextCache)
+            {
+                _queryContextCache.ClearCacheSafely();
+            }
+        }
+
         internal void UpdateQueryContextCache(ResponseQueryContext queryContext)
         {
             if (!_disableQueryContextCache)

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -527,6 +527,7 @@ namespace Snowflake.Data.Core.Session
                 return false;
             }
 
+            session.ClearQueryContextCache();
             var result = ReturnSessionToPool(session, ensureMinPoolSize);
             var wasSessionReturnedToPool = result.Item1;
             var sessionCreationTokens = result.Item2;


### PR DESCRIPTION
### Description
SNOW-2139007 Clear query context cache before returning session to pool.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
