### PR TITLE
SNOW-3247696 Add in-band telemetry infrastructure for .NET connector

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/TelemetryIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/TelemetryIT.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Telemetry;
+
+namespace Snowflake.Data.Tests.IntegrationTests
+{
+    [TestFixture]
+    class TelemetryIT : SFBaseTest
+    {
+        private TelemetryData CreateTestLog(string eventType = TelemetryEventType.SqlException)
+        {
+            return new TelemetryData(
+                new Dictionary<string, string>
+                {
+                    { TelemetryField.Type, eventType },
+                    { TelemetryField.DriverType, SFEnvironment.DriverName },
+                    { TelemetryField.DriverVersion, SFEnvironment.DriverVersion },
+                    { TelemetryField.Reason, "integration test telemetry event" }
+                },
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            );
+        }
+
+        [Test]
+        public void TestTelemetryClientCreatedOnConnection()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                Assert.IsNotNull(conn.SfSession._telemetry);
+                Assert.IsFalse(conn.SfSession._telemetry.IsClosed);
+
+                conn.Close();
+            }
+        }
+
+        [Test]
+        public void TestSendBatchToServer()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+
+                telemetry.AddLog(CreateTestLog());
+                telemetry.AddLog(CreateTestLog());
+
+                Assert.AreEqual(2, telemetry.BufferSize);
+
+                var result = telemetry.SendBatch();
+
+                Assert.IsTrue(result);
+                Assert.AreEqual(0, telemetry.BufferSize);
+            }
+        }
+
+        [Test]
+        public void TestSendBatchAsyncToServer()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+
+                telemetry.AddLog(CreateTestLog());
+                telemetry.AddLog(CreateTestLog());
+
+                var result = Task.Run(async () => await telemetry.SendBatchAsync().ConfigureAwait(false)).Result;
+
+                Assert.IsTrue(result);
+                Assert.AreEqual(0, telemetry.BufferSize);
+            }
+        }
+
+        [Test]
+        public void TestCloseFlushesToServer()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+
+                telemetry.AddLog(CreateTestLog());
+                telemetry.AddLog(CreateTestLog());
+                telemetry.AddLog(CreateTestLog());
+
+                Assert.AreEqual(3, telemetry.BufferSize);
+
+                // Close should flush
+                telemetry.Close();
+
+                Assert.IsTrue(telemetry.IsClosed);
+                Assert.AreEqual(0, telemetry.BufferSize);
+            }
+        }
+
+        [Test]
+        public void TestAutoFlushAtThreshold()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                // Close original telemetry client before replacing
+                conn.SfSession._telemetry.Close();
+                // Replace with small flush size for testing
+                var telemetry = new TelemetryClient(conn.SfSession, conn.SfSession.restRequester, 5);
+                conn.SfSession._telemetry = telemetry;
+
+                for (int i = 0; i < 5; i++)
+                {
+                    telemetry.AddLog(CreateTestLog());
+                }
+
+                // Wait for background async flush to complete
+                SpinWait.SpinUntil(() => telemetry.BufferSize == 0, TimeSpan.FromSeconds(5));
+
+                Assert.AreEqual(0, telemetry.BufferSize);
+            }
+        }
+
+        [Test]
+        public void TestConnectionCloseFlushTelemetry()
+        {
+            // Verify that closing a connection doesn't throw due to telemetry flush
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+                telemetry.AddLog(CreateTestLog());
+                telemetry.AddLog(CreateTestLog());
+
+                Assert.DoesNotThrow(() => conn.Close());
+            }
+        }
+
+        [Test]
+        public void TestAddLogAfterCloseDoesNotThrow()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+                telemetry.Close();
+
+                Assert.DoesNotThrow(() => telemetry.AddLog(CreateTestLog()));
+                Assert.AreEqual(0, telemetry.BufferSize);
+            }
+        }
+
+        [Test]
+        public void TestDoubleCloseDoesNotThrow()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+
+                Assert.DoesNotThrow(() =>
+                {
+                    telemetry.Close();
+                    telemetry.Close();
+                });
+            }
+        }
+
+        [Test]
+        public void TestTelemetryEnabledByDefault()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                Assert.IsTrue(conn.SfSession._telemetry.IsTelemetryEnabled());
+            }
+        }
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/TelemetryClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/TelemetryClientTest.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Core.Telemetry;
+
+namespace Snowflake.Data.Tests.UnitTests
+{
+    /// <summary>
+    /// A mock rest requester that captures telemetry POST requests for assertion.
+    /// Returns a configurable response for telemetry sends, and a successful
+    /// login response for session setup.
+    /// </summary>
+    internal class MockTelemetryRestRequester : IMockRestRequester
+    {
+        internal ConcurrentBag<TelemetryRequest> CapturedTelemetryRequests { get; } = new ConcurrentBag<TelemetryRequest>();
+        internal bool TelemetryResponseSuccess { get; set; } = true;
+        internal bool ThrowOnTelemetrySend { get; set; } = false;
+
+        public T Post<T>(IRestRequest request)
+        {
+            return Task.Run(async () => await PostAsync<T>(request, CancellationToken.None).ConfigureAwait(false)).Result;
+        }
+
+        public Task<T> PostAsync<T>(IRestRequest postRequest, CancellationToken cancellationToken)
+        {
+            SFRestRequest sfRequest = (SFRestRequest)postRequest;
+
+            if (sfRequest.jsonBody is LoginRequest)
+            {
+                LoginResponse authnResponse = new LoginResponse
+                {
+                    data = new LoginResponseData()
+                    {
+                        token = "session_token",
+                        masterToken = "master_token",
+                        authResponseSessionInfo = new SessionInfo(),
+                        nameValueParameter = new List<NameValueParameter>
+                        {
+                            new NameValueParameter
+                            {
+                                name = "CLIENT_TELEMETRY_ENABLED",
+                                value = "true"
+                            }
+                        }
+                    },
+                    success = true
+                };
+                return Task.FromResult<T>((T)(object)authnResponse);
+            }
+
+            if (sfRequest.Url.AbsolutePath.Contains("/telemetry/send"))
+            {
+                if (ThrowOnTelemetrySend)
+                {
+                    throw new Exception("Simulated telemetry send failure");
+                }
+
+                if (sfRequest.jsonBody is TelemetryRequest telemetryReq)
+                {
+                    CapturedTelemetryRequests.Add(telemetryReq);
+                }
+
+                var response = new NullDataResponse { success = TelemetryResponseSuccess };
+                return Task.FromResult<T>((T)(object)response);
+            }
+
+            // Close session
+            if (typeof(T) == typeof(CloseResponse))
+            {
+                return Task.FromResult<T>((T)(object)new CloseResponse { success = true });
+            }
+
+            throw new NotImplementedException($"Unexpected POST request: {sfRequest.Url}");
+        }
+
+        public T Get<T>(IRestRequest request) => default;
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken) => Task.FromResult<T>(default);
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken) => Task.FromResult<HttpResponseMessage>(null);
+        public HttpResponseMessage Get(IRestRequest request) => null;
+        public void setHttpClient(HttpClient httpClient) { }
+    }
+
+    [TestFixture]
+    class TelemetryClientTest
+    {
+        private const string ConnectionString = "account=testaccount;user=testuser;password=testpassword;";
+
+        private SFSession CreateSessionWithTelemetry(MockTelemetryRestRequester requester, int flushSize = TelemetryClient.DefaultFlushSize)
+        {
+            var sessionContext = new SessionPropertiesContext { Password = null };
+            var session = new SFSession(ConnectionString, sessionContext, requester);
+            session.ProcessLoginResponse(new LoginResponse
+            {
+                data = new LoginResponseData
+                {
+                    token = "session_token",
+                    masterToken = "master_token",
+                    authResponseSessionInfo = new SessionInfo(),
+                    nameValueParameter = new List<NameValueParameter>
+                    {
+                        new NameValueParameter
+                        {
+                            name = "CLIENT_TELEMETRY_ENABLED",
+                            value = "true"
+                        }
+                    }
+                },
+                success = true
+            });
+
+            // Replace with a custom flush size if needed
+            if (flushSize != TelemetryClient.DefaultFlushSize)
+            {
+                session._telemetry = new TelemetryClient(session, requester, flushSize);
+            }
+
+            return session;
+        }
+
+        private TelemetryData CreateTestTelemetryData(string eventType = TelemetryEventType.SqlException)
+        {
+            return new TelemetryData(
+                new Dictionary<string, string>
+                {
+                    { TelemetryField.Type, eventType },
+                    { TelemetryField.DriverType, SFEnvironment.DriverName },
+                    { TelemetryField.DriverVersion, SFEnvironment.DriverVersion },
+                    { TelemetryField.Reason, "test error" }
+                },
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            );
+        }
+
+        [Test]
+        public void TestTelemetryClientCreatedOnLogin()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            Assert.IsNotNull(session._telemetry);
+            Assert.IsFalse(session._telemetry.IsClosed);
+        }
+
+        [Test]
+        public void TestAddLogAccumulatesInBuffer()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.AddLog(CreateTestTelemetryData());
+
+            Assert.AreEqual(3, session._telemetry.BufferSize);
+            Assert.AreEqual(0, requester.CapturedTelemetryRequests.Count);
+        }
+
+        [Test]
+        public void TestSendBatchClearsBufferAndSends()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.AddLog(CreateTestTelemetryData());
+
+            var result = session._telemetry.SendBatch();
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+            Assert.AreEqual(1, requester.CapturedTelemetryRequests.Count);
+            Assert.AreEqual(2, requester.CapturedTelemetryRequests.First().Logs.Count);
+        }
+
+        [Test]
+        public void TestSendBatchPayloadFormat()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            var data = CreateTestTelemetryData();
+            session._telemetry.AddLog(data);
+            session._telemetry.SendBatch();
+
+            var captured = requester.CapturedTelemetryRequests.First();
+            var log = captured.Logs[0];
+
+            Assert.AreEqual(TelemetryEventType.SqlException, log.Message[TelemetryField.Type]);
+            Assert.AreEqual(SFEnvironment.DriverName, log.Message[TelemetryField.DriverType]);
+            Assert.AreEqual(SFEnvironment.DriverVersion, log.Message[TelemetryField.DriverVersion]);
+            Assert.AreEqual("test error", log.Message[TelemetryField.Reason]);
+            Assert.IsNotNull(log.Timestamp);
+            Assert.Greater(log.Timestamp, 0);
+        }
+
+        [Test]
+        public void TestAutoFlushAtThreshold()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester, flushSize: 5);
+
+            for (int i = 0; i < 5; i++)
+            {
+                session._telemetry.AddLog(CreateTestTelemetryData());
+            }
+
+            // Wait for background async flush to complete (generous timeout for CI)
+            var flushed = SpinWait.SpinUntil(() => requester.CapturedTelemetryRequests.Count > 0, TimeSpan.FromSeconds(10));
+
+            Assert.IsTrue(flushed, "Auto-flush did not trigger within timeout");
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+            Assert.AreEqual(5, requester.CapturedTelemetryRequests.First().Logs.Count);
+        }
+
+        [Test]
+        public void TestCloseFlushesRemainingLogs()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.Close();
+
+            Assert.IsTrue(session._telemetry.IsClosed);
+            Assert.AreEqual(1, requester.CapturedTelemetryRequests.Count);
+            Assert.AreEqual(2, requester.CapturedTelemetryRequests.First().Logs.Count);
+        }
+
+        [Test]
+        public void TestSelfDisablesOnSendFailure()
+        {
+            var requester = new MockTelemetryRestRequester { TelemetryResponseSuccess = false };
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.SendBatch();
+
+            // After failure, telemetry should be disabled
+            Assert.IsFalse(session._telemetry.IsTelemetryEnabled());
+
+            // Subsequent logs should be silently ignored
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+        }
+
+        [Test]
+        public void TestSelfDisablesOnSendException()
+        {
+            var requester = new MockTelemetryRestRequester { ThrowOnTelemetrySend = true };
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.SendBatch();
+
+            Assert.IsFalse(session._telemetry.IsTelemetryEnabled());
+        }
+
+        [Test]
+        public void TestDisabledTelemetryNoOps()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            // Simulate server disabling telemetry
+            session.ParameterMap[SFSessionParameter.CLIENT_TELEMETRY_ENABLED] = "false";
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+            Assert.AreEqual(0, requester.CapturedTelemetryRequests.Count);
+        }
+
+        [Test]
+        public void TestAddLogAfterCloseDoesNotThrow()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.Close();
+
+            Assert.DoesNotThrow(() => session._telemetry.AddLog(CreateTestTelemetryData()));
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+        }
+
+        [Test]
+        public void TestSendBatchWithEmptyBufferSucceeds()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            var result = session._telemetry.SendBatch();
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(0, requester.CapturedTelemetryRequests.Count);
+        }
+
+        [Test]
+        public void TestThreadSafety()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+            const int threadCount = 10;
+            const int logsPerThread = 20;
+
+            var threads = new List<Thread>();
+            for (int t = 0; t < threadCount; t++)
+            {
+                var thread = new Thread(() =>
+                {
+                    for (int i = 0; i < logsPerThread; i++)
+                    {
+                        session._telemetry.AddLog(CreateTestTelemetryData());
+                    }
+                });
+                threads.Add(thread);
+            }
+
+            threads.ForEach(t => t.Start());
+            threads.ForEach(t => t.Join());
+
+            // Wait for any background auto-flush to complete before manually sending remainder
+            SpinWait.SpinUntil(() => session._telemetry.BufferSize < threadCount * logsPerThread, TimeSpan.FromSeconds(5));
+
+            session._telemetry.SendBatch();
+
+            var totalSent = requester.CapturedTelemetryRequests.Sum(r => r.Logs.Count);
+            Assert.AreEqual(threadCount * logsPerThread, totalSent);
+        }
+
+        [Test]
+        public async Task TestSendBatchAsync()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.AddLog(CreateTestTelemetryData());
+
+            var result = await session._telemetry.SendBatchAsync();
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+            Assert.AreEqual(1, requester.CapturedTelemetryRequests.Count);
+            Assert.AreEqual(2, requester.CapturedTelemetryRequests.First().Logs.Count);
+        }
+
+        [Test]
+        public async Task TestCloseAsync()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            await session._telemetry.CloseAsync();
+
+            Assert.IsTrue(session._telemetry.IsClosed);
+            Assert.AreEqual(1, requester.CapturedTelemetryRequests.Count);
+        }
+
+        [Test]
+        public void TestDoubleCloseDoesNotThrow()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            session._telemetry.AddLog(CreateTestTelemetryData());
+            session._telemetry.Close();
+
+            Assert.DoesNotThrow(() => session._telemetry.Close());
+            Assert.AreEqual(1, requester.CapturedTelemetryRequests.Count);
+        }
+
+        [Test]
+        public void TestTelemetryEnabledByDefault()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var sessionContext = new SessionPropertiesContext { Password = null };
+            var session = new SFSession(ConnectionString, sessionContext, requester);
+
+            // Process login without CLIENT_TELEMETRY_ENABLED parameter
+            session.ProcessLoginResponse(new LoginResponse
+            {
+                data = new LoginResponseData
+                {
+                    token = "session_token",
+                    masterToken = "master_token",
+                    authResponseSessionInfo = new SessionInfo(),
+                    nameValueParameter = new List<NameValueParameter>()
+                },
+                success = true
+            });
+
+            Assert.IsNotNull(session._telemetry);
+            Assert.IsTrue(session._telemetry.IsTelemetryEnabled());
+        }
+    }
+}

