### PR TITLE
NO-SNOW support fix'd length ansi str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.6.0
+    - Added `DbType.AnsiStringFixedLength` to the set of types mapped to Snowflake `TEXT`, matching existing support for `AnsiString`, `String`, and `StringFixedLength`.
     - Extended login-request telemetry with libc detection (`LIBC_FAMILY`, `LIBC_VERSION`). On Linux, the driver now reports whether the runtime uses glibc and includes the library version.
     - Limited default maximal CRL size for download to 20MB.
     - Bug fix: Connections with sessions that no longer exist on the server are now detected and removed from the pool instead of being reused, which previously caused repeated failures until the connection expired on its own.

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -496,7 +496,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var dt = new DateTime(2024, 1, 1, 13, 45, 30, 500);
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Time, dt);
             Assert.AreEqual("TIME", result.Item1);
-            Assert.IsNotNull(result.Item2);
+            Assert.AreEqual("49530500000000", result.Item2);
         }
 
         [Test]
@@ -507,7 +507,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var dt = new DateTime(2024, 7, 15, 10, 30, 0);
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, dt);
             Assert.AreEqual("TIMESTAMP_NTZ", result.Item1);
-            Assert.IsNotNull(result.Item2);
+            Assert.AreEqual("1721039400000000000", result.Item2);
         }
 
         [Test]
@@ -516,7 +516,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var dto = new DateTimeOffset(2024, 7, 15, 10, 30, 0, TimeSpan.FromHours(5));
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.DateTimeOffset, dto);
             Assert.AreEqual("TIMESTAMP_TZ", result.Item1);
-            Assert.IsNotNull(result.Item2);
+            Assert.AreEqual("1721021400000000000 1740", result.Item2);
         }
 
         [Test]
@@ -535,8 +535,6 @@ namespace Snowflake.Data.Tests.UnitTests
                 SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Currency, 1.0m));
             SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.UNSUPPORTED_DOTNET_TYPE);
         }
-
-        // --- ConvertToCSharpVal: missing paths ---
 
         [Test]
         public void TestConvertToCSharpValNullReturnsDbNull()
@@ -638,8 +636,6 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.TIMESTAMP_TZ, typeof(DateTimeOffset)));
         }
-
-        // --- CSharpValToSfVal: missing paths ---
 
         [Test]
         public void TestCSharpValToSfValNullReturnsNull()

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -660,36 +660,40 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.IsNull(result);
         }
 
-        [Test]
-        public void TestCSharpValToSfValTime()
+        [TestCase(13, 45, 30, 500, "49530500000000")]
+        [TestCase(23, 59, 59, 999, "86399999000000")]
+        public void TestCSharpValToSfValTime(int hour, int minute, int second, int millisecond, string expected)
         {
-            var dt = new DateTime(2024, 1, 1, 13, 45, 30, 500);
+            var dt = new DateTime(2024, 1, 1, hour, minute, second, millisecond);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIME, dt);
-            Assert.AreEqual("49530500000000", result);
+            Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        public void TestCSharpValToSfValTimestampNtz()
+        [TestCase(13, 45, 30, 500, "1704116730500000000")]
+        [TestCase(23, 59, 59, 999, "1704153599999000000")]
+        public void TestCSharpValToSfValTimestampNtz(int hour, int minute, int second, int millisecond, string expected)
         {
-            var dt = new DateTime(2024, 7, 15, 10, 30, 0, DateTimeKind.Utc);
+            var dt = new DateTime(2024, 1, 1, hour, minute, second, millisecond);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_NTZ, dt);
-            Assert.AreEqual("1721039400000000000", result);
+            Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        public void TestCSharpValToSfValTimestampLtz()
+        [TestCase(13, 45, 30, 500, "1721051130500000000")]
+        [TestCase(23, 59, 59, 999, "1721087999999000000")]
+        public void TestCSharpValToSfValTimestampLtz(int hour, int minute, int second, int millisecond, string expected)
         {
-            var dto = new DateTimeOffset(2024, 7, 15, 10, 30, 0, TimeSpan.Zero);
+            var dto = new DateTimeOffset(2024, 7, 15, hour, minute, second, millisecond, TimeSpan.Zero);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_LTZ, dto);
-            Assert.AreEqual("1721039400000000000", result);
+            Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        public void TestCSharpValToSfValTimestampTz()
+        [TestCase(13, 45, 30, 500, "1721033130500000000 1740")]
+        [TestCase(23, 59, 59, 999, "1721069999999000000 1740")]
+        public void TestCSharpValToSfValTimestampTz(int hour, int minute, int second, int millisecond, string expected)
         {
-            var dto = new DateTimeOffset(2024, 7, 15, 15, 30, 0, TimeSpan.FromHours(5));
+            var dto = new DateTimeOffset(2024, 7, 15, hour, minute, second, millisecond, TimeSpan.FromHours(5));
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_TZ, dto);
-            Assert.AreEqual($"1721039400000000000 1740", result);
+            Assert.AreEqual(expected, result);
         }
 
         [Test]

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -449,45 +449,49 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestCSharpTypeValToSfTypeValGuidMapsToText()
         {
-            var guid = Guid.NewGuid();
+            var guid = new Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Guid, guid);
             Assert.AreEqual("TEXT", result.Item1);
