### PR TITLE
SNOW-3051131: Bump AWSSDK.S3 to 4.0.18.2 to resolve GHSA-9cvc-h2w8-phrp

### DIFF
--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net481;net8.0;net8.0-windows</TargetFrameworks>
     <Title>Snowflake.Data</Title>
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.Arrow" Version="14.0.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.18.2" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Azure.Storage.Common" Version="12.12.0" />


### PR DESCRIPTION
### Description
Update AWSSDK.S3 from 4.0.4 to 4.0.18.2, which transitively resolves
AWSSDK.Core to 4.0.3.12 (patched in 4.0.3.3+), addressing the low-severity
security advisory CVE-2026-22611 regarding improper region parameter validation.

Closes #1312

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
