### PR TITLE
SNOW-3247696 Add error telemetry collection for .NET connector

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/TelemetryIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/TelemetryIT.cs
@@ -196,5 +196,33 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.IsTrue(conn.SfSession._telemetry.IsTelemetryEnabled());
             }
         }
+
+        [Test]
+        public void TestFailedQueryGeneratesTelemetryEvent()
+        {
+            using (var conn = new SnowflakeDbConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var telemetry = conn.SfSession._telemetry;
+                var bufferBefore = telemetry.BufferSize;
+
+                try
+                {
+                    var cmd = conn.CreateCommand();
+                    cmd.CommandText = "SELECT * FROM nonexistent_table_for_telemetry_test_xyz";
+                    cmd.ExecuteReader();
+                    Assert.Fail("Expected exception was not thrown");
+                }
+                catch (SnowflakeDbException)
+                {
+                    // Expected - the query should fail
+                }
+
+                // The failed query should have generated a telemetry event
+                Assert.Greater(telemetry.BufferSize, bufferBefore);
+            }
+        }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/TelemetryHelperTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/TelemetryHelperTest.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Core.Telemetry;
+
+namespace Snowflake.Data.Tests.UnitTests
+{
+    [TestFixture]
+    class TelemetryHelperTest
+    {
+        private const string ConnectionString = "account=testaccount;user=testuser;password=testpassword;";
+
+        private SFSession CreateSessionWithTelemetry(MockTelemetryRestRequester requester)
+        {
+            var sessionContext = new SessionPropertiesContext { Password = null };
+            var session = new SFSession(ConnectionString, sessionContext, requester);
+            session.ProcessLoginResponse(new LoginResponse
+            {
+                data = new LoginResponseData
+                {
+                    token = "session_token",
+                    masterToken = "master_token",
+                    authResponseSessionInfo = new SessionInfo(),
+                    nameValueParameter = new List<NameValueParameter>
+                    {
+                        new NameValueParameter
+                        {
+                            name = "CLIENT_TELEMETRY_ENABLED",
+                            value = "true"
+                        }
+                    }
+                },
+                success = true
+            });
+            return session;
+        }
+
+        [Test]
+        public void TestGenerateExceptionDataWithAllFields()
+        {
+            var ex = new SnowflakeDbException("42S02", 2003, "Table not found", "query-123");
+
+            var data = TelemetryHelper.GenerateExceptionData(ex);
+
+            Assert.AreEqual(TelemetryEventType.SqlException, data.Message[TelemetryField.Type]);
+            Assert.AreEqual(SFEnvironment.DriverName, data.Message[TelemetryField.Source]);
+            Assert.AreEqual(SFEnvironment.DriverName, data.Message[TelemetryField.DriverType]);
+            Assert.AreEqual(SFEnvironment.DriverVersion, data.Message[TelemetryField.DriverVersion]);
+            Assert.AreEqual("query-123", data.Message[TelemetryField.QueryId]);
+            Assert.AreEqual("42S02", data.Message[TelemetryField.SqlState]);
+            Assert.AreEqual("2003", data.Message[TelemetryField.ErrorNumber]);
+            Assert.IsTrue(data.Message.ContainsKey(TelemetryField.Reason));
+            Assert.IsFalse(data.Message.ContainsKey("ErrorMessage"));
+            Assert.AreEqual("SnowflakeDbException", data.Message[TelemetryField.Exception]);
+            Assert.IsNotNull(data.Timestamp);
+        }
+
+        [Test]
+        public void TestGenerateExceptionDataWithMinimalFields()
+        {
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "something went wrong");
+
+            var data = TelemetryHelper.GenerateExceptionData(ex);
+
+            Assert.AreEqual(TelemetryEventType.SqlException, data.Message[TelemetryField.Type]);
+            Assert.AreEqual(SFEnvironment.DriverName, data.Message[TelemetryField.DriverType]);
+            Assert.IsFalse(data.Message.ContainsKey(TelemetryField.QueryId));
+            Assert.IsTrue(data.Message.ContainsKey(TelemetryField.ErrorNumber));
+            Assert.AreEqual("SnowflakeDbException", data.Message[TelemetryField.Exception]);
+        }
+
+        [Test]
+        public void TestGenerateExceptionDataWithCustomEventType()
+        {
+            var ex = new SnowflakeDbException(SFError.REQUEST_TIMEOUT);
+
+            var data = TelemetryHelper.GenerateExceptionData(ex, TelemetryEventType.HttpException);
+
+            Assert.AreEqual(TelemetryEventType.HttpException, data.Message[TelemetryField.Type]);
+        }
+
+        [Test]
+        public void TestGenerateExceptionDataMasksSecrets()
+        {
+            // Error message containing a password pattern (not a real credential)
+            var ex = new SnowflakeDbException("", 1234, "Connection failed with password=s3cretP@ss", ""); // ggignore
+
+            var data = TelemetryHelper.GenerateExceptionData(ex);
+
+            // The secret detector should mask the password
+            Assert.IsFalse(data.Message[TelemetryField.Reason].Contains("s3cretP@ss")); // ggignore
+        }
+
+        [Test]
+        public void TestFilterStacktraceKeepsOnlySnowflakeFrames()
+        {
+            var nl = Environment.NewLine;
+            var stacktrace =
+                $"   at System.Environment.get_StackTrace(){nl}" +
+                $"   at Snowflake.Data.Core.Telemetry.TelemetryHelper.FilterStacktrace(String stacktrace) in /Users/dev/repo/Snowflake.Data/Core/Telemetry/TelemetryHelper.cs:line 105{nl}" +
+                $"   at MyApp.Program.Main(String[] args) in /Users/dev/myapp/Program.cs:line 10{nl}" +
+                $"   at Snowflake.Data.Core.SFStatement.Execute() in /Users/dev/repo/Snowflake.Data/Core/SFStatement.cs:line 200{nl}";
+
+            var filtered = TelemetryHelper.FilterStacktrace(stacktrace);
+
+            // Should contain Snowflake.Data frames
+            Assert.IsTrue(filtered.Contains("Snowflake.Data.Core.Telemetry.TelemetryHelper"));
+            Assert.IsTrue(filtered.Contains("Snowflake.Data.Core.SFStatement"));
+            // Should NOT contain user code or system frames
+            Assert.IsFalse(filtered.Contains("MyApp.Program"));
+            Assert.IsFalse(filtered.Contains("System.Environment"));
+            // Should NOT contain user filesystem paths (neither app paths nor repo paths)
+            Assert.IsFalse(filtered.Contains("/Users/dev/myapp"));
+            Assert.IsFalse(filtered.Contains("/Users/dev/repo/"));
+        }
+
+        [Test]
+        public void TestFilterStacktraceWithEmptyInput()
+        {
+            Assert.AreEqual(string.Empty, TelemetryHelper.FilterStacktrace(null));
+            Assert.AreEqual(string.Empty, TelemetryHelper.FilterStacktrace(""));
+        }
+
+        [Test]
+        public void TestSendExceptionTelemetryAddsToBuffer()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            var ex = new SnowflakeDbException("42S02", 2003, "Table not found", "query-123");
+
+            TelemetryHelper.SendExceptionTelemetry(ex, session);
+
+            Assert.AreEqual(1, session._telemetry.BufferSize);
+        }
+
+        [Test]
+        public void TestSendExceptionTelemetryWithNullSessionDoesNotThrow()
+        {
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "error");
+
+            Assert.DoesNotThrow(() => TelemetryHelper.SendExceptionTelemetry(ex, null));
+        }
+
+        [Test]
+        public void TestSendExceptionTelemetryWithDisabledTelemetryDoesNotSend()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+            session.ParameterMap[SFSessionParameter.CLIENT_TELEMETRY_ENABLED] = "false";
+
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "error");
+
+            TelemetryHelper.SendExceptionTelemetry(ex, session);
+
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+        }
+
+        [Test]
+        public void TestSendExceptionTelemetryWithClosedTelemetryDoesNotThrow()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+            session._telemetry.Close();
+
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "error");
+
+            Assert.DoesNotThrow(() => TelemetryHelper.SendExceptionTelemetry(ex, session));
+        }
+
+        [Test]
+        public void TestSendAndThrowReturnsSameException()
+        {
+            var requester = new MockTelemetryRestRequester();
+            var session = CreateSessionWithTelemetry(requester);
+
+            var ex = new SnowflakeDbException("42S02", 2003, "Table not found", "query-123");
+
+            var returned = TelemetryHelper.SendAndThrow(ex, session);
+
+            Assert.AreSame(ex, returned);
+            Assert.AreEqual(1, session._telemetry.BufferSize);
+        }
+
+        [Test]
+        public void TestSendAndThrowWithNullSession()
+        {
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "error");
+
+            var returned = TelemetryHelper.SendAndThrow(ex, null);
+
+            Assert.AreSame(ex, returned);
+        }
+
+        [Test]
+        public void TestNoErrorLoopWhenTelemetrySendFails()
+        {
+            // If telemetry send itself fails, it should not trigger another telemetry event
+            var requester = new MockTelemetryRestRequester { ThrowOnTelemetrySend = true };
+            var session = CreateSessionWithTelemetry(requester);
+
+            var ex = new SnowflakeDbException(SFError.INTERNAL_ERROR, "error");
+
+            // First send - should disable telemetry due to failure
+            session._telemetry.AddLog(new TelemetryData(
+                new Dictionary<string, string> { { "type", "test" } },
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+            session._telemetry.SendBatch();
+
+            // Now exception telemetry should be a no-op since telemetry is disabled
+            Assert.DoesNotThrow(() => TelemetryHelper.SendExceptionTelemetry(ex, session));
+            Assert.AreEqual(0, session._telemetry.BufferSize);
+        }
+    }
+}

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Snowflake.Data.Client;
+using Snowflake.Data.Core.Telemetry;
 using Snowflake.Data.Log;
 using System.Threading;
 using System.Threading.Tasks;