-            Assert.AreEqual(guid.ToString(), result.Item2);
+            Assert.AreEqual("a1b2c3d4-e5f6-7890-abcd-ef1234567890", result.Item2);
         }
 
         [Test]
-        [TestCase(DbType.Decimal, "42.5")]
-        [TestCase(DbType.SByte, "-1")]
-        [TestCase(DbType.Int16, "123")]
-        [TestCase(DbType.Int32, "42")]
-        [TestCase(DbType.Int64, "9999999999")]
-        [TestCase(DbType.Byte, "255")]
-        [TestCase(DbType.UInt16, "65535")]
-        [TestCase(DbType.UInt32, "4294967295")]
-        [TestCase(DbType.UInt64, "18446744073709551615")]
-        [TestCase(DbType.VarNumeric, "123")]
-        public void TestCSharpTypeValToSfTypeValNumericTypes(DbType dbType, string srcVal)
+        [TestCase(DbType.Decimal, 42.4f, "42.4")]
+        [TestCase(DbType.Decimal, 42.3d, "42.3")]
+        [TestCase(DbType.SByte, -1, "-1")]
+        [TestCase(DbType.Int16, 123, "123")]
+        [TestCase(DbType.Int32, 42, "42")]
+        [TestCase(DbType.Int64, 9999999999L, "9999999999")]
+        [TestCase(DbType.Byte, 255, "255")]
+        [TestCase(DbType.UInt16, 65535u, "65535")]
+        [TestCase(DbType.UInt32, 4294967295u,  "4294967295")]
+        [TestCase(DbType.UInt64, 18446744073709551615ul, "18446744073709551615")]
+        [TestCase(DbType.VarNumeric, 123, "123")]
+        public void TestCSharpTypeValToSfTypeValNumericTypes(DbType dbType, object srcVal, string expectedVal)
         {
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, srcVal);
             Assert.AreEqual("FIXED", result.Item1);
-            Assert.AreEqual(srcVal, result.Item2);
+            Assert.AreEqual(expectedVal, result.Item2);
         }
 
         [Test]
-        public void TestCSharpTypeValToSfTypeValBoolean()
+        [TestCase(true, "True")]
+        [TestCase(false, "False")]
+        public void TestCSharpTypeValToSfTypeValBoolean(bool srcVal, string expectedVal)
         {
-            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Boolean, true);
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Boolean, srcVal);
             Assert.AreEqual("BOOLEAN", result.Item1);
-            Assert.AreEqual("True", result.Item2);
+            Assert.AreEqual(expectedVal, result.Item2);
         }
 
         [Test]
