### PR TITLE
SNOW-3007075 Inject SPCS_TOKEN into login request when running in SPCS container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.5.0
+    - Include `SPCS_TOKEN` in login requests when running inside an SPCS container (`SNOWFLAKE_RUNNING_INSIDE_SPCS` env var set).
     - Extended login-request telemetry with cloud platform and environment detection (AWS Lambda, EC2, Azure VM/Functions, GCE/Cloud Run, GitHub Actions). Detection runs once at startup in the background within a 200ms timeout. Can be disabled via the `SNOWFLAKE_DISABLE_PLATFORM_DETECTION` environment variable.
     - Added `workloadIdentityImpersonationPath` config option for `authenticator=WORKLOAD_IDENTITY` allowing workloads to authenticate as a different identity through transitive service account impersonation.
     - Added `HonorSessionTimezone` connection parameter (default: `false`). When set to `true`, TIMESTAMP_LTZ values honor the session TIMEZONE parameter (`ALTER SESSION SET TIMEZONE`) instead of using the local machine timezone. This will become the default behavior in a future major release.

--- a/Snowflake.Data.Tests/UnitTests/Tools/SpcsTokenProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/SpcsTokenProviderTest.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Data.Core.Tools;
+
+namespace Snowflake.Data.Tests.UnitTests.Tools
+{
+    [TestFixture]
+    public class SpcsTokenProviderTest
+    {
+        [ThreadStatic]
+        private static Mock<FileOperations> t_fileOperations;
+
+        [ThreadStatic]
+        private static Mock<EnvironmentOperations> t_environmentOperations;
+
+        [ThreadStatic]
+        private static SpcsTokenProvider t_provider;
+
+        [SetUp]
+        public void Setup()
+        {
+            t_fileOperations = new Mock<FileOperations>();
+            t_environmentOperations = new Mock<EnvironmentOperations>();
+            t_provider = new SpcsTokenProvider(t_fileOperations.Object, t_environmentOperations.Object);
+        }
+
+        [Test]
+        public void TestReturnsNullWhenRunningInsideSpcsEnvVarIsNotSet()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns((string)null);
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+            t_fileOperations.Verify(f => f.ReadAllText(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void TestReturnsNullWhenRunningInsideSpcsEnvVarIsEmpty()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("");
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+            t_fileOperations.Verify(f => f.ReadAllText(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void TestReturnsTokenFromDefaultPath()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Returns("my-spcs-token");
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.AreEqual("my-spcs-token", token);
+        }
+
+        [Test]
+        public void TestTrimsWhitespaceFromToken()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Returns("  my-spcs-token\n");
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.AreEqual("my-spcs-token", token);
+        }
+
+        [Test]
+        public void TestReturnsNullWhenFileDoesNotExist()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Throws(new FileNotFoundException("File not found", SpcsTokenProvider.DefaultSpcsTokenPath));
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+        }
+
+        [Test]
+        public void TestReturnsNullWhenFileIsEmpty()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Returns("");
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+        }
+
+        [Test]
+        public void TestReturnsNullWhenFileContainsOnlyWhitespace()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Returns("   \n  ");
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+        }
+
+        [Test]
+        public void TestReturnsNullAndDoesNotThrowOnReadException()
+        {
+            // arrange
+            t_environmentOperations.Setup(e => e.GetEnvironmentVariable(SpcsTokenProvider.RunningInsideSpcsEnvVar))
+                .Returns("true");
+            t_fileOperations.Setup(f => f.ReadAllText(SpcsTokenProvider.DefaultSpcsTokenPath))
+                .Throws(new IOException("Access denied"));
+
+            // act
+            var token = t_provider.GetSpcsToken();
+
+            // assert
+            Assert.IsNull(token);
+        }
+    }
+}

--- a/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Snowflake.Data.Client;
+using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
 
 namespace Snowflake.Data.Core.Authenticator
@@ -52,6 +53,9 @@ namespace Snowflake.Data.Core.Authenticator
 
         // The client environment properties
         private LoginRequestClientEnv ClientEnv = SFEnvironment.ClientEnv.CloneForSession();
+
+        // Provider for the SPCS container identity token
+        internal SpcsTokenProvider SpcsTokenProvider = SpcsTokenProvider.Instance;
 
         /// <summary>
         /// The abstract base for all authenticators.
@@ -146,6 +150,7 @@ namespace Snowflake.Data.Core.Authenticator
                 SessionParameters = session.ParameterMap,
                 Authenticator = authName,
             };
+            data.SpcsToken = SpcsTokenProvider.GetSpcsToken();
             SetSpecializedAuthenticatorData(ref data);
             return data;
         }

--- a/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/IAuthenticator.cs
@@ -55,7 +55,7 @@ namespace Snowflake.Data.Core.Authenticator
         private LoginRequestClientEnv ClientEnv = SFEnvironment.ClientEnv.CloneForSession();
 
         // Provider for the SPCS container identity token
