### PR TITLE
Replace obsolete HttpRequestMessage.Properties with extension methods that use Options on .NET 5+

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/CertificateRevocationIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/CertificateRevocationIT.cs
@@ -58,8 +58,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var host = string.IsNullOrEmpty(testConfig.host) ? $"{testConfig.account}.snowflakecomputing.com" : testConfig.host;
             var request = new HttpRequestMessage(HttpMethod.Post, $"https://{host}/queries/v1/abort-request");
             var timeout = TimeSpan.FromSeconds(30);
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, timeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, timeout);
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, timeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, timeout);
             return request;
         }
     }

--- a/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
+++ b/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
@@ -32,11 +32,7 @@ namespace Snowflake.Data.Tests.Mock
                 _forceTimeoutForNonLoginRequestsOnly && !message.RequestUri.AbsolutePath.Equals(RestPath.SF_LOGIN_PATH))
             {
                 // Override the http timeout and set to 1ms to force all http request to timeout and retry
-                // Disable warning as this is the way to be compliant with netstandard2.0
-                // API reference: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestmessage?view=netstandard-2.0
-#pragma warning disable CS0618 // Type or member is obsolete
-                message.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY] = TimeSpan.FromTicks(0);
-#pragma warning restore CS0618 // Type or member is obsolete
+                message.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, TimeSpan.FromTicks(0));
             }
 
             return await (base.SendAsync(message, restTimeout, externalCancellationToken).ConfigureAwait(false));

--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -19,12 +19,8 @@ namespace Snowflake.Data.Tests.UnitTests
         public async Task TestNonRetryableHttpExceptionThrowsError()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, new Uri("https://authenticationexceptiontest.com/"));
-            // Disable warning as this is the way to be compliant with netstandard2.0
-            // API reference: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestmessage?view=netstandard-2.0
-#pragma warning disable CS0618 // Type or member is obsolete
-            request.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY] = Timeout.InfiniteTimeSpan;
-            request.Properties[BaseRestRequest.REST_REQUEST_TIMEOUT_KEY] = Timeout.InfiniteTimeSpan;
-#pragma warning restore CS0618 // Type or member is obsolete
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, Timeout.InfiniteTimeSpan);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, Timeout.InfiniteTimeSpan);
 
             var handler = new Mock<DelegatingHandler>();
             handler.Protected()

--- a/Snowflake.Data.Tests/UnitTests/RedirectUnitTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RedirectUnitTest.cs
@@ -79,10 +79,8 @@ namespace Snowflake.Data.Tests.UnitTests
         private HttpRequestMessage CreateQueryRequest()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, _runner.WiremockBaseHttpsUrl + "/queries/v1/query-request?requestId=abc");
-#pragma warning disable CS0618 // Type or member is obsolete
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, TimeSpan.FromSeconds(BaseRestRequest.s_defaultHttpSecondsTimeout));
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, TimeSpan.FromSeconds(BaseRestRequest.s_defaultRestRetrySecondsTimeout));
-#pragma warning restore CS0618 // Type or member is obsolete
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, TimeSpan.FromSeconds(BaseRestRequest.s_defaultHttpSecondsTimeout));
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, TimeSpan.FromSeconds(BaseRestRequest.s_defaultRestRetrySecondsTimeout));
             return request;
         }
 

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAzureAttestationRetriever.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAzureAttestationRetriever.cs
@@ -130,8 +130,8 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
             {
                 request.Headers.Add(keyValuePair.Key, keyValuePair.Value);
             }
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
             return request;
         }
     }

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityGcpAttestationRetriever.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityGcpAttestationRetriever.cs
@@ -184,8 +184,8 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
             var uri = new Uri(url);
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Add("Metadata-Flavor", "Google");
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
             return request;
         }
 

