### PR TITLE
add tracing

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -1,11 +1,12 @@
-using System;
 using Snowflake.Data.Core;
-using System.Data.Common;
-using System.Data;
+using Snowflake.Data.Log;
+using Snowflake.Data.Telemetry;
+using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Snowflake.Data.Log;
 
 namespace Snowflake.Data.Client
 {
@@ -161,6 +162,9 @@ namespace Snowflake.Data.Client
 
         public override int ExecuteNonQuery()
         {
+            using var activity = connection.StartActivity("ExecuteNonQuery");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteNonQuery");
             SFBaseResultSet resultSet = ExecuteInternal();
             long total = 0;
@@ -186,6 +190,9 @@ namespace Snowflake.Data.Client
 
         public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("ExecuteNonQueryAsync");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteNonQueryAsync");
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -213,6 +220,9 @@ namespace Snowflake.Data.Client
 
         public override object ExecuteScalar()
         {
+            using var activity = connection.StartActivity("ExecuteScalar");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteScalar");
             SFBaseResultSet resultSet = ExecuteInternal();
 
@@ -224,6 +234,9 @@ namespace Snowflake.Data.Client
 
         public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("ExecuteScalarAsync");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteScalarAsync");
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -259,6 +272,9 @@ namespace Snowflake.Data.Client
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
+            using var activity = connection.StartActivity("ExecuteDbDataReader");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteDbDataReader");
             SFBaseResultSet resultSet = ExecuteInternal();
             return new SnowflakeDbDataReader(this, resultSet);
@@ -266,6 +282,9 @@ namespace Snowflake.Data.Client
 
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("ExecuteDbDataReaderAsync");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteDbDataReaderAsync");
             try
             {
@@ -286,6 +305,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query id.</returns>
         public string ExecuteInAsyncMode()
         {
+            using var activity = connection.StartActivity("ExecuteInAsyncMode");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteInAsyncMode");
             SFBaseResultSet resultSet = ExecuteInternal(asyncExec: true);
             return resultSet.queryId;
@@ -299,6 +321,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query id.</returns>
         public async Task<string> ExecuteAsyncInAsyncMode(CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("ExecuteAsyncInAsyncMode");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"ExecuteAsyncInAsyncMode");
             var resultSet = await ExecuteInternalAsync(cancellationToken, asyncExec: true).ConfigureAwait(false);
             return resultSet.queryId;
@@ -311,6 +336,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query status.</returns>
         public QueryStatus GetQueryStatus(string queryId)
         {
+            using var activity = connection.StartActivity("GetQueryStatus");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"GetQueryStatus");
             return _queryResultsAwaiter.GetQueryStatus(connection, queryId);
         }
@@ -323,6 +351,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query status.</returns>
         public async Task<QueryStatus> GetQueryStatusAsync(string queryId, CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("GetQueryStatusAsync");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"GetQueryStatusAsync");
             return await _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken);
         }
@@ -334,6 +365,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query results.</returns>
         public DbDataReader GetResultsFromQueryId(string queryId)
         {
+            using var activity = connection.StartActivity("GetResultsFromQueryId");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"GetResultsFromQueryId");
 
             Task task = _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, CancellationToken.None, false);
@@ -352,6 +386,9 @@ namespace Snowflake.Data.Client
         /// <returns>The query results.</returns>
         public async Task<DbDataReader> GetResultsFromQueryIdAsync(string queryId, CancellationToken cancellationToken)
         {
+            using var activity = connection.StartActivity("GetResultsFromQueryIdAsync");
+            activity?.SetQuery(CommandText);
+
             logger.Debug($"GetResultsFromQueryIdAsync");
 
             await _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.Session;
 using Snowflake.Data.Log;
+using Snowflake.Data.Telemetry;
 
 namespace Snowflake.Data.Client
 {
@@ -270,6 +271,7 @@ namespace Snowflake.Data.Client
 
         public override void Open()
         {
+            using var activity = this.StartActivity(ActivitySourceHelper.OperationConnect);
             logger.Debug("Open Connection.");
             if (_connectionState != ConnectionState.Closed)
             {
@@ -291,10 +293,14 @@ namespace Snowflake.Data.Client
                 if (SfSession == null)
                     throw new SnowflakeDbException(SFError.INTERNAL_ERROR, "Could not open session");
                 logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
+                activity?.SetTag(ActivitySourceHelper.Tags.DbSystem, "snowflake");
+                activity?.SetTag(ActivitySourceHelper.Tags.SessionId, SfSession.sessionId);
                 OnSessionEstablished();
+                activity?.SetSuccess();
             }
             catch (Exception e)
             {
+                activity?.SetException(e);
                 // Otherwise when Dispose() is called, the close request would timeout.
                 _connectionState = ConnectionState.Closed;
                 logger.Error("Unable to connect: ", e);
@@ -320,6 +326,7 @@ namespace Snowflake.Data.Client
 
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
+            var activity = this.StartActivity(ActivitySourceHelper.OperationConnect);
             logger.Debug("Open Connection Async.");
             if (_connectionState != ConnectionState.Closed)
             {
@@ -345,6 +352,7 @@ namespace Snowflake.Data.Client
                         Exception sfSessionEx = previousTask.Exception;
                         _connectionState = ConnectionState.Closed;
                         logger.Error("Unable to connect", sfSessionEx);
+                        activity?.SetException(sfSessionEx);
                         throw new SnowflakeDbException(
                            sfSessionEx,
                            SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
@@ -353,6 +361,7 @@ namespace Snowflake.Data.Client
                     }
                     else if (previousTask.IsCanceled)
                     {
+                        activity?.Stop();
                         _connectionState = ConnectionState.Closed;
                         logger.Debug("Connection canceled");
                         throw new TaskCanceledException("Connecting was cancelled");
@@ -363,6 +372,7 @@ namespace Snowflake.Data.Client
                         SfSession = previousTask.Result;
                         logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
                         OnSessionEstablished();
+                        activity.SetSuccess();
                     }
                 }, TaskContinuationOptions.None); // this continuation should be executed always (even if the whole operation was canceled) because it sets the proper state of the connection
         }

--- a/Snowflake.Data/Telemetry/ActivitySourceHelper.cs
+++ b/Snowflake.Data/Telemetry/ActivitySourceHelper.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using Snowflake.Data.Client;
+
+namespace Snowflake.Data.Telemetry
+{
+    /// <summary>
+    /// Central ActivitySource for Snowflake connector tracing.
+    /// This class manages all tracing activities for the connector.
+    /// </summary>
+    internal static class ActivitySourceHelper
+    {
+        // Common span names
+        public const string OperationConnect = "snowflake.connection.open";
+
+        public static class Tags
+        {
+            public const string DbSystem = "db.system";
+            public const string DbName = "db.name";
+            public const string DbStatement = "db.statement";
+            public const string DbWarehouse = "db.warehouse";
+            public const string DbRole = "db.role";
+            public const string StatusCode = "";
+
+            public const string SessionId = "snowflake.session.id";
+        }
+
+        internal const string ActivitySourceName = "Snowflake.Data";
+        internal const int StatementMaxLen = 300;
+
+        private static readonly ActivitySource activitySource = CreateActivitySource();
+
+        internal static Activity? StartActivity(this SnowflakeDbConnection connection, string name)
+        {
+            if (connection is null) throw new ArgumentNullException(nameof(connection));
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+
+            var activity = activitySource.StartActivity(name, ActivityKind.Client);
+
+            if (activity is null)
+                return null;
+
+            activity.SetTag(Tags.DbWarehouse, connection.SfSession.warehouse);
+            activity.SetTag(Tags.DbRole, connection.SfSession.role);
+            activity.SetTag(Tags.DbName, connection.Database);
+            return activity;
+        }
+
+        internal static void SetQuery(this Activity activity, string sql)
+        {
+            if (activity is null || sql is null)
+                return;
+            if (sql.Length > StatementMaxLen)
+            {
+                sql = sql.Substring(0, StatementMaxLen);
+            }
+            activity.SetTag(Tags.DbStatement, sql);
+        }
+
+        internal static void SetSuccess(this Activity activity)
+        {
+        #if NET6_0_OR_GREATER
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        #endif
+            activity?.SetTag(Tags.StatusCode, "OK");
+            activity?.Stop();
+        }
+
+        internal static void SetException(this Activity activity, Exception exception)
+        {
+            if (exception is null) throw new ArgumentNullException(nameof(exception));
+
+            var description = exception.Message;
+
+            #if NET6_0_OR_GREATER
+                activity?.SetStatus(ActivityStatusCode.Error, description);
+            #endif
+
+            activity?.SetTag("otel.status_code", "ERROR");
+            activity?.SetTag("otel.status_description", description);
+            activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
+            {
+                { "exception.type", exception?.GetType().FullName },
+                { "exception.message", exception?.Message },
+            }));
+            activity?.Stop();
+        }
+
+        private static ActivitySource CreateActivitySource()
+        {
+            var assembly = typeof(ActivitySourceHelper).Assembly;
+            var version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            return new ActivitySource(ActivitySourceName, version);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Hi all,

While monitoring our .NET services, we noticed a significant gap in our traces regarding Snowflake operations. To solve this, I’m proposing the integration of OpenTelemetry Tracing into Snowflake.Data.

The goal: Provide native instrumentation for command execution and connection management.

I have a working draft of the implementation. Before I spend more time on refinement and unit tests, I wanted to check if the maintainers are open to adding OTel support to the core library. If so, I’ll finalize the PR for review.

Thanks!

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