@@ -310,8 +311,10 @@ namespace Snowflake.Data.Core
             {
                 SfSession.UpdateQueryContextCache(response.data.QueryContext);
             }
-            throw new SnowflakeDbException(response.data?.sqlState,
-                response.code, response.message, response.data?.queryId);
+            throw TelemetryHelper.SendAndThrow(
+                new SnowflakeDbException(response.data?.sqlState,
+                response.code, response.message, response.data?.queryId),
+                SfSession);
         }
 
         private void SetTimeout(int timeout)
@@ -725,11 +728,13 @@ namespace Snowflake.Data.Core
                     {
                         SfSession.UpdateQueryContextCache(queryData.QueryContext);
                     }
-                    throw new SnowflakeDbException(
+                    throw TelemetryHelper.SendAndThrow(
+                        new SnowflakeDbException(
                         response.data.sqlState,
                         response.code,
                         response.message,
-                        response.data.queryId);
+                        response.data.queryId),
+                        SfSession);
                 }
 
                 return response;
@@ -817,11 +822,13 @@ namespace Snowflake.Data.Core
                     {
                         SfSession.UpdateQueryContextCache(queryData.QueryContext);
                     }
-                    throw new SnowflakeDbException(
+                    throw TelemetryHelper.SendAndThrow(
+                        new SnowflakeDbException(
                         response.data.sqlState,
                         response.code,
                         response.message,
-                        response.data.queryId);
+                        response.data.queryId),
+                        SfSession);
                 }
 
                 return response;
