### PR TITLE
Import TimeProvider in a more direct way to avoid errors when changing targets

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Revocation/CertificateRevocationVerifierTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CertificateRevocationVerifierTest.cs
@@ -10,6 +10,7 @@ using Snowflake.Data.Core.Rest;
 using Snowflake.Data.Core.Revocation;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Tests.Util;
+using TimeProvider = Snowflake.Data.Core.Tools.TimeProvider;
 
 namespace Snowflake.Data.Tests.UnitTests.Revocation
 {
@@ -29,7 +30,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             MockByteResponseForGet(restRequester, DigiCertCrlUrl2, crlBytes);
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
             var environmentOperation = new Mock<EnvironmentOperations>();
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
 
             // act
             var result = verifier.CheckCertRevocation(certificate, expectedCrlUrls);
@@ -51,7 +52,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             MockErrorResponseForGet(restRequester, DigiCertCrlUrl2, NotFoundHttpExceptionProvider);
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
             var environmentOperation = new Mock<EnvironmentOperations>();
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
 
             // act
             var result = verifier.CheckCertRevocation(certificate, expectedCrlUrls);
@@ -74,7 +75,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             MockByteResponseForGet(restRequester, DigiCertCrlUrl1, notParsableCrlBytes);
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
             var environmentOperation = new Mock<EnvironmentOperations>();
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
 
             // act
             var result = verifier.CheckCertRevocation(certificate, expectedCrlUrls);
@@ -100,7 +101,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             var restRequester = new Mock<IRestRequester>();
             var environmentOperation = new Mock<EnvironmentOperations>();
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
 
             // act
             var result = verifier.CheckChainRevocation(chain);
@@ -125,7 +126,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             var restRequester = new Mock<IRestRequester>();
             var environmentOperation = new Mock<EnvironmentOperations>();
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
 
             // act
             var isShortLived = verifier.IsShortLived(certificate);
@@ -146,7 +147,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             var restRequester = new Mock<IRestRequester>();
             var crlRepository = new CrlRepository(config.EnableCRLInMemoryCaching, config.EnableCRLDiskCaching);
             var environmentOperation = new Mock<EnvironmentOperations>();
-            var verifier = new CertificateRevocationVerifier(config, Core.Tools.TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
+            var verifier = new CertificateRevocationVerifier(config, TimeProvider.Instance, restRequester.Object, CertificateCrlDistributionPointsExtractor.Instance, new CrlParser(environmentOperation.Object), crlRepository);
             var crl = new Crl { IssuerName = issuerName };
 
             // act

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetriever.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetriever.cs
@@ -6,6 +6,7 @@ using Amazon.Runtime;
 using Newtonsoft.Json;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
+using TimeProvider = Snowflake.Data.Core.Tools.TimeProvider;
 
 namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
 {

--- a/Snowflake.Data/Core/Authenticator/WorkloadIdentityFederationAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkloadIdentityFederationAuthenticator.cs
@@ -5,6 +5,7 @@ using Snowflake.Data.Client;
 using Snowflake.Data.Core.Authenticator.WorkflowIdentity;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
+using TimeProvider = Snowflake.Data.Core.Tools.TimeProvider;
 
 namespace Snowflake.Data.Core.Authenticator
 {

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Snowflake.Data.Core.Authenticator;
 using Snowflake.Data.Core.Revocation;
 using Snowflake.Data.Core.Tools;
+using TimeProvider = Snowflake.Data.Core.Tools.TimeProvider;
 
 namespace Snowflake.Data.Core
 {

--- a/Snowflake.Data/Core/Revocation/CertificateRevocationVerifier.cs
+++ b/Snowflake.Data/Core/Revocation/CertificateRevocationVerifier.cs
@@ -7,8 +7,8 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Asn1.X509;
 using Snowflake.Data.Core.Rest;
-using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
+using TimeProvider = Snowflake.Data.Core.Tools.TimeProvider;
 
 namespace Snowflake.Data.Core.Revocation
 {


### PR DESCRIPTION
### Description
Import TimeProvider in a more direct way to avoid errors when changing targets

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