-        internal SpcsTokenProvider SpcsTokenProvider = SpcsTokenProvider.Instance;
+        internal SpcsTokenProvider SpcsTokenProvider = SpcsTokenProvider.CreateIfRunningInSpcs();
 
         /// <summary>
         /// The abstract base for all authenticators.
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Core.Authenticator
                 SessionParameters = session.ParameterMap,
                 Authenticator = authName,
             };
-            data.SpcsToken = SpcsTokenProvider.GetSpcsToken();
+            data.SpcsToken = SpcsTokenProvider?.GetSpcsToken();
             SetSpecializedAuthenticatorData(ref data);
             return data;
         }

--- a/Snowflake.Data/Core/RestRequest.cs
+++ b/Snowflake.Data/Core/RestRequest.cs
@@ -266,6 +266,9 @@ namespace Snowflake.Data.Core
         [JsonProperty(PropertyName = "PROVIDER", NullValueHandling = NullValueHandling.Ignore)]
         internal string Provider { get; set; }
 
+        [JsonProperty(PropertyName = "SPCS_TOKEN", NullValueHandling = NullValueHandling.Ignore)]
+        internal string SpcsToken { get; set; }
+
         [JsonProperty(PropertyName = "SESSION_PARAMETERS", NullValueHandling = NullValueHandling.Ignore)]
         internal Dictionary<SFSessionParameter, Object> SessionParameters { get; set; }
 

--- a/Snowflake.Data/Core/Tools/SpcsTokenProvider.cs
+++ b/Snowflake.Data/Core/Tools/SpcsTokenProvider.cs
@@ -10,7 +10,10 @@ namespace Snowflake.Data.Core.Tools
 
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SpcsTokenProvider>();
 
-        public static readonly SpcsTokenProvider Instance = new SpcsTokenProvider();
+        internal static SpcsTokenProvider CreateIfRunningInSpcs() =>
+            string.IsNullOrEmpty(EnvironmentOperations.Instance.GetEnvironmentVariable(RunningInsideSpcsEnvVar))
+                ? null
+                : new SpcsTokenProvider();
 
         private readonly FileOperations _fileOperations;
         private readonly EnvironmentOperations _environmentOperations;

--- a/Snowflake.Data/Core/Tools/SpcsTokenProvider.cs
+++ b/Snowflake.Data/Core/Tools/SpcsTokenProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Core.Tools
+{
+    internal class SpcsTokenProvider
+    {
+        internal const string RunningInsideSpcsEnvVar = "SNOWFLAKE_RUNNING_INSIDE_SPCS";
+        internal const string DefaultSpcsTokenPath = "/snowflake/session/spcs_token";
+
+        private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SpcsTokenProvider>();
+
+        public static readonly SpcsTokenProvider Instance = new SpcsTokenProvider();
+
+        private readonly FileOperations _fileOperations;
+        private readonly EnvironmentOperations _environmentOperations;
+
+        internal SpcsTokenProvider() : this(FileOperations.Instance, EnvironmentOperations.Instance)
+        {
+        }
+
+        internal SpcsTokenProvider(FileOperations fileOperations, EnvironmentOperations environmentOperations)
+        {
+            _fileOperations = fileOperations;
+            _environmentOperations = environmentOperations;
+        }
+
+        /// <summary>
+        /// Returns the SPCS token read from /snowflake/session/spcs_token, or null.
+        /// Only attempts to read the token when SNOWFLAKE_RUNNING_INSIDE_SPCS is set.
+        /// Any I/O errors or missing/empty files are treated as "no token".
+        /// </summary>
+        internal virtual string GetSpcsToken()
+        {
+            if (string.IsNullOrEmpty(_environmentOperations.GetEnvironmentVariable(RunningInsideSpcsEnvVar)))
+            {
+                return null;
+            }
+
+            try
+            {
+                var token = _fileOperations.ReadAllText(DefaultSpcsTokenPath).Trim();
+                return string.IsNullOrEmpty(token) ? null : token;
+            }
+            catch (Exception e)
+            {
+                s_logger.Warn($"Failed to read SPCS token from {DefaultSpcsTokenPath}: {e.Message}");
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
SPCS (Snowpark Container Services) containers expose a service identity token at `/snowflake/session/spcs_token`. This token must be included in the login request as `SPCS_TOKEN` so Snowflake can identify which SPCS service the request originates from.

The driver only activates this behaviour when the `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable is set. If unset, the token file is never read.

Changes:
- Added `SpcsTokenProvider` utility class that reads the token from the fixed path `/snowflake/session/spcs_token`. Missing files, permission errors, and other I/O failures are caught and logged as warnings; the driver continues without a token.
- Added `SPCS_TOKEN` field to `LoginRequestData` (omitted from JSON when null).
- `BaseAuthenticator.BuildLoginRequestData()` injects the SPCS token for all authenticator types.

Resolves: SNOW-3007075

Reference implementations: [Node.js connector](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1372) · [Python connector](https://github.com/snowflakedb/snowflake-connector-python/pull/2714) · [ODBC](https://github.com/snowflakedb/snowflake-odbc/pull/849)

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name