### PR TITLE
SNOW-3350284 Introduce SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION for TOML and JSON token files

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
@@ -144,6 +144,38 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             Environment.SetEnvironmentVariable(TomlConnectionBuilder.SkipWarningForReadPermissions, "false");
         }
 
+        [TestCase("true", false)]
+        [TestCase("false", true)]
+        public void TestTomlPermissionChecksWithSkipTokenFileVerification(string skipValue, bool shouldThrow)
+        {
+            var filePath = CreateConfigTempFile(s_workingDirectory, "random text");
+            Syscall.chmod(filePath, (FilePermissions)(FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.GroupWrite));
+            Environment.SetEnvironmentVariable(TomlConnectionBuilder.SkipTokenFilePermissionsVerification, skipValue);
+
+            if (shouldThrow)
+                Assert.Throws<SecurityException>(() => s_unixOperations.ReadAllText(filePath, TomlConnectionBuilder.ValidateFilePermissions));
+            else
+                Assert.DoesNotThrow(() => s_unixOperations.ReadAllText(filePath, TomlConnectionBuilder.ValidateFilePermissions));
+
+            Environment.SetEnvironmentVariable(TomlConnectionBuilder.SkipTokenFilePermissionsVerification, null);
+        }
+
+        [TestCase("true", false)]
+        [TestCase("false", true)]
+        public void TestCredentialManagerPermissionChecksWithSkipTokenFileVerification(string skipValue, bool shouldThrow)
+        {
+            var filePath = CreateConfigTempFile(s_workingDirectory, "random text");
+            Syscall.chmod(filePath, (FilePermissions)(FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.GroupWrite));
+            Environment.SetEnvironmentVariable(TomlConnectionBuilder.SkipTokenFilePermissionsVerification, skipValue);
+
+            if (shouldThrow)
+                Assert.Throws<SecurityException>(() => s_unixOperations.WriteAllText(filePath, "test", SFCredentialManagerFileImpl.Instance.ValidateFilePermissions));
+            else
+                Assert.DoesNotThrow(() => s_unixOperations.WriteAllText(filePath, "test", SFCredentialManagerFileImpl.Instance.ValidateFilePermissions));
+
+            Environment.SetEnvironmentVariable(TomlConnectionBuilder.SkipTokenFilePermissionsVerification, null);
+        }
+
         [Test]
         public void TestWriteAllTextCheckingPermissionsUsingSFCredentialManagerFileValidations(
             [ValueSource(nameof(UserAllowedWritePermissions))] FileAccessPermissions userAllowedPermissions)

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
@@ -268,6 +268,12 @@ namespace Snowflake.Data.Core.CredentialManager.Infrastructure
 
         internal void ValidateFilePermissions(UnixStream stream)
         {
+            if (bool.TryParse(_environmentOperations.GetEnvironmentVariable(TomlConnectionBuilder.SkipTokenFilePermissionsVerification), out var skipAll) && skipAll)
+            {
+                s_logger.Info("Skipping file permissions verification due to environment variable: " + TomlConnectionBuilder.SkipTokenFilePermissionsVerification);
+                return;
+            }
+
             ValidatorOperations.Instance.ValidateUserAndGroupPermissions(stream);
             var allowedPermissions = new[]
             {

--- a/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
+++ b/Snowflake.Data/Core/CredentialManager/Infrastructure/SFCredentialManagerFileImpl.cs
@@ -274,7 +274,7 @@ namespace Snowflake.Data.Core.CredentialManager.Infrastructure
                 return;
             }
 
-            ValidatorOperations.Instance.ValidateUserAndGroupPermissions(stream);
+            ValidatorOperations.Instance.ValidateUserPermissions(stream);
             var allowedPermissions = new[]
             {
                 FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite

--- a/Snowflake.Data/Core/TomlConnectionBuilder.cs
+++ b/Snowflake.Data/Core/TomlConnectionBuilder.cs
@@ -24,6 +24,7 @@ namespace Snowflake.Data.Core
         internal const string SnowflakeDefaultConnectionName = "SNOWFLAKE_DEFAULT_CONNECTION_NAME";
         internal const string SnowflakeHome = "SNOWFLAKE_HOME";
         internal const string SkipWarningForReadPermissions = "SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE";
+        internal const string SkipTokenFilePermissionsVerification = "SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION";
 
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SnowflakeDbConnection>();
 
@@ -166,6 +167,12 @@ namespace Snowflake.Data.Core
 
         internal static void ValidateFilePermissions(UnixStream stream)
         {
+            if (bool.TryParse(EnvironmentOperations.Instance.GetEnvironmentVariable(SkipTokenFilePermissionsVerification), out var skipAll) && skipAll)
+            {
+                s_logger.Info("Skipping file permissions verification due to environment variable: " + SkipTokenFilePermissionsVerification);
+                return;
+            }
+
             var allowedPermissions = new[]
             {
                 FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.GroupRead | FileAccessPermissions.OtherRead,
@@ -176,8 +183,6 @@ namespace Snowflake.Data.Core
             };
             if (stream.OwnerUser.UserId != Syscall.geteuid())
                 throw new SecurityException("Attempting to read a file not owned by the effective user of the current process");
-            if (stream.OwnerGroup.GroupId != Syscall.getegid())
-                throw new SecurityException("Attempting to read a file not owned by the effective group of the current process");
 
             bool.TryParse(EnvironmentOperations.Instance.GetEnvironmentVariable(SkipWarningForReadPermissions), out _skipWarningForReadPermissions);
             if (!_skipWarningForReadPermissions)

--- a/Snowflake.Data/Core/Tools/ValidatorOperations.cs
+++ b/Snowflake.Data/Core/Tools/ValidatorOperations.cs
@@ -37,6 +37,12 @@ namespace Snowflake.Data.Core.Tools
                 ThrowSecurityException("Attempting to read or write a file not owned by the effective group of the current process");
         }
 
+        internal void ValidateUserPermissions(UnixStream stream)
+        {
+            if (stream.OwnerUser.UserId != _unixUserId)
+                ThrowSecurityException("Attempting to read or write a file not owned by the effective user of the current process");
+        }
+
         internal void ThrowSecurityException(string errorMessage)
         {
             s_logger.Error(errorMessage);


### PR DESCRIPTION
### Description
  Introduces the `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` environment variable to allow bypassing file permission checks for `connections.toml` and `credential_cache_v1.json`. This is needed for SPCS environments where file ownership or permissions cannot be fully controlled.

  Also fixes a pre-existing issue where .NET was the only driver checking **group ownership (GID)** for `connections.toml`, making it uniquely strict compared to Python, JDBC, and ODBC.

  **`TomlConnectionBuilder.cs`**
  - Added `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` constant
  - When set to `true`, bypasses all permission checks in `ValidateFilePermissions` (UID ownership, read warning, write error). Also applies to `token_file_path` token reading since it reuses the same validator.
  - Removed GID ownership check — no other driver checks group ownership for `connections.toml`

  **`SFCredentialManagerFileImpl.cs`**
  - When `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION=true`, bypasses both the ownership check and the strict 0600 permission check for `credential_cache_v1.json`

  **`UnixOperationsTest.cs`**
  - Added 2 parameterized tests covering enabled/disabled bypass for TOML and credential cache


  ### Checklist
  - [x] Code compiles correctly
  - [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
  - [x] Created tests which fail without the change (if possible)
  - [x] All tests passing (`dotnet test`)
  - [ ] Extended the README / documentation, if necessary
  - [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name