-        [TestCase(DbType.Double, 1.5d, "REAL")]
-        [TestCase(DbType.Single, 1.5f, "REAL")]
-        public void TestCSharpTypeValToSfTypeValRealTypes(DbType dbType, object srcVal, string expectedType)
+        [TestCase(DbType.Double, 1.5d, "REAL", "1.5")]
+        [TestCase(DbType.Single, 1.5f, "REAL", "1.5")]
+        public void TestCSharpTypeValToSfTypeValRealTypes(DbType dbType, object srcVal, string expectedType, string expectedValue)
         {
             var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, srcVal);
             Assert.AreEqual(expectedType, result.Item1);
+            Assert.AreEqual(expectedValue, result.Item2);
         }
 
         [Test]
@@ -553,8 +557,8 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestConvertToCSharpValGuid()
         {
-            var expected = Guid.NewGuid();
-            var result = SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(expected.ToString()), SFDataType.TEXT, typeof(Guid));
+            var expected = new Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+            var result = SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("a1b2c3d4-e5f6-7890-abcd-ef1234567890"), SFDataType.TEXT, typeof(Guid));
             Assert.AreEqual(expected, result);
         }
 
@@ -605,36 +609,41 @@ namespace Snowflake.Data.Tests.UnitTests
         [Test]
         public void TestConvertToCSharpValInvalidDestTypeThrows()
         {
-            Assert.Throws<SnowflakeDbException>(() =>
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("1"), SFDataType.FIXED, typeof(uint)));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INTERNAL_ERROR);
         }
 
         [Test]
         public void TestConvertToCSharpValTimeSpanWithNonTimeTypeThrows()
         {
-            Assert.Throws<SnowflakeDbException>(() =>
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(TimeSpan)));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
         }
 
         [Test]
         public void TestConvertToCSharpValDateTimeWithUnsupportedSrcTypeThrows()
         {
-            Assert.Throws<SnowflakeDbException>(() =>
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(DateTime)));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
         }
 
         [Test]
         public void TestConvertToCSharpValDateTimeOffsetWithUnsupportedSrcTypeThrows()
         {
-            Assert.Throws<SnowflakeDbException>(() =>
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(DateTimeOffset)));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
         }
 
         [Test]
         public void TestConvertToCSharpValTimestampTzMissingSpaceThrows()
         {
-            Assert.Throws<SnowflakeDbException>(() =>
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
                 SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.TIMESTAMP_TZ, typeof(DateTimeOffset)));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INTERNAL_ERROR);
         }
 
         [Test]
@@ -656,10 +665,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var dt = new DateTime(2024, 1, 1, 13, 45, 30, 500);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIME, dt);
-            // 13:45:30.500 -> ticks from midnight, then formatted as nanoseconds string
-            var tickDiff = dt.Ticks - dt.Date.Ticks;
-            var expected = $"{tickDiff}00";
-            Assert.AreEqual(expected, result);
+            Assert.AreEqual("49530500000000", result);
         }
 
         [Test]
@@ -667,9 +673,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var dt = new DateTime(2024, 7, 15, 10, 30, 0, DateTimeKind.Utc);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_NTZ, dt);
-            var tickDiff = dt.Subtract(SFDataConverter.UnixEpoch).Ticks;
-            var expected = $"{tickDiff}00";
-            Assert.AreEqual(expected, result);
+            Assert.AreEqual("1721039400000000000", result);
         }
 
         [Test]
@@ -677,9 +681,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var dto = new DateTimeOffset(2024, 7, 15, 10, 30, 0, TimeSpan.Zero);
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_LTZ, dto);
-            var tickDiff = dto.UtcTicks - SFDataConverter.UnixEpoch.Ticks;
-            var expected = $"{tickDiff}00";
-            Assert.AreEqual(expected, result);
+            Assert.AreEqual("1721039400000000000", result);
         }
 
         [Test]
@@ -687,9 +689,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var dto = new DateTimeOffset(2024, 7, 15, 15, 30, 0, TimeSpan.FromHours(5));
             var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_TZ, dto);
