### PR TITLE
SNOW-2205602 Improve error message handling

### DIFF
--- a/Snowflake.Data/Logger/SFConsoleAppender.cs
+++ b/Snowflake.Data/Logger/SFConsoleAppender.cs
@@ -16,7 +16,8 @@ namespace Snowflake.Data.Log
                 Console.Write(formattedMessage);
                 if (ex != null)
                 {
-                    Console.WriteLine(ex.ToString());
+                    var maskedExceptionString = SecretDetector.MaskSecrets(ex.ToString()).maskedText;
+                    Console.WriteLine(maskedExceptionString);
                 }
             }
             catch (Exception)

--- a/Snowflake.Data/Logger/SFLoggerPair.cs
+++ b/Snowflake.Data/Logger/SFLoggerPair.cs
@@ -19,8 +19,8 @@ namespace Snowflake.Data.Log
             if (!IsDebugEnabled())
                 return;
             message = SecretDetector.MaskSecrets(message).maskedText;
-            _snowflakeLogger.Debug(message, ex);
-            SFLoggerFactory.s_customLogger.LogDebug(FormatBrackets(message), ex);
+            _snowflakeLogger.Debug(message, new MaskedException(ex));
+            SFLoggerFactory.s_customLogger.LogDebug(FormatBrackets(message), new MaskedException(ex));
         }
 
         public void Info(string message, Exception ex = null)
@@ -28,8 +28,8 @@ namespace Snowflake.Data.Log
             if (!IsInfoEnabled())
                 return;
             message = SecretDetector.MaskSecrets(message).maskedText;
-            _snowflakeLogger.Info(message, ex);
-            SFLoggerFactory.s_customLogger.LogInformation(FormatBrackets(message), ex);
+            _snowflakeLogger.Info(message, new MaskedException(ex));
+            SFLoggerFactory.s_customLogger.LogInformation(FormatBrackets(message), new MaskedException(ex));
         }
 
         public void Warn(string message, Exception ex = null)
@@ -37,8 +37,8 @@ namespace Snowflake.Data.Log
             if (!IsWarnEnabled())
                 return;
             message = SecretDetector.MaskSecrets(message).maskedText;
-            _snowflakeLogger.Warn(message, ex);
-            SFLoggerFactory.s_customLogger.LogWarning(FormatBrackets(message), ex);
+            _snowflakeLogger.Warn(message, new MaskedException(ex));
+            SFLoggerFactory.s_customLogger.LogWarning(FormatBrackets(message), new MaskedException(ex));
         }
 
         public void Error(string message, Exception ex = null)
@@ -46,8 +46,8 @@ namespace Snowflake.Data.Log
             if (!IsErrorEnabled())
                 return;
             message = SecretDetector.MaskSecrets(message).maskedText;
-            _snowflakeLogger.Error(message, ex);
-            SFLoggerFactory.s_customLogger.LogError(FormatBrackets(message), ex);
+            _snowflakeLogger.Error(message, new MaskedException(ex));
+            SFLoggerFactory.s_customLogger.LogError(FormatBrackets(message), new MaskedException(ex));
         }
 
         public bool IsDebugEnabled()
@@ -98,6 +98,25 @@ namespace Snowflake.Data.Log
         {
             var sb = new StringBuilder(message).Replace("{", "{{").Replace("}", "}}");
             return sb.ToString();
+        }
+
+        private class MaskedException : Exception
+        {
+            private readonly Exception _innerException;
+
+            public MaskedException(Exception innerException)
+            {
+                _innerException = innerException;
+            }
+
+            public override string ToString()
+            {
+                return SecretDetector.MaskSecrets(_innerException?.ToString()).maskedText;
+            }
+
+            public override string Message => SecretDetector.MaskSecrets(_innerException?.Message).maskedText;
+
+            public override string StackTrace => SecretDetector.MaskSecrets(_innerException?.StackTrace).maskedText;
         }
     }
 }

--- a/Snowflake.Data/Logger/SFRollingFileAppender.cs
+++ b/Snowflake.Data/Logger/SFRollingFileAppender.cs
@@ -36,17 +36,18 @@ namespace Snowflake.Data.Log
         public void Append(string logLevel, string message, Type type, Exception ex = null)
         {
             var formattedMessage = PatternLayout.Format(logLevel, message, type);
+            var maskedExceptionString = SecretDetector.MaskSecrets(ex?.ToString()).maskedText;
             try
             {
                 long fileSize;
                 if (_isWindows)
                 {
-                    _fileOperations.Append(LogFilePath, formattedMessage, ex?.ToString());
+                    _fileOperations.Append(LogFilePath, formattedMessage, maskedExceptionString);
                     fileSize = LogFileSize();
                 }
                 else
                 {
-                    fileSize = _unixOperations.AppendToFile(LogFilePath, formattedMessage, ex?.ToString(),
+                    fileSize = _unixOperations.AppendToFile(LogFilePath, formattedMessage, maskedExceptionString,
                         EasyLoggerValidator.Instance.ValidateLogFilePermissions, EasyLoggingStarter.Instance._logFileUnixPermissions);
                 }
                 if (fileSize > MaximumFileSizeInBytes)


### PR DESCRIPTION
### Description
[SNOW-2205602](https://snowflakecomputing.atlassian.net/browse/SNOW-2205602) Mask secrets in exceptions

**SFLoggerPair**
- Wraps exceptions in `MaskedException` before logging
 - Applied when using `SFLoggerFactory.GetLogger`


**Appenders**
- Provides protection even if `MaskedException` wrapper is omitted (e.g. in tests) and appender is called explicitly
- Additional layer of protection if an appender is ever called explicitly in the production code


### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name


[SNOW-2205602]: https://snowflakecomputing.atlassian.net/browse/SNOW-2205602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