### PR TITLE
SNOW-3081179 Start minicore loading earlier

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -13,6 +13,11 @@ namespace Snowflake.Data.Client
     [System.ComponentModel.DesignerCategory("Code")]
     public class SnowflakeDbConnection : DbConnection
     {
+        static SnowflakeDbConnection()
+        {
+            SFEnvironment.StartMinicoreLoading();
+        }
+
         private SFLogger logger = SFLoggerFactory.GetLogger<SnowflakeDbConnection>();
 
         internal SFSession SfSession { get; set; }

--- a/Snowflake.Data/Core/RestParams.cs
+++ b/Snowflake.Data/Core/RestParams.cs
@@ -66,14 +66,17 @@ namespace Snowflake.Data.Core
     {
         internal static bool MinicoreDisabled { get; set; }
 
-        static SFEnvironment()
+        internal static void StartMinicoreLoading()
         {
-            MinicoreDisabled = IsMinicoreDisabled();
             if (!MinicoreDisabled)
             {
                 SfMiniCore.StartLoading();
             }
+        }
 
+        static SFEnvironment()
+        {
+            MinicoreDisabled = IsMinicoreDisabled();
             ClientEnv = new LoginRequestClientEnv()
             {
                 processName = System.Diagnostics.Process.GetCurrentProcess().ProcessName,


### PR DESCRIPTION
## Start minicore loading earlier to reduce "still loading" telemetry

### Problem

The minicore native library load (`Task.Run`) and the telemetry read (`CloneForSession()`) were both triggered in the same call chain — when `BaseAuthenticator` is constructed during `Open()`. This left zero time for the background task to complete, causing most login requests to report `CORE_LOAD_ERROR: "Minicore is still loading"`.

### Fix

Invoke `SFEnvironment.StartMinicoreLoading()` from `SnowflakeDbConnection`'s static constructor so the background load begins when the connection type is first referenced, not at authentication time. This gives the task the gap between `new SnowflakeDbConnection()` and `Open()` to complete.

### Notes

- `SfMiniCore.StartLoading()` is idempotent (lock + null check), so multiple calls are safe.
- No behaviour change, no concurrency impact, no performance cost.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