--- a/Snowflake.Data/Core/RestParams.cs
+++ b/Snowflake.Data/Core/RestParams.cs
@@ -46,6 +46,8 @@ namespace Snowflake.Data.Core
 
         internal const string SF_SESSION_HEARTBEAT_PATH = SF_SESSION_PATH + "/heartbeat";
 
+        internal const string SF_TELEMETRY_PATH = "/telemetry/send";
+
         internal const string SF_CONSOLE_LOGIN = "/console/login";
     }
 

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Core.Session;
+using Snowflake.Data.Core.Telemetry;
 using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Core
@@ -49,6 +50,8 @@ namespace Snowflake.Data.Core
         internal bool sessionPropertiesChanged = false;
 
         internal string serverVersion;
+
+        internal TelemetryClient _telemetry;
 
         private readonly ConnectionPoolConfig _poolConfig;
 
@@ -139,6 +142,7 @@ namespace Snowflake.Data.Core
                 logger.Debug($"Session opened: {sessionId}");
                 _startTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 _timeSinceLastRenew = _startTime;
+                _telemetry = new TelemetryClient(this, restRequester);
             }
             else
             {
@@ -329,6 +333,7 @@ namespace Snowflake.Data.Core
             if (!IsEstablished()) return;
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
+            _telemetry?.Close();
             var closeSessionRequest = PrepareCloseSessionRequest();
             PostCloseSession(closeSessionRequest, restRequester);
             sessionToken = null;
@@ -340,6 +345,7 @@ namespace Snowflake.Data.Core
             if (!IsEstablished()) return;
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
+            _telemetry?.Close();
             var closeSessionRequest = PrepareCloseSessionRequest();
             Task.Run(() => PostCloseSession(closeSessionRequest, restRequester));
             sessionToken = null;
@@ -351,6 +357,10 @@ namespace Snowflake.Data.Core
             if (!IsEstablished()) return;
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
+            if (_telemetry != null)
+            {
+                await _telemetry.CloseAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             var closeSessionRequest = PrepareCloseSessionRequest();
 

--- a/Snowflake.Data/Core/Session/SFSessionParameter.cs
+++ b/Snowflake.Data/Core/Session/SFSessionParameter.cs
@@ -12,6 +12,7 @@ namespace Snowflake.Data.Core
         TIME_OUTPUT_FORMAT,
         CLIENT_REQUEST_MFA_TOKEN,
         CLIENT_STORE_TEMPORARY_CREDENTIAL,
-        TIMEZONE
+        TIMEZONE,
+        CLIENT_TELEMETRY_ENABLED
     }
 }

