### PR TITLE
SNOW-2473789 Fix wiremock tests cleanup

### DIFF
--- a/Snowflake.Data.Tests/Util/WiremockRunner.cs
+++ b/Snowflake.Data.Tests/Util/WiremockRunner.cs
@@ -146,7 +146,18 @@ namespace Snowflake.Data.Tests.Util
 
         public void Stop()
         {
-            _process?.Kill();
+            if (_process != null && !_process.HasExited)
+            {
+                try
+                {
+                    _process.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited, ignore
+                }
+                _process = null;
+            }
             IsAvailable = false;
         }
 


### PR DESCRIPTION
### Description
[SNOW-2473789](https://snowflakecomputing.atlassian.net/browse/SNOW-2473789) Fix wiremock tests cleanup

**Problem**: Tests were failing because the `WiremockRunner` destructor tried to kill a process that had already exited.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name


[SNOW-2473789]: https://snowflakecomputing.atlassian.net/browse/SNOW-2473789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