--- a/Snowflake.Data/Core/HttpRequestMessageExtensions.cs
+++ b/Snowflake.Data/Core/HttpRequestMessageExtensions.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+
+namespace Snowflake.Data.Core
+{
+    /// <summary>
+    /// Extension methods for <see cref="HttpRequestMessage"/> that abstract away the
+    /// difference between <c>Properties</c> (netstandard2.0 / .NET Framework) and
+    /// <c>Options</c> (.NET 5+), avoiding the CS0618 obsolete-member warning.
+    /// </summary>
+    internal static class HttpRequestMessageExtensions
+    {
+        internal static void SetOption(this HttpRequestMessage message, string key, object value)
+        {
+#if NET5_0_OR_GREATER
+            message.Options.Set(new HttpRequestOptionsKey<object>(key), value);
+#else
+            message.Properties[key] = value;
+#endif
+        }
+
+        internal static object GetOption(this HttpRequestMessage message, string key)
+        {
+#if NET5_0_OR_GREATER
+            message.Options.TryGetValue(new HttpRequestOptionsKey<object>(key), out var value);
+            return value;
+#else
+            return message.Properties[key];
+#endif
+        }
+    }
+}

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -499,8 +499,8 @@ namespace Snowflake.Data.Core
                 p.UseNagleAlgorithm = false; // Saves about 200 ms per request
                 p.ConnectionLimit = connectionLimit;    // Default value is 2, we need more connections for performing multiple parallel queries
 
-                TimeSpan httpTimeout = (TimeSpan)requestMessage.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY];
-                TimeSpan restTimeout = (TimeSpan)requestMessage.Properties[BaseRestRequest.REST_REQUEST_TIMEOUT_KEY];
+                TimeSpan httpTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY);
+                TimeSpan restTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY);
 
                 if (logger.IsDebugEnabled())
                 {

--- a/Snowflake.Data/Core/Rest/BaseOAuthAccessTokenRequest.cs
+++ b/Snowflake.Data/Core/Rest/BaseOAuthAccessTokenRequest.cs
@@ -31,8 +31,8 @@ namespace Snowflake.Data.Core.Rest
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", authorizationHeader);
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             requestMessage.Content = GetContent();
-            requestMessage.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-            requestMessage.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+            requestMessage.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            requestMessage.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
             return requestMessage;
         }
 

--- a/Snowflake.Data/Core/Rest/RestRequestWrapper.cs
+++ b/Snowflake.Data/Core/Rest/RestRequestWrapper.cs
@@ -18,6 +18,6 @@ namespace Snowflake.Data.Core.Rest
         }
 
         public TimeSpan GetRestTimeout() =>
-            (TimeSpan)_httpRequestMessage.Properties[REST_REQUEST_TIMEOUT_KEY];
+            (TimeSpan)_httpRequestMessage.GetOption(REST_REQUEST_TIMEOUT_KEY);
     }
 }

--- a/Snowflake.Data/Core/RestRequest.cs
+++ b/Snowflake.Data/Core/RestRequest.cs
@@ -51,8 +51,8 @@ namespace Snowflake.Data.Core
         protected HttpRequestMessage newMessage(HttpMethod method, Uri url)
         {
             HttpRequestMessage message = new HttpRequestMessage(method, url);
-            message.Properties[HTTP_REQUEST_TIMEOUT_KEY] = HttpTimeout;
-            message.Properties[REST_REQUEST_TIMEOUT_KEY] = RestTimeout;
+            message.SetOption(HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            message.SetOption(REST_REQUEST_TIMEOUT_KEY, RestTimeout);
             return message;
         }
 

--- a/Snowflake.Data/Core/Revocation/CertificateRevocationVerifier.cs
+++ b/Snowflake.Data/Core/Revocation/CertificateRevocationVerifier.cs
@@ -369,8 +369,8 @@ namespace Snowflake.Data.Core.Revocation
         private Crl FetchCrl(string crlUrl)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, crlUrl);
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, _httpTimeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, _httpTimeout);
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, _httpTimeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, _httpTimeout);
             byte[] crlBytes = null;
             DateTime now;
             try


### PR DESCRIPTION
### Description
Replace all usages of the obsolete `HttpRequestMessage.Properties` with new `SetOption`/`GetOption` extension methods that use `Options` on .NET 5+ and fall back to `Properties` on `netstandard2.0`/`net481`

`#pragma warning disable CS0618` somehow didn't worked

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