@@ -889,11 +896,13 @@ namespace Snowflake.Data.Core
 
                 if (!response.success)
                 {
-                    throw new SnowflakeDbException(
+                    throw TelemetryHelper.SendAndThrow(
+                        new SnowflakeDbException(
                         response.data.queries[0].state,
                         response.code,
                         response.message,
-                        queryId);
+                        queryId),
+                        SfSession);
                 }
 
                 QueryStatus queryStatus = QueryStatus.NoData;
@@ -944,11 +953,13 @@ namespace Snowflake.Data.Core
 
                 if (!response.success)
                 {
-                    throw new SnowflakeDbException(
+                    throw TelemetryHelper.SendAndThrow(
+                        new SnowflakeDbException(
                         response.data.queries[0].state,
                         response.code,
                         response.message,
-                        queryId);
+                        queryId),
+                        SfSession);
                 }
 
                 QueryStatus queryStatus = QueryStatus.NoData;

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -421,6 +421,7 @@ namespace Snowflake.Data.Core
                 SnowflakeDbException e = new SnowflakeDbException("",
                     response.code, response.message, sessionId);
                 logger.Error($"Renew session (ID: {sessionId}) failed", e);
+                TelemetryHelper.SendExceptionTelemetry(e, this);
                 throw e;
             }
             else