--- a/Snowflake.Data/Core/Telemetry/TelemetryClient.cs
+++ b/Snowflake.Data/Core/Telemetry/TelemetryClient.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Core.Telemetry
+{
+    /// <summary>
+    /// In-band telemetry client that batches log entries and sends them
+    /// to the Snowflake /telemetry/send endpoint using the session token.
+    /// Thread-safe. Self-disables on send failure. Never throws to callers.
+    /// </summary>
+    internal class TelemetryClient
+    {
+        private static readonly SFLogger logger = SFLoggerFactory.GetLogger<TelemetryClient>();
+
+        internal const int DefaultFlushSize = 100;
+
+        private readonly object _lock = new object();
+        private readonly IRestRequester _restRequester;
+        private readonly SFSession _session;
+        private readonly int _flushSize;
+
+        private List<TelemetryData> _logBatch = new List<TelemetryData>();
+        private volatile bool _isClosed;
+
+        /// <summary>
+        /// When false, the telemetry service has been disabled (either by the server
+        /// via CLIENT_TELEMETRY_ENABLED=false, or because a send failed).
+        /// </summary>
+        private volatile bool _isTelemetryServiceAvailable = true;
+
+        internal TelemetryClient(SFSession session, IRestRequester restRequester, int flushSize = DefaultFlushSize)
+        {
+            _session = session ?? throw new ArgumentNullException(nameof(session));
+            _restRequester = restRequester ?? throw new ArgumentNullException(nameof(restRequester));
+            _flushSize = flushSize;
+        }
+
+        /// <summary>
+        /// Whether telemetry is enabled. Checks both the server parameter and the service availability flag.
+        /// </summary>
+        internal bool IsTelemetryEnabled()
+        {
+            if (!_isTelemetryServiceAvailable)
+                return false;
+
+            if (_session.ParameterMap.TryGetValue(SFSessionParameter.CLIENT_TELEMETRY_ENABLED, out var value))
+            {
+                if (bool.TryParse(value?.ToString(), out var enabled))
+                    return enabled;
+            }
+
+            // Default: enabled (matches JDBC/Go behavior)
+            return true;
+        }
+
+        /// <summary>
+        /// Add a telemetry log entry to the batch.
+        /// If the batch reaches the flush size, sends asynchronously.
+        /// Silently no-ops if telemetry is disabled or closed.
+        /// </summary>
+        internal void AddLog(TelemetryData data)
+        {
+            try
+            {
+                if (_isClosed || !IsTelemetryEnabled())
+                    return;
+
+                int batchSize;
+                lock (_lock)
+                {
+                    _logBatch.Add(data);
+                    batchSize = _logBatch.Count;
+                }
+
+                if (batchSize == _flushSize)
+                {
+                    logger.Debug($"Force flushing telemetry batch of size: {batchSize}");
+                    _ = Task.Run(async () => await SendBatchAsync().ConfigureAwait(false));
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Failed to add telemetry log: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Send all cached logs to the server. Swaps the batch under the lock,
+        /// then sends without holding the lock.
+        /// </summary>
+        internal bool SendBatch()
+        {
+            if (_isClosed || !IsTelemetryEnabled())
+                return false;
+
+            List<TelemetryData> toSend;
+            lock (_lock)
+            {
+                toSend = _logBatch;
+                _logBatch = new List<TelemetryData>();
+            }
+
+            if (toSend.Count == 0)
+            {
+                logger.Debug("Nothing to send to telemetry.");
+                return true;
+            }
+
+            try
+            {
+                var request = BuildSendRequest(toSend);
+                var response = _restRequester.Post<NullDataResponse>(request);
+
+                if (response == null || !response.success)
+                {
+                    logger.Info("Non-success response from telemetry server. Disabling telemetry.");
+                    _isTelemetryServiceAvailable = false;
+                    return false;
+                }
+
+                logger.Debug($"Successfully sent {toSend.Count} telemetry logs.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Failed to send telemetry batch: {ex.Message}. Disabling telemetry.");
+                _isTelemetryServiceAvailable = false;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Async variant of SendBatch.
+        /// </summary>
+        internal async Task<bool> SendBatchAsync(CancellationToken cancellationToken = default)
+        {
+            if (_isClosed || !IsTelemetryEnabled())
+                return false;
+
+            List<TelemetryData> toSend;
+            lock (_lock)
+            {
+                toSend = _logBatch;
+                _logBatch = new List<TelemetryData>();
+            }
+
+            if (toSend.Count == 0)
+            {
+                logger.Debug("Nothing to send to telemetry.");
+                return true;
+            }
+
+            try
+            {
+                var request = BuildSendRequest(toSend);
+                var response = await _restRequester.PostAsync<NullDataResponse>(request, cancellationToken).ConfigureAwait(false);
+
+                if (response == null || !response.success)
+                {
+                    logger.Info("Non-success response from telemetry server. Disabling telemetry.");
+                    _isTelemetryServiceAvailable = false;
+                    return false;
+                }
+
+                logger.Debug($"Successfully sent {toSend.Count} telemetry logs.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Failed to send telemetry batch: {ex.Message}. Disabling telemetry.");
+                _isTelemetryServiceAvailable = false;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Flush remaining logs and mark the client as closed (sync).
+        /// </summary>
+        internal void Close()
+        {
+            if (_isClosed)
+                return;
+
+            try
+            {
+                SendBatch();
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Error flushing telemetry on close: {ex.Message}");
+            }
+            finally
+            {
+                _isClosed = true;
+            }
+        }
+
+        /// <summary>
+        /// Flush remaining logs and mark the client as closed (async).
+        /// </summary>
+        internal async Task CloseAsync(CancellationToken cancellationToken = default)
+        {
+            if (_isClosed)
+                return;
+
+            try
+            {
+                await SendBatchAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Error flushing telemetry on close: {ex.Message}");
+            }
+            finally
+            {
+                _isClosed = true;
+            }
+        }
+
+        /// <summary>
+        /// Disable the telemetry service (e.g. when the server parameter changes).
+        /// </summary>
+        internal void Disable()
+        {
+            _isTelemetryServiceAvailable = false;
+        }
+
+        internal bool IsClosed => _isClosed;
+
+        /// <summary>
+        /// Number of logs currently in the buffer. Primarily for testing.
+        /// </summary>
+        internal int BufferSize
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _logBatch.Count;
+                }
+            }
+        }
+
+        private SFRestRequest BuildSendRequest(List<TelemetryData> logs)
+        {
+            return new SFRestRequest
+            {
+                Url = _session.BuildUri(RestPath.SF_TELEMETRY_PATH),
+                authorizationToken = string.Format("Snowflake Token=\"{0}\"", _session.sessionToken),
+                jsonBody = new TelemetryRequest(logs),
+                sid = _session.sessionId,
+                RestTimeout = TimeSpan.FromSeconds(30),
+                HttpTimeout = TimeSpan.FromSeconds(10)
+            };
+        }
+    }
+}

--- a/Snowflake.Data/Core/Telemetry/TelemetryConstants.cs
+++ b/Snowflake.Data/Core/Telemetry/TelemetryConstants.cs
@@ -1,0 +1,28 @@
+namespace Snowflake.Data.Core.Telemetry
+{
+    /// <summary>
+    /// Field keys used in telemetry message payloads.
+    /// </summary>
+    internal static class TelemetryField
+    {
+        internal const string Type = "type";
+        internal const string Source = "source";
+        internal const string DriverType = "DriverType";
+        internal const string DriverVersion = "DriverVersion";
+        internal const string QueryId = "QueryID";
+        internal const string SqlState = "SQLState";
+        internal const string ErrorNumber = "ErrorNumber";
+        internal const string Stacktrace = "Stacktrace";
+        internal const string Reason = "reason";
+        internal const string Exception = "exception";
+    }
+
+    /// <summary>
+    /// Event type values for the "type" field in telemetry messages.
+    /// </summary>
+    internal static class TelemetryEventType
+    {
+        internal const string SqlException = "client_sql_exception";
+        internal const string HttpException = "client_http_exception";
+    }
+}

--- a/Snowflake.Data/Core/Telemetry/TelemetryData.cs
+++ b/Snowflake.Data/Core/Telemetry/TelemetryData.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Snowflake.Data.Core.Telemetry
+{
+    /// <summary>
+    /// A single telemetry log entry consisting of a message and a timestamp.
+    /// Matches the wire format expected by the /telemetry/send endpoint.
+    /// </summary>
+    internal class TelemetryData
+    {
+        [JsonProperty(PropertyName = "message")]
+        internal Dictionary<string, string> Message { get; }
+
+        [JsonProperty(PropertyName = "timestamp")]
+        internal long Timestamp { get; }
+
+        internal TelemetryData(Dictionary<string, string> message, long timestampMs)
+        {
+            Message = message;
+            Timestamp = timestampMs;
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for the telemetry send request body: {"logs": [...]}.
+    /// </summary>
+    internal class TelemetryRequest
+    {
+        [JsonProperty(PropertyName = "logs")]
+        internal List<TelemetryData> Logs { get; }
+
+        internal TelemetryRequest(List<TelemetryData> logs)
+        {
+            Logs = logs;
+        }
+    }
+}


### PR DESCRIPTION
Introduce the core plumbing for in-band telemetry, matching the pattern used by the JDBC, Python, Go, and Node.js connectors. This sends batched telemetry logs to POST /telemetry/send using the session token.

New classes:
- TelemetryData: log entry DTO (message dict + timestamp)
- TelemetryConstants: field keys and event type values
- TelemetryClient: thread-safe batching client with auto-flush at 100, self-disable on send failure, and sync/async send and close

Integration into SFSession:
- Created on successful login (ProcessLoginResponse)
- Flushed and closed before session close (close, CloseNonBlocking, CloseAsync)
- Respects server-side CLIENT_TELEMETRY_ENABLED session parameter

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
