### PR TITLE
SNOW-3026576 Fix `System.IndexOutOfRangeException` when processing empty Arrow batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### For the official .NET Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/dotnet
 
 # Changelog
+- v5.4.0
+    - Bug fix: Fixed IndexOutOfRangeException in Arrow result processing when empty batches are returned by Snowflake backend.
 - v5.3.0
     - Introduced shared library([source code](https://github.com/snowflakedb/universal-driver/tree/main/sf_mini_core)) for extended telemetry to identify and prepare testing platform for native rust extensions.
 - v5.2.1


### PR DESCRIPTION
SNOW-3026576 Fix `System.IndexOutOfRangeException` when processing empty Arrow batches


### Description
When processing Arrow format results, ArrowResultChunk.Next() could incorrectly return true after transitioning to an empty batch (a batch with 0 rows). Subsequent calls to ExtractCell() would then throw IndexOutOfRangeException because there's no data at row index 0 in an empty batch.


### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