-            var tickDiff = dto.UtcTicks - SFDataConverter.UnixEpoch.Ticks;
-            var expectedOffset = 5 * 60 + 1440; // offset in minutes + 1440
-            Assert.AreEqual($"{tickDiff}00 {expectedOffset}", result);
+            Assert.AreEqual($"1721039400000000000 1740", result);
         }
 
         [Test]

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Text;
 using Snowflake.Data.Client;
 using Snowflake.Data.Tests.Util;
@@ -12,7 +13,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
     [TestFixture]
     [SetCulture("en-US")]
-    class SFDataConverterTest
+    public sealed class SFDataConverterTest
     {
         // Method with the same signature as before the performance work
         // Used by unit tests only
@@ -431,6 +432,340 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.NotNull(unsupportedObject);
             SnowflakeDbException ex = Assert.Throws<SnowflakeDbException>(() => SFDataConverter.CSharpValToSfVal(dataType, unsupportedObject));
             SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        [TestCase(DbType.AnsiStringFixedLength, "hello", "hello")]
+        [TestCase(DbType.AnsiString, "hello", "hello")]
+        [TestCase(DbType.String, "hello", "hello")]
+        [TestCase(DbType.StringFixedLength, "hello", "hello")]
+        public void TestCSharpTypeValToSfTypeValTextTypes(DbType dbType, string srcVal, string expectedVal)
+        {
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, srcVal);
+            Assert.AreEqual("TEXT", result.Item1);
+            Assert.AreEqual(expectedVal, result.Item2);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValGuidMapsToText()
+        {
+            var guid = Guid.NewGuid();
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Guid, guid);
+            Assert.AreEqual("TEXT", result.Item1);
+            Assert.AreEqual(guid.ToString(), result.Item2);
+        }
+
+        [Test]
+        [TestCase(DbType.Decimal, "42.5")]
+        [TestCase(DbType.SByte, "-1")]
+        [TestCase(DbType.Int16, "123")]
+        [TestCase(DbType.Int32, "42")]
+        [TestCase(DbType.Int64, "9999999999")]
+        [TestCase(DbType.Byte, "255")]
+        [TestCase(DbType.UInt16, "65535")]
+        [TestCase(DbType.UInt32, "4294967295")]
+        [TestCase(DbType.UInt64, "18446744073709551615")]
+        [TestCase(DbType.VarNumeric, "123")]
+        public void TestCSharpTypeValToSfTypeValNumericTypes(DbType dbType, string srcVal)
+        {
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, srcVal);
+            Assert.AreEqual("FIXED", result.Item1);
+            Assert.AreEqual(srcVal, result.Item2);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValBoolean()
+        {
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Boolean, true);
+            Assert.AreEqual("BOOLEAN", result.Item1);
+            Assert.AreEqual("True", result.Item2);
+        }
+
+        [Test]
+        [TestCase(DbType.Double, 1.5d, "REAL")]
+        [TestCase(DbType.Single, 1.5f, "REAL")]
+        public void TestCSharpTypeValToSfTypeValRealTypes(DbType dbType, object srcVal, string expectedType)
+        {
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, srcVal);
+            Assert.AreEqual(expectedType, result.Item1);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValTime()
+        {
+            var dt = new DateTime(2024, 1, 1, 13, 45, 30, 500);
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Time, dt);
+            Assert.AreEqual("TIME", result.Item1);
+            Assert.IsNotNull(result.Item2);
+        }
+
+        [Test]
+        [TestCase(DbType.DateTime)]
+        [TestCase(DbType.DateTime2)]
+        public void TestCSharpTypeValToSfTypeValTimestampNtz(DbType dbType)
+        {
+            var dt = new DateTime(2024, 7, 15, 10, 30, 0);
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(dbType, dt);
+            Assert.AreEqual("TIMESTAMP_NTZ", result.Item1);
+            Assert.IsNotNull(result.Item2);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValTimestampTz()
+        {
+            var dto = new DateTimeOffset(2024, 7, 15, 10, 30, 0, TimeSpan.FromHours(5));
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.DateTimeOffset, dto);
+            Assert.AreEqual("TIMESTAMP_TZ", result.Item1);
+            Assert.IsNotNull(result.Item2);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValBinary()
+        {
+            var bytes = new byte[] { 0xCA, 0xFE };
+            var result = SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Binary, bytes);
+            Assert.AreEqual("BINARY", result.Item1);
+            Assert.AreEqual("cafe", result.Item2);
+        }
+
+        [Test]
+        public void TestCSharpTypeValToSfTypeValUnsupportedTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpTypeValToSfTypeVal(DbType.Currency, 1.0m));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.UNSUPPORTED_DOTNET_TYPE);
+        }
+
+        // --- ConvertToCSharpVal: missing paths ---
+
+        [Test]
+        public void TestConvertToCSharpValNullReturnsDbNull()
+        {
+            var result = SFDataConverter.ConvertToCSharpVal(null, SFDataType.TEXT, typeof(string));
+            Assert.AreEqual(DBNull.Value, result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValString()
+        {
+            var result = SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("hello world"), SFDataType.TEXT, typeof(string));
+            Assert.AreEqual("hello world", result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValGuid()
+        {
+            var expected = Guid.NewGuid();
+            var result = SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(expected.ToString()), SFDataType.TEXT, typeof(Guid));
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValByteArrayFromBinary()
+        {
+            var expected = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE };
+            var hex = "cafebabe";
+            var result = (byte[])SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(hex), SFDataType.BINARY, typeof(byte[]));
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValByteArrayFromNonBinary()
+        {
+            var input = "hello";
+            var expected = Encoding.UTF8.GetBytes(input);
+            var result = (byte[])SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(input), SFDataType.TEXT, typeof(byte[]));
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValCharArrayFromBinary()
+        {
+            var hex = "68656c6c6f"; // "hello" in hex
+            var result = (char[])SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(hex), SFDataType.BINARY, typeof(char[]));
+            Assert.AreEqual("hello".ToCharArray(), result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValCharArrayFromNonBinary()
+        {
+            var input = "hello";
+            var result = (char[])SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(input), SFDataType.TEXT, typeof(char[]));
+            Assert.AreEqual("hello".ToCharArray(), result);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValDateTimeFromDate()
+        {
+            // DATE type: value is days since Unix epoch
+            var daysStr = "19723"; // 2024-01-01 = 19723 days since 1970-01-01
+            var result = (DateTime)SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer(daysStr), SFDataType.DATE, typeof(DateTime));
+            Assert.AreEqual(new DateTime(2024, 1, 1), result);
+            Assert.AreEqual(DateTimeKind.Unspecified, result.Kind);
+        }
+
+        [Test]
+        public void TestConvertToCSharpValInvalidDestTypeThrows()
+        {
+            Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("1"), SFDataType.FIXED, typeof(uint)));
+        }
+
+        [Test]
+        public void TestConvertToCSharpValTimeSpanWithNonTimeTypeThrows()
+        {
+            Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(TimeSpan)));
+        }
+
+        [Test]
+        public void TestConvertToCSharpValDateTimeWithUnsupportedSrcTypeThrows()
+        {
+            Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(DateTime)));
+        }
+
+        [Test]
+        public void TestConvertToCSharpValDateTimeOffsetWithUnsupportedSrcTypeThrows()
+        {
+            Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.FIXED, typeof(DateTimeOffset)));
+        }
+
+        [Test]
+        public void TestConvertToCSharpValTimestampTzMissingSpaceThrows()
+        {
+            Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.ConvertToCSharpVal(ConvertToUTF8Buffer("12345"), SFDataType.TIMESTAMP_TZ, typeof(DateTimeOffset)));
+        }
+
+        // --- CSharpValToSfVal: missing paths ---
+
+        [Test]
+        public void TestCSharpValToSfValNullReturnsNull()
+        {
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TEXT, null);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValDbNullReturnsNull()
+        {
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TEXT, DBNull.Value);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTime()
+        {
+            var dt = new DateTime(2024, 1, 1, 13, 45, 30, 500);
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIME, dt);
+            // 13:45:30.500 -> ticks from midnight, then formatted as nanoseconds string
+            var tickDiff = dt.Ticks - dt.Date.Ticks;
+            var expected = $"{tickDiff}00";
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampNtz()
+        {
+            var dt = new DateTime(2024, 7, 15, 10, 30, 0, DateTimeKind.Utc);
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_NTZ, dt);
+            var tickDiff = dt.Subtract(SFDataConverter.UnixEpoch).Ticks;
+            var expected = $"{tickDiff}00";
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampLtz()
+        {
+            var dto = new DateTimeOffset(2024, 7, 15, 10, 30, 0, TimeSpan.Zero);
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_LTZ, dto);
+            var tickDiff = dto.UtcTicks - SFDataConverter.UnixEpoch.Ticks;
+            var expected = $"{tickDiff}00";
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampTz()
+        {
+            var dto = new DateTimeOffset(2024, 7, 15, 15, 30, 0, TimeSpan.FromHours(5));
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_TZ, dto);
+            var tickDiff = dto.UtcTicks - SFDataConverter.UnixEpoch.Ticks;
+            var expectedOffset = 5 * 60 + 1440; // offset in minutes + 1440
+            Assert.AreEqual($"{tickDiff}00 {expectedOffset}", result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValBinary()
+        {
+            var bytes = new byte[] { 0xCA, 0xFE };
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.BINARY, bytes);
+            Assert.AreEqual("cafe", result);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValBinaryWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.BINARY, "not bytes"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValUnsupportedSfTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.VARIANT, "data"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.UNSUPPORTED_SNOWFLAKE_TYPE_FOR_PARAM);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimeWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.TIME, "not a datetime"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValDateWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.DATE, "not a datetime"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampNtzWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_NTZ, "not a datetime"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampLtzWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_LTZ, "not a datetimeoffset"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimestampTzWrongTypeThrows()
+        {
+            var ex = Assert.Throws<SnowflakeDbException>(() =>
+                SFDataConverter.CSharpValToSfVal(SFDataType.TIMESTAMP_TZ, "not a datetimeoffset"));
+            SnowflakeDbExceptionAssert.HasErrorCode(ex, SFError.INVALID_DATA_CONVERSION);
+        }
+
+        [Test]
+        public void TestCSharpValToSfValTimeMidnight()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0);
+            var result = SFDataConverter.CSharpValToSfVal(SFDataType.TIME, dt);
+            Assert.AreEqual("0", result);
         }
     }
 }

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -268,7 +268,6 @@ namespace Snowflake.Data.Core
         internal static Tuple<string, string> CSharpTypeValToSfTypeVal(DbType srcType, object srcVal)
         {
             SFDataType destType;
-            string destVal;
 
             switch (srcType)
             {
@@ -296,6 +295,7 @@ namespace Snowflake.Data.Core
 
                 case DbType.Guid:
                 case DbType.AnsiString:
+                case DbType.AnsiStringFixedLength:
                 case DbType.String:
                 case DbType.StringFixedLength:
                     destType = SFDataType.TEXT;
@@ -314,7 +314,6 @@ namespace Snowflake.Data.Core
                     destType = SFDataType.TIMESTAMP_NTZ;
                     break;
 
-                // By default map DateTimeoffset to TIMESTAMP_TZ
                 case DbType.DateTimeOffset:
                     destType = SFDataType.TIMESTAMP_TZ;
                     break;
@@ -326,7 +325,7 @@ namespace Snowflake.Data.Core
                 default:
                     throw new SnowflakeDbException(SFError.UNSUPPORTED_DOTNET_TYPE, srcType);
             }
-            destVal = CSharpValToSfVal(destType, srcVal);
+            var destVal = CSharpValToSfVal(destType, srcVal);
             return Tuple.Create(destType.ToString(), destVal);
         }
 
