### PR TITLE
Fix database property and Read method name in documentation

### DIFF
--- a/doc/Connecting.md
+++ b/doc/Connecting.md
@@ -135,7 +135,7 @@ Snowflake supports using [double quote identifiers](https://docs.snowflake.com/e
   ```cs
   string connectionString = String.Format(
     "account=testaccount; " +
-    "database=\"testDB\";"
+    "db=\"testDB\";"
   );
   ```
 - To include a `"` character as part of the value should be escaped using `\"\"`.
@@ -143,7 +143,7 @@ Snowflake supports using [double quote identifiers](https://docs.snowflake.com/e
   ```cs
   string connectionString = String.Format(
     "account=testaccount; " +
-    "database=\"\"\"test\"\"user\"\"\";" // DATABASE => ""test"db""
+    "db=\"\"\"test\"\"user\"\"\";" // DATABASE => ""test"db""
   );
   ```
 

--- a/doc/StageFiles.md
+++ b/doc/StageFiles.md
@@ -17,7 +17,7 @@ using (IDbConnection conn = new SnowflakeDbConnection())
 
 	    cmd.CommandText = "PUT file://some_data.csv @my_schema.my_stage AUTO_COMPRESS=TRUE";
 	    var reader = cmd.ExecuteReader();
-	    Assert.IsTrue(reader.read());
+	    Assert.IsTrue(reader.Read());
         Assert.DoesNotThrow(() => Guid.Parse(cmd.GetQueryId()));
     }
     catch (SnowflakeDbException e)
@@ -50,7 +50,7 @@ To use the command in a driver similar code can be executed in a client app:
 
 	    cmd.CommandText = "GET @my_schema.my_stage/stage_file.csv file://local_file.csv AUTO_COMPRESS=TRUE";
 	    var reader = cmd.ExecuteReader();
-	    Assert.IsTrue(reader.read()); // True on success, False if failure
+	    Assert.IsTrue(reader.Read()); // True on success, False if failure
         Assert.DoesNotThrow(() => Guid.Parse(cmd.GetQueryId()));
     }
     catch (SnowflakeDbException e)


### PR DESCRIPTION
### Description
Fix database property and Read method name in documentation

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
