### PR TITLE
Limited default maximum CRL size for download to 20MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### For the official .NET Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/dotnet
 
 # Changelog
+- v5.6.0
+    - Limited default maximal CRL size for download to 20MB.
 - v5.5.0
     - Include `SPCS_TOKEN` in login requests when running inside an SPCS container (`SNOWFLAKE_RUNNING_INSIDE_SPCS` env var set).
     - Extended login-request telemetry with cloud platform and environment detection (AWS Lambda, EC2, Azure VM/Functions, GCE/Cloud Run, GitHub Actions). Detection runs once at startup in the background within a 200ms timeout. Can be disabled via the `SNOWFLAKE_DISABLE_PLATFORM_DETECTION` environment variable.

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CertificateRevocationVerifierTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CertificateRevocationVerifierTest.cs
@@ -548,7 +548,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.AreEqual(CertRevocationCheckResult.CertUnrevoked, result);
         }
 
-        private HttpClientConfig GetHttpConfig(CertRevocationCheckMode checkMode = CertRevocationCheckMode.Enabled, long crlDownloadMaxSize = 209715200) =>
+        private HttpClientConfig GetHttpConfig(CertRevocationCheckMode checkMode = CertRevocationCheckMode.Enabled, long crlDownloadMaxSize = 20971520) =>
             new HttpClientConfig(
                 null,
                 null,

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -113,7 +113,7 @@ namespace Snowflake.Data.Tests.UnitTests
                     stageCredentials = null
                 },
                 statementTypeId = 0,
-                threshold = 209715200 // Server default threshold
+                threshold = 20971520 // Server default threshold
             };
 
             _cancellationToken = new CancellationToken();

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -135,7 +135,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
         [Test]
         [TestCase(100)]
-        [TestCase(209715200)]
+        [TestCase(20971520)]
         public void TestValidCrlDownloadMaxSize(long validMaxSize)
         {
             // arrange

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -146,7 +146,7 @@ namespace Snowflake.Data.Core
         ALLOWCERTIFICATESWITHOUTCRLURL,
         [SFSessionPropertyAttr(required = false, defaultValue = "10")]
         CRLDOWNLOADTIMEOUT,
-        [SFSessionPropertyAttr(required = false, defaultValue = "209715200")]
+        [SFSessionPropertyAttr(required = false, defaultValue = "20971520")]
         CRLDOWNLOADMAXSIZE,
         [SFSessionPropertyAttr(required = false, defaultValue = "tls12")]
         MINTLS,


### PR DESCRIPTION
### Description
Before the change default size of Certificate Revocation List was set to 200MB and now it's aligned with the rest of drivers to 20MB.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
