### PR TITLE
SNOW-2295539: Set noisy log info messages to debug (#1227)

### DIFF
--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -95,7 +95,7 @@ namespace Snowflake.Data.Core
 
         public async Task<BaseResultChunk> GetNextChunkAsync()
         {
-            logger.Info($"NextChunkToConsume: {nextChunkToConsumeIndex}, NextChunkToDownload: {nextChunkToDownloadIndex}");
+            logger.Debug($"NextChunkToConsume: {nextChunkToConsumeIndex}, NextChunkToDownload: {nextChunkToDownloadIndex}");
             if (nextChunkToConsumeIndex < chunkInfos.Count)
             {
                 Task<BaseResultChunk> chunk = taskQueues[nextChunkToConsumeIndex % prefetchSlot];
@@ -211,7 +211,7 @@ namespace Snowflake.Data.Core
                     }
                 }
             } while (retry);
-            logger.Info($"Succeed downloading chunk #{chunk.ChunkIndex}");
+            logger.Debug($"Succeed downloading chunk #{chunk.ChunkIndex}");
             return chunk;
         }
 


### PR DESCRIPTION
### Description
Have changed 2 noisy info logs to debug - it makes sense looking at their content and the fact that a higher level function is using debug level to log the chunks it downloads

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