@@ -444,6 +445,7 @@ namespace Snowflake.Data.Core
                 SnowflakeDbException e = new SnowflakeDbException("",
                     response.code, response.message, sessionId);
                 logger.Error($"Renew session (ID: {sessionId}) failed", e);
+                TelemetryHelper.SendExceptionTelemetry(e, this);
                 throw e;
             }
             else

--- a/Snowflake.Data/Core/Telemetry/TelemetryHelper.cs
+++ b/Snowflake.Data/Core/Telemetry/TelemetryHelper.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Snowflake.Data.Client;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Core.Telemetry
+{
+    /// <summary>
+    /// Helper to generate and send telemetry events from exceptions.
+    /// Follows the Go connector's exceptionTelemetry() pattern:
+    /// a standalone function called at key throw sites, rather than
+    /// embedding telemetry in the exception constructor.
+    /// </summary>
+    internal static class TelemetryHelper
+    {
+        private static readonly SFLogger logger = SFLoggerFactory.GetLogger<TelemetryClient>();
+
+        private const string SnowflakeNamespace = "Snowflake.Data";
+
+        /// <summary>
+        /// Main entry point: generate telemetry data from an exception and send it
+        /// via the session's telemetry client. Silently no-ops if session is null,
+        /// telemetry is disabled, or any error occurs.
+        /// </summary>
+        internal static void SendExceptionTelemetry(
+            SnowflakeDbException ex,
+            SFSession session,
+            string eventType = TelemetryEventType.SqlException)
+        {
+            try
+            {
+                if (session?._telemetry == null || !session._telemetry.IsTelemetryEnabled())
+                    return;
+
+                var data = GenerateExceptionData(ex, eventType);
+                session._telemetry.AddLog(data);
+            }
+            catch (Exception e)
+            {
+                // Telemetry must never affect exception propagation
+                logger.Debug($"Failed to send exception telemetry: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Convenience method for throw sites: sends telemetry and returns the exception
+        /// so callers can write: throw TelemetryHelper.SendAndThrow(ex, session);
+        /// </summary>
+        internal static SnowflakeDbException SendAndThrow(
+            SnowflakeDbException ex,
+            SFSession session,
+            string eventType = TelemetryEventType.SqlException)
+        {
+            SendExceptionTelemetry(ex, session, eventType);
+            return ex;
+        }
+
+        /// <summary>
+        /// Generate a TelemetryData instance from an exception, matching the
+        /// wire format used by JDBC/Go/Python connectors.
+        /// </summary>
+        internal static TelemetryData GenerateExceptionData(
+            SnowflakeDbException ex,
+            string eventType = TelemetryEventType.SqlException)
+        {
+            var message = new Dictionary<string, string>
+            {
+                { TelemetryField.Type, eventType },
+                { TelemetryField.Source, SFEnvironment.DriverName },
+                { TelemetryField.DriverType, SFEnvironment.DriverName },
+                { TelemetryField.DriverVersion, SFEnvironment.DriverVersion }
+            };
+
+            if (!string.IsNullOrEmpty(ex.QueryId))
+            {
+                message[TelemetryField.QueryId] = ex.QueryId;
+            }
+
+            if (!string.IsNullOrEmpty(ex.SqlState))
+            {
+                message[TelemetryField.SqlState] = ex.SqlState;
+            }
+
+            if (ex.ErrorCode != 0)
+            {
+                message[TelemetryField.ErrorNumber] = ex.ErrorCode.ToString();
+            }
+
+            var maskedMessage = SecretDetector.MaskSecrets(ex.Message);
+            if (!string.IsNullOrEmpty(maskedMessage.maskedText))
+            {
+                message[TelemetryField.Reason] = maskedMessage.maskedText;
+            }
+
+            // ex.StackTrace is null before the exception is thrown (SendAndThrow pattern).
+            // Fall back to capturing the current call stack in that case.
+            var rawStacktrace = ex.StackTrace ?? new StackTrace(true).ToString();
+            var stacktrace = FilterStacktrace(rawStacktrace);
+            if (!string.IsNullOrEmpty(stacktrace))
+            {
+                message[TelemetryField.Stacktrace] = stacktrace;
+            }
+
+            message[TelemetryField.Exception] = ex.GetType().Name;
+
+            return new TelemetryData(message, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
+
+        /// <summary>
+        /// Filter a stacktrace to only include frames from Snowflake.Data,
+        /// truncate paths to hide user-specific filesystem prefixes,
+        /// and mask any secrets that may appear in the trace.
+        /// </summary>
+        internal static string FilterStacktrace(string stacktrace)
+        {
+            if (string.IsNullOrEmpty(stacktrace))
+                return string.Empty;
+
+            var lines = stacktrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var filtered = new StringBuilder();
+
+            foreach (var line in lines)
+            {
+                if (line.Contains(SnowflakeNamespace))
+                {
+                    // Truncate file paths to start from Snowflake.Data to hide user-specific prefixes.
+                    // A .NET stack frame looks like:
+                    //   "   at Snowflake.Data.Core.SFStatement.Execute() in /Users/dev/repo/Snowflake.Data/Core/SFStatement.cs:line 200"
+                    // We want to keep the method part and truncate the "in /path/" part.
+                    var truncated = line;
+                    var inIdx = line.IndexOf(" in ", StringComparison.Ordinal);
+                    if (inIdx >= 0)
+                    {
+                        var pathPart = line.Substring(inIdx);
+                        var nsIdx = pathPart.IndexOf(SnowflakeNamespace, StringComparison.Ordinal);
+                        if (nsIdx > 0)
+                        {
+                            // Replace " in /full/path/Snowflake.Data/..." with " in Snowflake.Data/..."
+                            truncated = line.Substring(0, inIdx) + " in " + pathPart.Substring(nsIdx);
+                        }
+                    }
+
+                    // Strip any leading whitespace/path before the "at" keyword
+                    var atIdx = truncated.IndexOf(" at ", StringComparison.Ordinal);
+                    if (atIdx >= 0)
+                    {
+                        filtered.AppendLine(truncated.Substring(atIdx));
+                    }
+                    else
+                    {
+                        filtered.AppendLine(truncated);
+                    }
+                }
+            }
+
+            var result = filtered.ToString().TrimEnd();
+            var masked = SecretDetector.MaskSecrets(result);
+            return masked.maskedText ?? result;
+        }
+    }
+}


### PR DESCRIPTION
Add automatic telemetry reporting for exceptions at key throw sites, following the Go connector's exceptionTelemetry() pattern.

New class TelemetryHelper with:
- SendExceptionTelemetry/SendAndThrow: generate and send telemetry from SnowflakeDbException, silently no-op on any failure
- GenerateExceptionData: builds telemetry payload with error code, SQL state, query ID, masked error message, and filtered stacktrace
- FilterStacktrace: keeps only Snowflake.Data frames, strips user paths, masks secrets via existing SecretDetector

Integration points:
- SFStatement: 5 query error throw sites (BuildResultSet, ExecuteHelper, ExecuteAsyncHelper, GetQueryStatus, GetQueryStatusAsync)
- SFSession: 2 session renewal failure throw sites

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