@@ -342,117 +341,78 @@ namespace Snowflake.Data.Core
 
         internal static byte[] HexToBytes(string hex)
         {
-            int NumberChars = hex.Length;
-            byte[] bytes = new byte[NumberChars / 2];
-            for (int i = 0; i < NumberChars; i += 2)
+            var numberChars = hex.Length;
+            var bytes = new byte[numberChars / 2];
+            for (var i = 0; i < numberChars; i += 2)
                 bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+
             return bytes;
         }
 
         internal static string CSharpValToSfVal(SFDataType sfDataType, object srcVal)
         {
-            string destVal = null;
+            if (srcVal == DBNull.Value || srcVal == null)
+                return null;
 
-            if (srcVal != DBNull.Value && srcVal != null)
+            switch (sfDataType)
             {
-                switch (sfDataType)
-                {
-                    case SFDataType.FIXED:
-                    case SFDataType.BOOLEAN:
-                    case SFDataType.REAL:
-                    case SFDataType.TEXT:
-                        destVal = string.Format(CultureInfo.InvariantCulture, "{0}", srcVal);
-                        break;
+                case SFDataType.FIXED:
+                case SFDataType.BOOLEAN:
+                case SFDataType.REAL:
+                case SFDataType.TEXT:
+                    return string.Format(CultureInfo.InvariantCulture, "{0}", srcVal);
 
-                    case SFDataType.TIME:
-                        if (srcVal.GetType() != typeof(DateTime))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), DbType.Time.ToString());
-                        }
-                        else
-                        {
-                            DateTime srcDt = ((DateTime)srcVal);
-                            var tickDiff = srcDt.Ticks - srcDt.Date.Ticks;
-                            destVal = TicksToNanoSecondsString(tickDiff);
-                        }
-                        break;
+                case SFDataType.TIME:
+                    if (srcVal.GetType() != typeof(DateTime))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(), nameof(DbType.Time));
 
