### PR TITLE
SNOW-834807: Allow users to configure ServicePointManager.ConnectionLimit property

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -36,7 +36,7 @@ namespace Snowflake.Data.Tests.UnitTests
             .ThrowsAsync(new HttpRequestException("", new AuthenticationException()));
 
             var httpClient = HttpUtil.Instance.GetHttpClient(
-                new HttpClientConfig(false, "fakeHost", "fakePort", "user", "password", "fakeProxyList", false, false, 7),
+                new HttpClientConfig(false, "fakeHost", "fakePort", "user", "password", "fakeProxyList", false, false, 7, 20),
                 handler.Object);
 
             try
@@ -152,7 +152,8 @@ namespace Snowflake.Data.Tests.UnitTests
                 "localhost",
                 false,
                 false,
-                7
+                7,
+                20
             );
 
             // when
@@ -176,6 +177,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 null,
                 false,
                 false,
+                20,
                 0
             );
 

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -51,6 +51,37 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         }
 
         [Test]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(100)]
+        public void TestSettingConnectionLimitProperty(int expectedConnectionLimit)
+        {
+            // arrange
+            var connectionString = $"ACCOUNT=account;USER=test;PASSWORD=test;CONNECTION_LIMIT={expectedConnectionLimit}";
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, new SessionPropertiesContext());
+
+            // act
+            var extractedProperties = SFSessionHttpClientProperties.ExtractAndValidate(properties);
+
+            // assert
+            Assert.AreEqual(expectedConnectionLimit, extractedProperties._connectionLimit);
+        }
+
+        [Test]
+        public void TestSettingConnectionLimitPropertyToLessThan1()
+        {
+            // arrange
+            var connectionString = $"ACCOUNT=account;USER=test;PASSWORD=test;CONNECTION_LIMIT={0}";
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, new SessionPropertiesContext());
+
+            // act
+            var extractedProperties = SFSessionHttpClientProperties.ExtractAndValidate(properties);
+
+            // assert
+            Assert.AreEqual(SFSessionHttpClientProperties.DefaultConnectionLimit, extractedProperties._connectionLimit);
+        }
+
+        [Test]
         public void TestBuildHttpClientConfig()
         {
             // arrange

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -26,6 +26,7 @@ namespace Snowflake.Data.Core
             bool disableRetry,
             bool forceRetryOn404,
             int maxHttpRetries,
+            int connectionLimit,
             bool includeRetryReason = true)
         {
             CrlCheckEnabled = crlCheckEnabled;
@@ -38,6 +39,7 @@ namespace Snowflake.Data.Core
             ForceRetryOn404 = forceRetryOn404;
             MaxHttpRetries = maxHttpRetries;
             IncludeRetryReason = includeRetryReason;
+            ConnectionLimit = connectionLimit;
 
             ConfKey = string.Join(";",
                 new string[] {
@@ -50,7 +52,8 @@ namespace Snowflake.Data.Core
                     disableRetry.ToString(),
                     forceRetryOn404.ToString(),
                     maxHttpRetries.ToString(),
-                    includeRetryReason.ToString()});
+                    includeRetryReason.ToString(),
+                    connectionLimit.ToString()});
         }
 
         public readonly bool CrlCheckEnabled;
@@ -63,6 +66,7 @@ namespace Snowflake.Data.Core
         public readonly bool ForceRetryOn404;
         public readonly int MaxHttpRetries;
         public readonly bool IncludeRetryReason;
+        public readonly int ConnectionLimit;
 
         // Key used to identify the HttpClient with the configuration matching the settings
         public readonly string ConfKey;
@@ -113,7 +117,7 @@ namespace Snowflake.Data.Core
                 logger.Debug("Http client not registered. Adding.");
 
                 var httpClient = new HttpClient(
-                    new RetryHandler(SetupCustomHttpHandler(config, customHandler), config.DisableRetry, config.ForceRetryOn404, config.MaxHttpRetries, config.IncludeRetryReason))
+                    new RetryHandler(SetupCustomHttpHandler(config, customHandler), config.DisableRetry, config.ForceRetryOn404, config.MaxHttpRetries, config.IncludeRetryReason, config.ConnectionLimit))
                 {
                     Timeout = Timeout.InfiniteTimeSpan
                 };
@@ -335,13 +339,15 @@ namespace Snowflake.Data.Core
             private bool forceRetryOn404;
             private int maxRetryCount;
             private bool includeRetryReason;
+            private int connectionLimit;
 
-            internal RetryHandler(HttpMessageHandler innerHandler, bool disableRetry, bool forceRetryOn404, int maxRetryCount, bool includeRetryReason) : base(innerHandler)
+            internal RetryHandler(HttpMessageHandler innerHandler, bool disableRetry, bool forceRetryOn404, int maxRetryCount, bool includeRetryReason, int connectionLimit) : base(innerHandler)
             {
                 this.disableRetry = disableRetry;
                 this.forceRetryOn404 = forceRetryOn404;
                 this.maxRetryCount = maxRetryCount;
                 this.includeRetryReason = includeRetryReason;
+                this.connectionLimit = connectionLimit;
             }
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage,
@@ -358,7 +364,7 @@ namespace Snowflake.Data.Core
                 ServicePoint p = ServicePointManager.FindServicePoint(requestMessage.RequestUri);
                 p.Expect100Continue = false; // Saves about 100 ms per request
                 p.UseNagleAlgorithm = false; // Saves about 200 ms per request
-                p.ConnectionLimit = 20;      // Default value is 2, we need more connections for performing multiple parallel queries
+                p.ConnectionLimit = connectionLimit;    // Default value is 2, we need more connections for performing multiple parallel queries
 
                 TimeSpan httpTimeout = (TimeSpan)requestMessage.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY];
                 TimeSpan restTimeout = (TimeSpan)requestMessage.Properties[BaseRestRequest.REST_REQUEST_TIMEOUT_KEY];

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -133,6 +133,8 @@ namespace Snowflake.Data.Core
         WIFENTRARESOURCE,
         [SFSessionPropertyAttr(required = false, defaultValue = "false")]
         OAUTHENABLESINGLEUSEREFRESHTOKENS,
+        [SFSessionPropertyAttr(required = false, defaultValue = "20")]
+        CONNECTION_LIMIT,
     }
 
     class SFSessionPropertyAttr : Attribute


### PR DESCRIPTION
### Description
Allow users to configure ServicePointManager.ConnectionLimit property

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