-                    case SFDataType.DATE:
-                        if (srcVal.GetType() != typeof(DateTime))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), DbType.Date.ToString());
-                        }
-                        else
-                        {
-                            DateTime dt = ((DateTime)srcVal).Date;
-                            var ts = dt.Subtract(UnixEpoch);
-                            long millis = (long)(ts.TotalMilliseconds);
-                            destVal = millis.ToString();
-                        }
-                        break;
+                    var srcDt = ((DateTime)srcVal);
+                    var tickDiff = srcDt.Ticks - srcDt.Date.Ticks;
+                    return TicksToNanoSecondsString(tickDiff);
 
-                    case SFDataType.TIMESTAMP_LTZ:
-                        if (srcVal.GetType() != typeof(DateTimeOffset))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), SFDataType.TIMESTAMP_LTZ.ToString());
-                        }
-                        else
-                        {
-                            var tickDiff = ((DateTimeOffset)srcVal).UtcTicks - UnixEpoch.Ticks;
-                            destVal = TicksToNanoSecondsString(tickDiff);
-                        }
-                        break;
+                case SFDataType.DATE:
+                    if (srcVal.GetType() != typeof(DateTime))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(), nameof(DbType.Date));
 
-                    case SFDataType.TIMESTAMP_NTZ:
-                        if (srcVal.GetType() != typeof(DateTime))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), DbType.DateTime.ToString());
-                        }
-                        else
-                        {
-                            DateTime srcDt = (DateTime)srcVal;
-                            var diff = srcDt.Subtract(UnixEpoch);
-                            var tickDiff = diff.Ticks;
-                            destVal = TicksToNanoSecondsString(tickDiff);
-                        }
-                        break;
+                    var dt = ((DateTime)srcVal).Date;
+                    var ts = dt.Subtract(UnixEpoch);
+                    var millis = (long)(ts.TotalMilliseconds);
+                    return millis.ToString();
 
-                    case SFDataType.TIMESTAMP_TZ:
-                        if (srcVal.GetType() != typeof(DateTimeOffset))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), DbType.DateTimeOffset.ToString());
-                        }
-                        else
-                        {
-                            DateTimeOffset dtOffset = (DateTimeOffset)srcVal;
-                            var tickDiff = dtOffset.UtcTicks - UnixEpoch.Ticks;
-                            destVal = $"{TicksToNanoSecondsString(tickDiff)} {dtOffset.Offset.TotalMinutes + 1440}";
-                        }
-                        break;
+                case SFDataType.TIMESTAMP_LTZ:
+                    if (srcVal.GetType() != typeof(DateTimeOffset))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(),
+                            nameof(SFDataType.TIMESTAMP_LTZ));
 
-                    case SFDataType.BINARY:
-                        if (srcVal.GetType() != typeof(byte[]))
-                        {
-                            throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal,
-                                srcVal.GetType().ToString(), DbType.Binary.ToString());
-                        }
-                        else
-                        {
-                            destVal = BytesToHex((byte[])srcVal);
-                        }
-                        break;
+                    var tickDiffLtz = ((DateTimeOffset)srcVal).UtcTicks - UnixEpoch.Ticks;
+                    return TicksToNanoSecondsString(tickDiffLtz);
 
-                    default:
-                        throw new SnowflakeDbException(
-                            SFError.UNSUPPORTED_SNOWFLAKE_TYPE_FOR_PARAM, sfDataType.ToString());
-                }
+                case SFDataType.TIMESTAMP_NTZ:
+                    if (srcVal.GetType() != typeof(DateTime))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(), nameof(DbType.DateTime));
+
+                    var srcDtNtz = (DateTime)srcVal;
+                    var diff = srcDtNtz.Subtract(UnixEpoch);
+                    var tickDiffNtz = diff.Ticks;
+                    return TicksToNanoSecondsString(tickDiffNtz);
+
+                case SFDataType.TIMESTAMP_TZ:
+                    if (srcVal.GetType() != typeof(DateTimeOffset))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(), nameof(DbType.DateTimeOffset));
+
+                    var dtOffset = (DateTimeOffset)srcVal;
+                    var tickDiffTz = dtOffset.UtcTicks - UnixEpoch.Ticks;
+                    return $"{TicksToNanoSecondsString(tickDiffTz)} {dtOffset.Offset.TotalMinutes + 1440}";
+
+                case SFDataType.BINARY:
+                    if (srcVal.GetType() != typeof(byte[]))
+                        throw new SnowflakeDbException(SFError.INVALID_DATA_CONVERSION, srcVal, srcVal.GetType().ToString(), nameof(DbType.Binary));
+
+                    return BytesToHex((byte[])srcVal);
+
+                default:
+                    throw new SnowflakeDbException(SFError.UNSUPPORTED_SNOWFLAKE_TYPE_FOR_PARAM, sfDataType.ToString());
             }
-            return destVal;
         }
 
         private static string TicksToNanoSecondsString(long tickDiff) => tickDiff == 0 ? "0" : $"{tickDiff}00";


### PR DESCRIPTION
### Description
Added DbType.AnsiStringFixedLength to the TEXT type mapping in SFDataConverter.CSharpTypeValToSfTypeVal as requested by external users, matching
  existing support for AnsiString, String, and StringFixedLength. Slightly refactored CSharpValToSfVal with no behavioral changes. Added 37 unit tests covering the new mapping
   and previously untested code paths in ConvertToCSharpVal, CSharpTypeValToSfTypeVal, and CSharpValToSfVal —
  including null handling, type mismatches, error codes, and boundary conditions. All tests use hardcoded expected
  values to avoid tautological assertions. Updated CHANGELOG.md with the new feature entry under v5.6.0.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
