### PR TITLE
SNOW-3373902 Inbound Telemetry in dotnet driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 - v5.6.0
+    - Added client-side telemetry instrumentation using `System.Diagnostics.Activity` (OpenTelemetry-compatible). When `CLIENT_TELEMETRY_ENABLED=true` (the default), the driver automatically instruments all command executions
+      and their async variants and sends telemetry data to Snowflake's `/telemetry/send` endpoint. Activities are enriched with session context (warehouse, role, database, session id) and report success/error
+      status with exception details.
+    - Added public `StartActivity` extension method on `SnowflakeDbCommand` for creating custom client-defined
+      telemetry activities. Custom activities use a separate activity source (`Client_custom_activity`).
     - Added .NET 10 support. Changed LangVersion to C#13.
     - Added `DbType.AnsiStringFixedLength` to the set of types mapped to Snowflake `TEXT`, matching existing support for `AnsiString`, `String`, and `StringFixedLength`.
     - Extended login-request telemetry with libc detection (`LIBC_FAMILY`, `LIBC_VERSION`). On Linux, the driver now reports whether the runtime uses glibc and includes the library version.

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -1686,7 +1686,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync(); break;
                 case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync(); break;
-                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync()).Dispose(); break;
+                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync().ConfigureAwait(false)).Dispose(); break;
             }
 
             // Assert
@@ -1727,7 +1727,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             switch (method)
             {
                 case "ExecuteInAsyncMode": cmd.ExecuteInAsyncMode(); break;
-                case "ExecuteAsyncInAsyncMode": await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None); break;
+                case "ExecuteAsyncInAsyncMode": await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false); break;
                 default: throw new ArgumentException(method);
             }
 
@@ -1776,8 +1776,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         activity1Nested.SetException(new AbandonedMutexException("AAAMutex Yellow Pages"));
                     }
                     activity1.SetSuccess();
-                };
-            };
+                }
+                ;
+            }
+            ;
 
             // Act
             await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -17,6 +17,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
     using System.Collections.Generic;
     using System.Globalization;
     using Snowflake.Data.Tests.Mock;
+    using Snowflake.Data.Telemetry;
 
     [TestFixture]
     class SFDbCommandITAsync : SFBaseTestAsync
@@ -1612,6 +1613,217 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 conn.Close();
             }
+        }
+
+        [TestCase("ExecuteNonQuery", TestName = "ExecuteNonQuery emits telemetry")]
+        [TestCase("ExecuteScalar", TestName = "ExecuteScalar emits telemetry")]
+        [TestCase("ExecuteReader", TestName = "ExecuteDbDataReader emits telemetry")]
+        public void TestSyncCommandExecutionEmitsTelemetry(string method)
+        {
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = $"{ConnectionString.Replace($"CLIENT_TELEMETRY_ENABLED={false}", $"CLIENT_TELEMETRY_ENABLED={true}")}poolingEnabled=false";
+            conn.Open();
+
+            var capturedActivities = new List<Activity>();
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+            listener.ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(TelemetryTags.SessionId)?.Equals(conn.SfSession.sessionId) == true)
+                    capturedActivities.Add(activity);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            // Act
+            switch (method)
+            {
+                case "ExecuteNonQuery": cmd.ExecuteNonQuery(); break;
+                case "ExecuteScalar": cmd.ExecuteScalar(); break;
+                case "ExecuteReader": cmd.ExecuteReader().Dispose(); break;
+            }
+
+            // Assert
+            var expectedOp = method switch
+            {
+                "ExecuteNonQuery" => TelemetryActivities.ExecuteNonQuery,
+                "ExecuteScalar" => TelemetryActivities.ExecuteScalar,
+                "ExecuteReader" => TelemetryActivities.ExecuteDbDataReader,
+                _ => throw new ArgumentException(method)
+            };
+            SpinWait.SpinUntil(capturedActivities.Any, TimeSpan.FromSeconds(30));
+            AssertSingleTelemetryActivity(capturedActivities, expectedOp);
+        }
+
+        [TestCase("ExecuteNonQueryAsync", TestName = "ExecuteNonQueryAsync emits telemetry")]
+        [TestCase("ExecuteScalarAsync", TestName = "ExecuteScalarAsync emits telemetry")]
+        [TestCase("ExecuteReaderAsync", TestName = "ExecuteDbDataReaderAsync emits telemetry")]
+        public async Task TestAsyncCommandExecutionEmitsTelemetry(string method)
+        {
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = $"{ConnectionString.Replace($"CLIENT_TELEMETRY_ENABLED={false}", $"CLIENT_TELEMETRY_ENABLED={true}")}poolingEnabled=false";
+            await conn.OpenAsync();
+
+            var capturedActivities = new List<Activity>();
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+            listener.ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(TelemetryTags.SessionId)?.Equals(conn.SfSession.sessionId) == true)
+                    capturedActivities.Add(activity);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            // Act
+            switch (method)
+            {
+                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync(); break;
+                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync(); break;
+                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync()).Dispose(); break;
+            }
+
+            // Assert
+            var expectedOp = method switch
+            {
+                "ExecuteNonQueryAsync" => TelemetryActivities.ExecuteNonQueryAsync,
+                "ExecuteScalarAsync" => TelemetryActivities.ExecuteScalarAsync,
+                "ExecuteReaderAsync" => TelemetryActivities.ExecuteDbDataReaderAsync,
+                _ => throw new ArgumentException(method)
+            };
+            SpinWait.SpinUntil(capturedActivities.Any, TimeSpan.FromSeconds(30));
+            AssertSingleTelemetryActivity(capturedActivities, expectedOp);
+        }
+
+        [TestCase("ExecuteInAsyncMode", TestName = "ExecuteInAsyncMode emits telemetry")]
+        [TestCase("ExecuteAsyncInAsyncMode", TestName = "ExecuteAsyncInAsyncMode emits telemetry")]
+        public async Task TestAsyncModeExecutionEmitsTelemetry(string method)
+        {
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = $"{ConnectionString.Replace($"CLIENT_TELEMETRY_ENABLED={false}", $"CLIENT_TELEMETRY_ENABLED={true}")}poolingEnabled=false";
+            conn.Open();
+
+            var capturedActivities = new List<Activity>();
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+            listener.ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(TelemetryTags.SessionId)?.Equals(conn.SfSession.sessionId) == true)
+                    capturedActivities.Add(activity);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            // Act
+            switch (method)
+            {
+                case "ExecuteInAsyncMode": cmd.ExecuteInAsyncMode(); break;
+                case "ExecuteAsyncInAsyncMode": await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None); break;
+                default: throw new ArgumentException(method);
+            }
+
+            // Assert
+            var expectedOp = method switch
+            {
+                "ExecuteInAsyncMode" => TelemetryActivities.ExecuteInAsyncMode,
+                "ExecuteAsyncInAsyncMode" => TelemetryActivities.ExecuteAsyncInAsyncMode,
+                _ => throw new ArgumentException(method)
+            };
+            SpinWait.SpinUntil(capturedActivities.Any, TimeSpan.FromSeconds(30));
+            AssertSingleTelemetryActivity(capturedActivities, expectedOp);
+        }
+
+        [Test]
+        public async Task TestQueryIdOperationsEmitTelemetryWIthCustomEventsFromClient()
+        {
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = $"{ConnectionString.Replace($"client_telemetry_enabled=false", $"client_telemetry_enabled=true")}poolingEnabled=false";
+            conn.Open();
+
+            var capturedActivities = new List<Activity>();
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName || source.Name == ActivityStarter.ClientDefinedTelemetrySourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+            listener.ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(TelemetryTags.SessionId)?.Equals(conn.SfSession.sessionId) == true)
+                    capturedActivities.Add(activity);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            using (var activity1 = cmd.StartActivity("Custom activity!"))
+            {
+                activity1.AddTelemetryEvent("event1");
+                using (var activity1Nested = cmd.StartActivity("Custom activity 2!"))
+                {
+                    activity1.AddTelemetryEvent("event2");
+                    using (var activity1NestedNested = cmd.StartActivity("Custom activity 3!"))
+                    {
+                        activity1NestedNested.AddTelemetryEvent("event2");
+                        activity1NestedNested.SetTag("custom tag?", "value!");
+                        activity1Nested.SetTag("custom tag?2", "value!2");
+                        activity1Nested.SetException(new AbandonedMutexException("AAAMutex Yellow Pages"));
+                    }
+                    activity1.SetSuccess();
+                };
+            };
+
+            // Act
+            await cmd.ExecuteAsyncInAsyncMode(CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            SpinWait.SpinUntil(() => capturedActivities.Count > 3, TimeSpan.FromSeconds(30));
+            Assert.AreEqual(capturedActivities.Count, 4);
+            var capturedActivity1 = capturedActivities.Single(x => x.DisplayName == "Custom activity!");
+            var capturedActivity2 = capturedActivities.Single(x => x.DisplayName == "Custom activity 2!");
+            var capturedActivity3 = capturedActivities.Single(x => x.DisplayName == "Custom activity 3!");
+
+            Assert.AreEqual(ActivityKind.Client, capturedActivity1.Kind);
+            Assert.AreEqual(ActivityKind.Client, capturedActivity2.Kind);
+            Assert.AreEqual(ActivityKind.Client, capturedActivity3.Kind);
+
+            Assert.AreEqual(2, capturedActivity1.Events.Count());
+            Assert.AreEqual(1, capturedActivity2.Events.Count());
+            Assert.AreEqual(1, capturedActivity3.Events.Count());
+
+            Assert.AreEqual(conn.SfSession.sessionId, capturedActivity1.GetTagItem(TelemetryTags.SessionId));
+            Assert.AreEqual(conn.SfSession.sessionId, capturedActivity2.GetTagItem(TelemetryTags.SessionId));
+            Assert.AreEqual(conn.SfSession.sessionId, capturedActivity3.GetTagItem(TelemetryTags.SessionId));
+
+            Assert.AreEqual("OK", capturedActivity1.GetTagItem(TelemetryTags.StatusCode));
+            Assert.AreEqual("ERROR", capturedActivity2.GetTagItem(TelemetryTags.StatusCode));
+            Assert.Null(capturedActivity3.GetTagItem(TelemetryTags.StatusCode));
+        }
+
+        private static void AssertSingleTelemetryActivity(List<Activity> capturedActivities, string expectedOperationName)
+        {
+            var matching = capturedActivities
+                .Where(a => a.OperationName == expectedOperationName)
+                .ToList();
+
+            Assert.AreEqual(1, matching.Count,
+                $"Expected exactly 1 {expectedOperationName} activity but found {matching.Count}. " +
+                $"All captured: [{string.Join(", ", capturedActivities.Select(a => a.OperationName))}]");
+
+            var activity = matching.Single();
+            Assert.AreEqual(ActivityKind.Client, activity.Kind);
+            Assert.AreEqual("OK", activity.GetTagItem(TelemetryTags.StatusCode));
+            Assert.AreEqual("snowflake", activity.GetTagItem(TelemetryTags.DbSystem));
+            Assert.IsNotNull(activity.GetTagItem(TelemetryTags.SessionId));
+            Assert.IsNotNull(activity.GetTagItem(TelemetryTags.DbWarehouse));
+            Assert.IsNotNull(activity.GetTagItem(TelemetryTags.DbRole));
+            Assert.IsNotNull(activity.GetTagItem(TelemetryTags.DbName));
         }
 
         [Test]

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -129,7 +129,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // assert that cancel is not triggered by timeout, but external cancellation
                     Assert.IsTrue(externalCancel.IsCancellationRequested);
                 }
-                await Task.Delay(2000);
+                await Task.Delay(2000).ConfigureAwait(false);
                 conn.Close();
             }
         }
@@ -1665,7 +1665,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using var conn = new SnowflakeDbConnection();
             conn.ConnectionString = $"{ConnectionString.Replace($"CLIENT_TELEMETRY_ENABLED={false}", $"CLIENT_TELEMETRY_ENABLED={true}")}poolingEnabled=false";
-            await conn.OpenAsync();
+            await conn.OpenAsync().ConfigureAwait(false);
 
             var capturedActivities = new List<Activity>();
             using var listener = new ActivityListener();
@@ -1684,8 +1684,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             switch (method)
             {
-                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync(); break;
-                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync(); break;
+                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync().ConfigureAwait(false); break;
+                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync().ConfigureAwait(false); break;
                 case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync().ConfigureAwait(false)).Dispose(); break;
             }
 

--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -85,7 +85,7 @@ namespace Snowflake.Data.Tests
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SFBaseTestAsync>();
 
         private const string ConnectionStringWithoutAuthFmt = "scheme={0};host={1};port={2};certRevocationCheckMode=enabled;" +
-                                                              "account={3};role={4};db={5};schema={6};warehouse={7};";
+                                                              "account={3};role={4};db={5};schema={6};warehouse={7};client_telemetry_enabled={8}";
         private const string ConnectionStringSnowflakeAuthFmt = ";user={0};password={1};";
         private const string ConnectionStringJwtAuthFmt = ";authenticator=snowflake_jwt;user={0};private_key_file={1};";
         private const string ConnectionStringJwtContentFmt = ";authenticator=snowflake_jwt;user={0};private_key={1};";
@@ -168,7 +168,8 @@ namespace Snowflake.Data.Tests
                     testConfig.role,
                     testConfig.database,
                     testConfig.schema,
-                    testConfig.warehouse);
+                    testConfig.warehouse,
+                    "false");
 
         protected string ConnectionString => ConnectionStringWithoutAuth + GetAuthenticationString();
 

--- a/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/SFLoggerTest.cs
@@ -32,6 +32,24 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [Test]
+        public void TestIsTraceEnabled(
+            [Values(false, true)] bool isEnabled)
+        {
+            _logger = GetLogger();
+            if (isEnabled)
+            {
+                SFLoggerImpl.SetLevel(LoggingEvent.TRACE);
+            }
+            else
+            {
+                SFLoggerImpl.SetLevel(LoggingEvent.OFF);
+            }
+
+            Assert.AreEqual(isEnabled, _logger.IsTraceEnabled());
+            _logger.Trace("trace log message", new Exception("test exception"));
+        }
+
+        [Test]
         public void TestIsDebugEnabled(
             [Values(false, true)] bool isEnabled)
         {
@@ -116,6 +134,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
                 if (logLevel == LoggingEvent.OFF)
                 {
+                    Assert.IsFalse(_logger.IsTraceEnabled());
                     Assert.IsFalse(_logger.IsDebugEnabled());
                     Assert.IsFalse(_logger.IsInfoEnabled());
                     Assert.IsFalse(_logger.IsWarnEnabled());
@@ -123,6 +142,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
                 else if (logLevel == LoggingEvent.TRACE)
                 {
+                    Assert.IsTrue(_logger.IsTraceEnabled());
                     Assert.IsTrue(_logger.IsDebugEnabled());
                     Assert.IsTrue(_logger.IsInfoEnabled());
                     Assert.IsTrue(_logger.IsWarnEnabled());
@@ -130,6 +150,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
                 else if (logLevel == LoggingEvent.DEBUG)
                 {
+                    Assert.IsFalse(_logger.IsTraceEnabled());
                     Assert.IsTrue(_logger.IsDebugEnabled());
                     Assert.IsTrue(_logger.IsInfoEnabled());
                     Assert.IsTrue(_logger.IsWarnEnabled());
@@ -137,6 +158,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
                 else if (logLevel == LoggingEvent.INFO)
                 {
+                    Assert.IsFalse(_logger.IsTraceEnabled());
                     Assert.IsFalse(_logger.IsDebugEnabled());
                     Assert.IsTrue(_logger.IsInfoEnabled());
                     Assert.IsTrue(_logger.IsWarnEnabled());
@@ -144,6 +166,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
                 else if (logLevel == LoggingEvent.WARN)
                 {
+                    Assert.IsFalse(_logger.IsTraceEnabled());
                     Assert.IsFalse(_logger.IsDebugEnabled());
                     Assert.IsFalse(_logger.IsInfoEnabled());
                     Assert.IsTrue(_logger.IsWarnEnabled());
@@ -151,6 +174,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
                 else if (logLevel == LoggingEvent.ERROR)
                 {
+                    Assert.IsFalse(_logger.IsTraceEnabled());
                     Assert.IsFalse(_logger.IsDebugEnabled());
                     Assert.IsFalse(_logger.IsInfoEnabled());
                     Assert.IsFalse(_logger.IsWarnEnabled());

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -259,6 +259,20 @@ namespace Snowflake.Data.Tests.UnitTests
             }
         }
 
+        [TestCase("true")]
+        [TestCase("false")]
+        public void TestClientTelemetryEnabledPropertyIsReadFromConnectionString(string value)
+        {
+            // arrange
+            var connectionString = $"ACCOUNT=testaccount;USER=testuser;PASSWORD=testpassword;CLIENT_TELEMETRY_ENABLED={value}";
+
+            // act
+            var properties = SFSessionProperties.ParseConnectionString(connectionString, new SessionPropertiesContext());
+
+            // assert
+            Assert.AreEqual(value, properties[SFSessionProperty.CLIENT_TELEMETRY_ENABLED]);
+        }
+
         [Test]
         [TestCase("DB", SFSessionProperty.DB, "\"testdb\"")]
         [TestCase("SCHEMA", SFSessionProperty.SCHEMA, "\"quotedSchema\"")]

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
@@ -102,14 +102,11 @@ internal sealed class ActivityStarterTest
         // Assert
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
         Assert.AreEqual("ERROR", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
-        Assert.AreEqual("something went wrong", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
 
         var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "exception");
         Assert.IsNotNull(exceptionEvent);
         Assert.AreEqual(typeof(AbandonedMutexException).FullName,
             exceptionEvent.Tags.First(t => t.Key == TelemetryTags.Exception).Value);
-        Assert.AreEqual("something went wrong",
-            exceptionEvent.Tags.First(t => t.Key == TelemetryTags.ExceptionMessage).Value);
     }
 
     [Test]
@@ -136,7 +133,6 @@ internal sealed class ActivityStarterTest
 
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
         Assert.AreEqual("ERROR", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
-        Assert.AreEqual("Unknown error", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
         Assert.IsEmpty(_sessionIdCapturedActivitiesMap[session.sessionId].Events);
     }
 
@@ -150,9 +146,8 @@ internal sealed class ActivityStarterTest
         activity.SetException(exception);
 
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
-        Assert.AreEqual("password=****", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
-        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
-        Assert.AreEqual("password=****", exceptionEvent.Tags.First(t => t.Key == TelemetryTags.ExceptionMessage).Value);
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "exception");
+        Assert.NotNull(exceptionEvent);
     }
 
     [Test]

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
@@ -290,6 +290,58 @@ internal sealed class ActivityStarterTest
     }
 
     [Test]
+    public void TestAddTelemetryEventWithTagsStoresTagsOnEvent()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", telemetryEnabled: true);
+        var activity = session.StartActivity("Op");
+        Assert.IsNotNull(activity);
+
+        activity.AddTelemetryEvent("StepComplete",
+            new KeyValuePair<string, object>("step.name", "validation"),
+            new KeyValuePair<string, object>("step.duration_ms", 42));
+        activity.Stop();
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "StepComplete");
+        Assert.IsNotNull(evt);
+        Assert.AreEqual("validation", evt.Tags.First(t => t.Key == "step.name").Value);
+        Assert.AreEqual(42, evt.Tags.First(t => t.Key == "step.duration_ms").Value);
+    }
+
+    [Test]
+    public void TestAddTelemetryEventWithNoTagsCreatesEventWithEmptyTags()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", telemetryEnabled: true);
+        var activity = session.StartActivity("Op");
+        Assert.IsNotNull(activity);
+
+        activity.AddTelemetryEvent("SimpleEvent");
+        activity.Stop();
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "SimpleEvent");
+        Assert.IsNotNull(evt);
+        Assert.IsFalse(evt.Tags.Any());
+    }
+
+    [Test]
+    public void TestAddTelemetryEventWithEmptyNameDoesNotAddEvent()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", telemetryEnabled: true);
+        var activity = session.StartActivity("Op");
+        Assert.IsNotNull(activity);
+
+        activity.AddTelemetryEvent("",
+            new KeyValuePair<string, object>("key", "value"));
+        activity.AddTelemetryEvent(null,
+            new KeyValuePair<string, object>("key", "value"));
+        activity.Stop();
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        Assert.IsEmpty(_sessionIdCapturedActivitiesMap[session.sessionId].Events);
+    }
+
+    [Test]
     public void TestStartActivityOnCommandWithNullConnectionThrows()
     {
         var command = new SnowflakeDbCommand();

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Telemetry;
+
+namespace Snowflake.Data.Tests.UnitTests.Telemetry;
+
+[TestFixture]
+internal sealed class ActivityStarterTest
+{
+    private ActivityListener _listener;
+    private readonly Dictionary<string, Activity> _sessionIdCapturedActivitiesMap = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sessionIdCapturedActivitiesMap.Clear();
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => _sessionIdCapturedActivitiesMap[a.GetTagItem(TelemetryTags.SessionId).ToString()] = a
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _listener?.Dispose();
+    }
+
+    [Test]
+    public void TestStartActivityCreatesActivityWithSessionTags()
+    {
+        // Arrange
+        var session = CreateSession("sess-123", "WH_TEST", "ROLE_ADMIN", "DB_PROD", true);
+
+        // Act
+        using var activity = session.StartActivity("TestOperation");
+
+        // Assert
+        Assert.IsNotNull(activity);
+        Assert.AreEqual("TestOperation", activity.OperationName);
+        Assert.AreEqual(ActivityKind.Client, activity.Kind);
+        Assert.AreEqual("snowflake", activity.GetTagItem(TelemetryTags.DbSystem));
+        Assert.AreEqual("WH_TEST", activity.GetTagItem(TelemetryTags.DbWarehouse));
+        Assert.AreEqual("ROLE_ADMIN", activity.GetTagItem(TelemetryTags.DbRole));
+        Assert.AreEqual("DB_PROD", activity.GetTagItem(TelemetryTags.DbName));
+        Assert.AreEqual(session.sessionId, activity.GetTagItem(TelemetryTags.SessionId));
+    }
+
+    [Test]
+    public void TestStartActivityThrowsOnNullName()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        Assert.Throws<ArgumentException>(() => session.StartActivity(null));
+    }
+
+    [Test]
+    public void TestStartActivityThrowsOnEmptyName()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        Assert.Throws<ArgumentException>(() => session.StartActivity(""));
+    }
+
+    [Test]
+    public void TestSetSuccessSetsOkStatusAndStops()
+    {
+        // Arrange
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+
+        // Act
+        activity.SetSuccess();
+
+        // Assert
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        Assert.AreEqual("OK", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
+    }
+
+    [Test]
+    public void TestSetExceptionSetsErrorStatusAndAddsEvent()
+    {
+        // Arrange
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var exception = new AbandonedMutexException("something went wrong");
+
+        // Act
+        activity.SetException(exception);
+
+        // Assert
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        Assert.AreEqual("ERROR", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
+        Assert.AreEqual("something went wrong", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
+
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "exception");
+        Assert.IsNotNull(exceptionEvent);
+        Assert.AreEqual(typeof(AbandonedMutexException).FullName,
+            exceptionEvent.Tags.First(t => t.Key == TelemetryTags.Exception).Value);
+        Assert.AreEqual("something went wrong",
+            exceptionEvent.Tags.First(t => t.Key == TelemetryTags.ExceptionMessage).Value);
+    }
+
+    [Test]
+    public void TestSetSuccessOnNullActivityDoesNotThrow()
+    {
+        Activity nullActivity = null;
+        Assert.DoesNotThrow(nullActivity.SetSuccess);
+    }
+
+    [Test]
+    public void TestSetExceptionOnNullActivityDoesNotThrow()
+    {
+        Activity nullActivity = null;
+        Assert.DoesNotThrow(() => nullActivity.SetException(new Exception("test")));
+    }
+
+    [Test]
+    public void TestSetExceptionWithNullExceptionSetsUnknownError()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+
+        activity.SetException(null);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        Assert.AreEqual("ERROR", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
+        Assert.AreEqual("Unknown error", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
+        Assert.IsEmpty(_sessionIdCapturedActivitiesMap[session.sessionId].Events);
+    }
+
+    [Test]
+    public void TestSetExceptionMasksSecretsInMessage()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var exception = new InvalidOperationException("password=SuperSecret123");
+
+        activity.SetException(exception);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        Assert.AreEqual("password=****", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusDescription));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        Assert.AreEqual("password=****", exceptionEvent.Tags.First(t => t.Key == TelemetryTags.ExceptionMessage).Value);
+    }
+
+    [Test]
+    public void TestSetExceptionIncludesErrorCodeForSnowflakeDbException()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var exception = new SnowflakeDbException(SFError.INTERNAL_ERROR, "test failure");
+
+        activity.SetException(exception);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        Assert.AreEqual(typeof(SnowflakeDbException).FullName,
+            exceptionEvent.Tags.First(t => t.Key == TelemetryTags.Exception).Value);
+        var errorCode = exceptionEvent.Tags.FirstOrDefault(t => t.Key == TelemetryTags.ExceptionErrorCode).Value;
+        Assert.IsNotNull(errorCode);
+        Assert.AreEqual(exception.ErrorCode.ToString(), errorCode);
+    }
+
+    [Test]
+    public void TestSetExceptionDoesNotIncludeErrorCodeForNonSnowflakeException()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var exception = new InvalidOperationException("plain error");
+
+        activity.SetException(exception);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        Assert.IsFalse(exceptionEvent.Tags.Any(t => t.Key == TelemetryTags.ExceptionErrorCode));
+    }
+
+    [Test]
+    public void TestSetExceptionUnwrapsSnowflakeDbExceptionFromAggregateException()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var inner = new SnowflakeDbException(SFError.INTERNAL_ERROR, "nested failure");
+        var aggregate = new AggregateException("wrapper", inner);
+
+        activity.SetException(aggregate);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        var errorCode = exceptionEvent.Tags.FirstOrDefault(t => t.Key == TelemetryTags.ExceptionErrorCode).Value;
+        Assert.IsNotNull(errorCode);
+        Assert.AreEqual(inner.ErrorCode.ToString(), errorCode);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    public void TestSetExceptionUnwrapsNestedAggregateExceptions(int nestingLevel)
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        Exception snowflakeEx = new SnowflakeDbException(SFError.INTERNAL_ERROR, "deep");
+        var rootException = Enumerable.Range(0, nestingLevel).Aggregate(snowflakeEx, (ex, i) => new AggregateException($"{nestingLevel - i} level", ex));
+
+        activity.SetException(rootException);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        var errorCode = exceptionEvent.Tags.FirstOrDefault(t => t.Key == TelemetryTags.ExceptionErrorCode).Value;
+        Assert.IsNotNull(errorCode);
+        Assert.AreEqual(((SnowflakeDbException)snowflakeEx).ErrorCode.ToString(), errorCode);
+    }
+
+    [Test]
+    public void TestSetExceptionDoesNotUnwrapNestedAggregateExceptionsAfterThreshold()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        Exception snowflakeEx = new SnowflakeDbException(SFError.INTERNAL_ERROR, "deep");
+        var rootException = Enumerable.Range(0, 5).Aggregate(snowflakeEx, (ex, i) => new AggregateException($"{5 - i} level", ex));
+
+        activity.SetException(rootException);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        var errorCode = exceptionEvent.Tags.FirstOrDefault(t => t.Key == TelemetryTags.ExceptionErrorCode).Value;
+        Assert.IsNull(errorCode);
+    }
+
+    [Test]
+    public void TestSetExceptionDoesNotUnwrapNestedAggregateExceptionsAfterThresholdEvenThoughDepthFirstWouldWork()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var snowflakeEx = new SnowflakeDbException(SFError.INTERNAL_ERROR, "deep");
+        var level2 = new AggregateException("level2");
+        var level1B = new AggregateException("level1b", snowflakeEx);
+        var level1 = new AggregateException("level1", level1B);
+        var root = new AggregateException("root", level1, level2); // depth-first distance is 3, but with width-first we exceed threshold.
+
+        activity.SetException(root);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        var errorCode = exceptionEvent.Tags.FirstOrDefault(t => t.Key == TelemetryTags.ExceptionErrorCode).Value;
+        Assert.IsNull(errorCode);
+    }
+
+    [Test]
+    public void TestSetExceptionWithAggregateExceptionWithoutSnowflakeDbException()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", true);
+        var activity = session.StartActivity("Op");
+        var aggregate = new AggregateException("wrapper", new AbandonedMutexException("not snowflake"));
+
+        activity.SetException(aggregate);
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.First(e => e.Name == "exception");
+        Assert.IsFalse(exceptionEvent.Tags.Any(t => t.Key == TelemetryTags.ExceptionErrorCode));
+    }
+
+    [Test]
+    public void TestAddTelemetryEventOnNullActivityDoesNotThrow()
+    {
+        Activity nullActivity = null;
+        Assert.DoesNotThrow(() => nullActivity.AddTelemetryEvent("SomeEvent"));
+    }
+
+    [Test]
+    public void TestAddTelemetryEventAddsNamedEvent()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", telemetryEnabled: true);
+        var activity = session.StartActivity("Op");
+        Assert.IsNotNull(activity);
+
+        activity.AddTelemetryEvent("TestEvent");
+        activity.Stop();
+
+        Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
+        var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "TestEvent");
+        Assert.IsNotNull(evt);
+    }
+
+    [Test]
+    public void TestStartActivityOnCommandWithNullConnectionThrows()
+    {
+        var command = new SnowflakeDbCommand();
+        Assert.Throws<ArgumentException>(() => command.StartActivity("Op"));
+    }
+
+    [Test]
+    public void TestStartActivityOnCommandWithClosedConnectionThrows()
+    {
+        var connection = new SnowflakeDbConnection();
+        var command = new SnowflakeDbCommand(connection);
+        Assert.Throws<ArgumentException>(() => command.StartActivity("Op"));
+    }
+
+    [Test]
+    public void TestStartActivityOnCommandWithTelemetryDisabledThrows()
+    {
+        var session = CreateSession("s1", "wh", "role", "db", telemetryEnabled: false);
+
+        var connection = new SnowflakeDbConnection
+        {
+            SfSession = session,
+            _connectionState = ConnectionState.Open
+        };
+        var command = new SnowflakeDbCommand(connection);
+
+        Assert.Throws<ArgumentException>(() => command.StartActivity("Op"));
+    }
+
+    [Test]
+    public void TestStartActivityOnCommandUsesCustomActivitySource()
+    {
+        Activity captured = null;
+        using var customListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivityStarter.ClientDefinedTelemetrySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => captured = a,
+        };
+        ActivitySource.AddActivityListener(customListener);
+
+        var session = CreateSession("custom-s1", "WH", "ROLE", "DB", telemetryEnabled: true);
+
+        var connection = new SnowflakeDbConnection
+        {
+            SfSession = session,
+            _connectionState = ConnectionState.Open
+        };
+        var command = new SnowflakeDbCommand(connection);
+
+        using var activity = command.StartActivity("CustomOp");
+
+        Assert.IsNotNull(activity);
+        Assert.AreEqual(ActivityStarter.ClientDefinedTelemetrySourceName, activity.Source.Name);
+        Assert.AreEqual("CustomOp", activity.OperationName);
+        Assert.AreEqual(session.sessionId, activity.GetTagItem(TelemetryTags.SessionId));
+    }
+
+    private SFSession CreateSession(string sessionIdPrefix, string warehouse, string role, string database, bool telemetryEnabled)
+    {
+        var sessionId = sessionIdPrefix + Guid.NewGuid().ToString("N");
+        var connectionStr = "authenticator=snowflake;account=some_account;user=some_user;"
+                            + "password=fake_pwd;"
+                            + "db=testDb;role=ANALYST;warehouse=testWarehouse;host=localhost;port=443;scheme=https";
+        var mockRest = new Mock<IMockRestRequester>();
+        var session = new Mock<SFSession>(connectionStr, new SessionPropertiesContext(), mockRest.Object)
+        {
+            Object =
+            {
+                sessionId = sessionId,
+                warehouse = warehouse,
+                role = role,
+                database = database,
+                sessionToken = $"token-{sessionId}"
+            }
+        };
+        session.Setup(x => x.IsClientTelemetryEnabled()).Returns(telemetryEnabled);
+
+        return session.Object;
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -23,6 +23,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
     public sealed class ClientTelemetryWiremockTest
     {
         private static readonly string s_mappingPath = Path.Combine("wiremock", "Telemetry", "login_and_telemetry.json");
+        private static readonly string s_telemetryDisabledMappingPath = Path.Combine("wiremock", "Telemetry", "login_telemetry_disabled.json");
         private static readonly string s_failingQueryMappingPath = Path.Combine("wiremock", "Telemetry", "failing_query.json");
         private static readonly string s_connectionString =
             $"account=testaccount;user=dummyuser;password=testpwd;host=localhost;port={WiremockRunner.DefaultHttpPort};scheme=http;poolingEnabled=false;CLIENT_TELEMETRY_ENABLED=true;";
@@ -150,11 +151,30 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
         }
 
         [Test]
-        public void TestTelemetryDisabledSendsNothingToServer()
+        public void TestServerOverridesClientTelemetrySetting()
         {
+            // Client disables telemetry, but server responds with CLIENT_TELEMETRY_ENABLED=true
+            // Server wins — telemetry should be sent
             using var conn = new SnowflakeDbConnection(s_connectionStringTelemetryDisabled);
             conn.Open();
-            var sessionId = conn.SfSession.sessionId;
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+            Assert.IsNotEmpty(logs, "Server override should enable telemetry even when client disabled it");
+        }
+
+        [Test]
+        public void TestServerDisabledTelemetrySendsNothingToServer()
+        {
+            _wiremock.AddMappings(s_telemetryDisabledMappingPath);
+
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
 
             using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
             cmd.CommandText = "SELECT 1";
@@ -163,20 +183,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
             conn.Close();
 
             var telemetryRequests = GetWiremockRequestsTo("/telemetry/send", noRequestsExpected: true);
-            Assert.IsEmpty(telemetryRequests, "No telemetry should be sent when CLIENT_TELEMETRY_ENABLED=false");
-            using var conn2 = new SnowflakeDbConnection(s_connectionString);
-            conn2.Open();
-            var sessionId2 = conn2.SfSession.sessionId;
-
-            using var cmd2 = (SnowflakeDbCommand)conn2.CreateCommand();
-            cmd2.CommandText = "SELECT 1";
-            cmd2.ExecuteNonQuery();
-            conn2.Close();
-
-            var telemetryRequests2 = GetWiremockRequestsTo("/telemetry/send");
-            Assert.IsNotEmpty(telemetryRequests2);
-            Assert.True(telemetryRequests2.All(x => x["headers"]?["Sid"]?.ToString() != sessionId));
-            Assert.True(telemetryRequests2.Any(x => x["headers"]?["Sid"]?.ToString() != sessionId2));
+            Assert.IsEmpty(telemetryRequests, "No telemetry should be sent when server disables CLIENT_TELEMETRY_ENABLED");
         }
 
         [Test]
@@ -320,7 +327,10 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
         [Test]
         public void TestPublicStartActivityThrowsWhenTelemetryDisabled()
         {
-            using var conn = new SnowflakeDbConnection(s_connectionStringTelemetryDisabled);
+            _wiremock.ResetMapping();
+            _wiremock.AddMappings(s_telemetryDisabledMappingPath);
+
+            using var conn = new SnowflakeDbConnection(s_connectionString);
             conn.Open();
 
             using var cmd = (SnowflakeDbCommand)conn.CreateCommand();

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -414,25 +414,23 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
             // Custom activities
             var customLogs = logs.Where(l => l.Source == ActivityStarter.ClientDefinedTelemetrySourceName).ToList();
 
-            // Parent: 2 events (Parenting, OperationComplete) → 2 log entries
-            var parentLogs = customLogs.Where(l => l.StatusCode == "OK" && l.EventName is "Parenting" or "OperationComplete").ToList();
-            Assert.AreEqual(2, parentLogs.Count, "Parent activity should produce 2 log entries (one per event)");
-            foreach (var log in parentLogs)
-            {
-                Assert.AreEqual("client_activity", log.Type);
-                Assert.AreEqual("snowflake", log.Tag(TelemetryTags.DbSystem));
-                Assert.AreEqual("telemetry-test-session", log.Tag(TelemetryTags.SessionId));
-            }
+            // Parent: synthetic event + 2 explicit events (Parenting, OperationComplete) → 3 log entries
+            var parentSynthetic = customLogs.Single(l => l.EventName == "Parent");
+            Assert.AreEqual("client_activity", parentSynthetic.Type);
+            Assert.AreEqual("snowflake", parentSynthetic.Tag(TelemetryTags.DbSystem));
+            Assert.AreEqual("telemetry-test-session", parentSynthetic.Tag(TelemetryTags.SessionId));
+            var parentEventLogs = customLogs.Where(l => l.EventName is "Parenting" or "OperationComplete").ToList();
+            Assert.AreEqual(2, parentEventLogs.Count, "Parent activity should produce 2 explicit event log entries");
 
-            // OldestChild: 1 event (PsyOpDone), OK status, custom tag
-            var oldestChildLog = customLogs.Single(l => l.EventName == "PsyOpDone");
-            Assert.AreEqual("OK", oldestChildLog.StatusCode);
-            Assert.AreEqual("1000", oldestChildLog.Tag("some_sort_of_clients_psy_op"));
+            // OldestChild: synthetic event (with custom tag) + 1 explicit event (PsyOpDone)
+            var oldestChildSynthetic = customLogs.Single(l => l.EventName == "OldestChild");
+            Assert.AreEqual("OK", oldestChildSynthetic.StatusCode);
+            Assert.AreEqual("1000", oldestChildSynthetic.Tag("some_sort_of_clients_psy_op"));
 
-            // MiddleChild: failed with AbandonedMutexException → ERROR status, exception event
-            var middleChildLogs = customLogs.Where(l => l.StatusCode == "ERROR").ToList();
-            Assert.AreEqual(1, middleChildLogs.Count, "Exactly one activity expected (MiddleChild)");
-            Assert.AreEqual("123", middleChildLogs.Single().Tag("Something"));
+            // MiddleChild: synthetic event (with custom tag) + exception event → ERROR status
+            var middleChildSynthetic = customLogs.Single(l => l.EventName == "MiddleChild");
+            Assert.AreEqual("ERROR", middleChildSynthetic.StatusCode);
+            Assert.AreEqual("123", middleChildSynthetic.Tag("Something"));
 
             // YoungestChild: no SetSuccess/SetException called → UNSET status, synthetic event with display name
             var youngestChildLog = customLogs.Single(l => l.EventName == "YoungestChild");

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -97,7 +97,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
                 case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync()).Dispose(); break;
             }
 
-            await conn.CloseAsync();
+            await conn.CloseAsync(CancellationToken.None);
 
             var logs = GetTelemetryLogs();
             var matching = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName && l.StatusCode == "OK").ToList();

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -433,7 +433,6 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
             var middleChildLogs = customLogs.Where(l => l.StatusCode == "ERROR").ToList();
             Assert.AreEqual(1, middleChildLogs.Count, "Exactly one activity expected (MiddleChild)");
             Assert.AreEqual("123", middleChildLogs.Single().Tag("Something"));
-            Assert.AreEqual("Not great, not terrible", middleChildLogs.Single().Tag(TelemetryTags.StatusDescription));
 
             // YoungestChild: no SetSuccess/SetException called → UNSET status, synthetic event with display name
             var youngestChildLog = customLogs.Single(l => l.EventName == "YoungestChild");

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -1,0 +1,502 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Telemetry;
+using Snowflake.Data.Tests.Util;
+
+namespace Snowflake.Data.Tests.UnitTests.Telemetry
+{
+    /// <summary>
+    /// End-to-(almost)-end telemetry tests using wiremock.
+    /// Verifies the real pipeline: command execution -> activity -> SessionTelemetryModule -> POST /telemetry/send -> wiremock captures it.
+    /// Assertions are made against what wiremock actually received, not against in-process activity captures.
+    /// </summary>
+    [TestFixture, NonParallelizable]
+    public sealed class ClientTelemetryWiremockTest
+    {
+        private static readonly string s_mappingPath = Path.Combine("wiremock", "Telemetry", "login_and_telemetry.json");
+        private static readonly string s_failingQueryMappingPath = Path.Combine("wiremock", "Telemetry", "failing_query.json");
+        private static readonly string s_connectionString =
+            $"account=testaccount;user=dummyuser;password=testpwd;host=localhost;port={WiremockRunner.DefaultHttpPort};scheme=http;poolingEnabled=false;CLIENT_TELEMETRY_ENABLED=true;";
+        private static readonly string s_connectionStringTelemetryDisabled =
+            $"account=testaccount;user=dummyuser;password=testpwd;host=localhost;port={WiremockRunner.DefaultHttpPort};scheme=http;poolingEnabled=false;CLIENT_TELEMETRY_ENABLED=false;";
+        private static readonly HttpClient s_http = new();
+
+        private WiremockRunner _wiremock;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            _wiremock = WiremockRunner.NewWiremock();
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            _wiremock?.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _wiremock.ResetMapping();
+            _wiremock.AddMappings(s_mappingPath);
+        }
+
+        [Test]
+        [TestCase("ExecuteNonQuery", TestName = "ExecuteNonQuery telemetry sent to server")]
+        [TestCase("ExecuteScalar", TestName = "ExecuteScalar telemetry sent to server")]
+        [TestCase("ExecuteReader", TestName = "ExecuteDbDataReader telemetry sent to server")]
+        public void TestSyncCommandSendsTelemetryToServer(string method)
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            switch (method)
+            {
+                case "ExecuteNonQuery": cmd.ExecuteNonQuery(); break;
+                case "ExecuteScalar": cmd.ExecuteScalar(); break;
+                case "ExecuteReader": cmd.ExecuteReader().Dispose(); break;
+            }
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+            var matching = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName && l.StatusCode == "OK").ToList();
+            Assert.IsNotEmpty(matching, $"Expected telemetry log for {method} to be sent to /telemetry/send");
+            Assert.AreEqual("client_activity", matching.First().Type);
+        }
+
+        [Test]
+        [TestCase("ExecuteNonQueryAsync", TestName = "ExecuteNonQueryAsync telemetry sent to server")]
+        [TestCase("ExecuteScalarAsync", TestName = "ExecuteScalarAsync telemetry sent to server")]
+        [TestCase("ExecuteReaderAsync", TestName = "ExecuteDbDataReaderAsync telemetry sent to server")]
+        public async Task TestAsyncCommandSendsTelemetryToServer(string method)
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            await conn.OpenAsync();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            switch (method)
+            {
+                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync(); break;
+                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync(); break;
+                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync()).Dispose(); break;
+            }
+
+            await conn.CloseAsync();
+
+            var logs = GetTelemetryLogs();
+            var matching = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName && l.StatusCode == "OK").ToList();
+            Assert.IsNotEmpty(matching, $"Expected telemetry log for {method} to be sent to /telemetry/send");
+            Assert.AreEqual("client_activity", matching.First().Type);
+        }
+
+        [Test]
+        public void TestTelemetryPayloadContainsSessionTags()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+            Assert.IsNotEmpty(logs, "Expected at least one telemetry log");
+
+            var log = logs.First();
+            Assert.AreEqual("snowflake", log.Tag(TelemetryTags.DbSystem));
+            Assert.AreEqual("telemetry-test-session", log.Tag(TelemetryTags.SessionId));
+            Assert.AreEqual("TEST_WH", log.Tag(TelemetryTags.DbWarehouse));
+            Assert.AreEqual("TEST_ROLE", log.Tag(TelemetryTags.DbRole));
+            Assert.AreEqual("TEST_DB", log.Tag(TelemetryTags.DbName));
+        }
+
+        [Test]
+        public void TestTelemetryPayloadContainsDriverMetadata()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+            Assert.IsNotEmpty(logs);
+
+            var log = logs.First();
+            Assert.AreEqual(".NET", log.DriverType);
+            Assert.IsNotNull(log.DriverVersion);
+            Assert.IsNotNull(log.Duration);
+        }
+
+        [Test]
+        public void TestTelemetryDisabledSendsNothingToServer()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionStringTelemetryDisabled);
+            conn.Open();
+            var sessionId = conn.SfSession.sessionId;
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var telemetryRequests = GetWiremockRequestsTo("/telemetry/send", noRequestsExpected: true);
+            Assert.IsEmpty(telemetryRequests, "No telemetry should be sent when CLIENT_TELEMETRY_ENABLED=false");
+            using var conn2 = new SnowflakeDbConnection(s_connectionString);
+            conn2.Open();
+            var sessionId2 = conn2.SfSession.sessionId;
+
+            using var cmd2 = (SnowflakeDbCommand)conn2.CreateCommand();
+            cmd2.CommandText = "SELECT 1";
+            cmd2.ExecuteNonQuery();
+            conn2.Close();
+
+            var telemetryRequests2 = GetWiremockRequestsTo("/telemetry/send");
+            Assert.IsNotEmpty(telemetryRequests2);
+            Assert.True(telemetryRequests2.All(x => x["headers"]?["Sid"]?.ToString() != sessionId));
+            Assert.True(telemetryRequests2.Any(x => x["headers"]?["Sid"]?.ToString() != sessionId2));
+        }
+
+        [Test]
+        public void TestTelemetrySentWithCorrectAuthToken()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var telemetryRequests = GetWiremockRequestsTo("/telemetry/send");
+            Assert.IsNotEmpty(telemetryRequests);
+
+            var authHeader = telemetryRequests.First()["headers"]?["Authorization"]?.ToString();
+            Assert.AreEqual("Snowflake Token=\"session-token\"", authHeader);
+        }
+
+        [Test]
+        public void TestCommandFailureSendsTelemetryWithErrorStatus()
+        {
+            _wiremock.AddMappings(s_failingQueryMappingPath);
+
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            Assert.Throws<SnowflakeDbException>(() => cmd.ExecuteNonQuery());
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+            var errorLogs = logs.Where(l => l.StatusCode == "ERROR").ToList();
+            Assert.IsNotEmpty(errorLogs, "Expected at least one ERROR telemetry log when command fails");
+        }
+
+        [Test]
+        public void TestPublicStartActivityWithSuccessDoesNotInterfereWithInternalTelemetry()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            using (var activity = cmd.StartActivity("MyCustomOp"))
+            {
+                activity?.SetTag("app.module", "billing");
+                activity?.SetTag("app.batch_size", "500");
+                activity?.SetSuccess();
+            }
+
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+
+            // Internal telemetry
+            var internalLogs = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName).ToList();
+            Assert.IsNotEmpty(internalLogs, "Internal telemetry should still be sent");
+            Assert.AreEqual("OK", internalLogs.First().StatusCode);
+
+            // Custom telemetry — single synthetic entry (no events added → display name becomes event name)
+            var customLogs = logs.Where(l => l.Source == ActivityStarter.ClientDefinedTelemetrySourceName).ToList();
+            Assert.AreEqual(1, customLogs.Count, "Exactly one custom telemetry log expected (MyCustomOp has no events, so one synthetic entry)");
+
+            var custom = customLogs.Single();
+            Assert.AreEqual("client_activity", custom.Type);
+            Assert.AreEqual(ActivityStarter.ClientDefinedTelemetrySourceName, custom.Source);
+            Assert.AreEqual("MyCustomOp", custom.EventName);
+            Assert.AreEqual("OK", custom.StatusCode);
+            Assert.AreEqual(".NET", custom.DriverType);
+            Assert.AreEqual("billing", custom.Tag("app.module"));
+            Assert.AreEqual("500", custom.Tag("app.batch_size"));
+            Assert.AreEqual("telemetry-test-session", custom.Tag(TelemetryTags.SessionId));
+            Assert.AreEqual("snowflake", custom.Tag(TelemetryTags.DbSystem));
+        }
+
+        [Test]
+        public void TestPublicStartActivityWithExceptionDoesNotCrash()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            using (var activity = cmd.StartActivity("FailingOp"))
+            {
+                activity?.SetException(new InvalidOperationException("something broke"));
+            }
+
+            cmd.CommandText = "SELECT 1";
+            Assert.DoesNotThrow(() => cmd.ExecuteNonQuery());
+
+            conn.Close();
+        }
+
+        [Test]
+        public void TestPublicStartActivityWithTelemetryEvent()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            // Capture custom activities to verify events
+            var customActivities = new List<Activity>();
+            using var customListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == ActivityStarter.ClientDefinedTelemetrySourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStopped = customActivities.Add,
+            };
+            ActivitySource.AddActivityListener(customListener);
+
+            using (var activity = cmd.StartActivity("MultiStepOp"))
+            {
+                activity?.AddTelemetryEvent("StepOneComplete");
+                activity?.AddTelemetryEvent("StepTwoComplete");
+                activity?.SetSuccess();
+            }
+
+            Assert.AreEqual(1, customActivities.Count);
+            var captured = customActivities.Single();
+            Assert.AreEqual("MultiStepOp", captured.OperationName);
+            Assert.AreEqual(ActivityStarter.ClientDefinedTelemetrySourceName, captured.Source.Name);
+
+            var eventNames = captured.Events.Select(e => e.Name).ToList();
+            Assert.Contains("StepOneComplete", eventNames);
+            Assert.Contains("StepTwoComplete", eventNames);
+
+            conn.Close();
+        }
+
+        [Test]
+        public void TestPublicStartActivityThrowsWhenTelemetryDisabled()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionStringTelemetryDisabled);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            var ex = Assert.Throws<ArgumentException>(() => cmd.StartActivity("ShouldFail"));
+            Assert.That(ex.Message, Does.Contain("Client telemetry needs to be enabled"));
+
+            conn.Close();
+        }
+
+        [Test]
+        public void TestPublicStartActivityEnrichesWithSessionContext()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            var customActivities = new List<Activity>();
+            using var customListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == ActivityStarter.ClientDefinedTelemetrySourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStopped = customActivities.Add,
+            };
+            ActivitySource.AddActivityListener(customListener);
+
+            using (var activity = cmd.StartActivity("ContextCheck"))
+            {
+                activity?.SetSuccess();
+            }
+
+            Assert.AreEqual(1, customActivities.Count);
+            var captured = customActivities.Single();
+            Assert.AreEqual("snowflake", captured.GetTagItem(TelemetryTags.DbSystem));
+            Assert.AreEqual("telemetry-test-session", captured.GetTagItem(TelemetryTags.SessionId));
+            Assert.AreEqual("TEST_WH", captured.GetTagItem(TelemetryTags.DbWarehouse));
+            Assert.AreEqual("TEST_ROLE", captured.GetTagItem(TelemetryTags.DbRole));
+            Assert.AreEqual("TEST_DB", captured.GetTagItem(TelemetryTags.DbName));
+
+            conn.Close();
+        }
+
+        [Test]
+        public void TestPublicStartActivityWithNestedActivitiesAndCommandExecution()
+        {
+            using var conn = new SnowflakeDbConnection(s_connectionString);
+            conn.Open();
+
+            using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
+
+            using (var parentActvity = cmd.StartActivity("Parent"))
+            {
+                parentActvity?.AddTelemetryEvent("Parenting");
+
+                using (var childActivity = cmd.StartActivity("OldestChild"))
+                {
+                    childActivity?.SetTag("some_sort_of_clients_psy_op", "1000");
+                    childActivity?.AddTelemetryEvent("PsyOpDone");
+                    childActivity?.SetSuccess();
+                }
+
+                using (var unsuccessfulChild = cmd.StartActivity("MiddleChild"))
+                {
+                    unsuccessfulChild.SetTag("Something", "123");
+                    unsuccessfulChild.SetException(new AbandonedMutexException("Not great, not terrible"));
+                }
+
+                using (var youngestChild = cmd.StartActivity("YoungestChild"))
+                {
+                    youngestChild.SetCustomProperty("special", "✨");
+                    youngestChild.SetBaggage("emotional", "one");
+                }
+
+                cmd.CommandText = "SELECT 1";
+                cmd.ExecuteNonQuery();
+
+                parentActvity?.AddTelemetryEvent("OperationComplete");
+                parentActvity?.SetSuccess();
+            }
+
+            conn.Close();
+
+            var logs = GetTelemetryLogs();
+
+            // Internal command telemetry
+            var internalLogs = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName).ToList();
+            Assert.IsNotEmpty(internalLogs, "Internal telemetry for ExecuteNonQuery should be sent to server");
+            Assert.AreEqual("OK", internalLogs.First().StatusCode);
+
+            // Custom activities
+            var customLogs = logs.Where(l => l.Source == ActivityStarter.ClientDefinedTelemetrySourceName).ToList();
+
+            // Parent: 2 events (Parenting, OperationComplete) → 2 log entries
+            var parentLogs = customLogs.Where(l => l.StatusCode == "OK" && l.EventName is "Parenting" or "OperationComplete").ToList();
+            Assert.AreEqual(2, parentLogs.Count, "Parent activity should produce 2 log entries (one per event)");
+            foreach (var log in parentLogs)
+            {
+                Assert.AreEqual("client_activity", log.Type);
+                Assert.AreEqual("snowflake", log.Tag(TelemetryTags.DbSystem));
+                Assert.AreEqual("telemetry-test-session", log.Tag(TelemetryTags.SessionId));
+            }
+
+            // OldestChild: 1 event (PsyOpDone), OK status, custom tag
+            var oldestChildLog = customLogs.Single(l => l.EventName == "PsyOpDone");
+            Assert.AreEqual("OK", oldestChildLog.StatusCode);
+            Assert.AreEqual("1000", oldestChildLog.Tag("some_sort_of_clients_psy_op"));
+
+            // MiddleChild: failed with AbandonedMutexException → ERROR status, exception event
+            var middleChildLogs = customLogs.Where(l => l.StatusCode == "ERROR").ToList();
+            Assert.AreEqual(1, middleChildLogs.Count, "Exactly one activity expected (MiddleChild)");
+            Assert.AreEqual("123", middleChildLogs.Single().Tag("Something"));
+            Assert.AreEqual("Not great, not terrible", middleChildLogs.Single().Tag(TelemetryTags.StatusDescription));
+
+            // YoungestChild: no SetSuccess/SetException called → UNSET status, synthetic event with display name
+            var youngestChildLog = customLogs.Single(l => l.EventName == "YoungestChild");
+            Assert.AreEqual("UNSET", youngestChildLog.StatusCode);
+        }
+
+        #region Helpers
+
+        private List<TelemetryLogEntry> GetTelemetryLogs()
+        {
+            var requests = GetWiremockRequestsTo("/telemetry/send");
+            var logs = new List<TelemetryLogEntry>();
+            foreach (var req in requests)
+            {
+                var body = req["body"]?.ToString();
+                if (string.IsNullOrEmpty(body)) continue;
+                var parsed = JObject.Parse(body);
+                if (parsed["logs"] is JArray logsArray)
+                    logs.AddRange(logsArray.Select(t => new TelemetryLogEntry(t)));
+            }
+            return logs;
+        }
+
+        private List<JToken> GetWiremockRequestsTo(string urlPath, int alreadyRetriedCount = 0, bool noRequestsExpected = false)
+        {
+            for (;;)
+            {
+                if (alreadyRetriedCount++ == 3) throw new TimeoutException("Wiremock returns no data!");
+
+                var requestBody = $"{{\"urlPathPattern\": \"{urlPath}\"}}";
+                var baseUrl = _wiremock.WiremockBaseHttpUrl + "/__admin/requests/find";
+                var response = s_http.PostAsync(baseUrl, new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json")).Result;
+                var json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+                var wiremockRequestsTo = (json["requests"] as JArray)?.ToList();
+
+                if (noRequestsExpected) return wiremockRequestsTo;
+                if (wiremockRequestsTo != null && wiremockRequestsTo.Count != 0) return wiremockRequestsTo;
+
+                Thread.Sleep(500);
+            }
+        }
+
+        /// <summary>
+        /// Strongly typed view over a single telemetry log entry received by wiremock.
+        /// Wraps the raw <c>{"message": {...}, "timestamp": ...}</c> JToken.
+        /// </summary>
+        private sealed class TelemetryLogEntry
+        {
+            private readonly JToken _message;
+
+            internal TelemetryLogEntry(JToken raw) => _message = raw["message"];
+
+            internal string Type => _message?[TelemetryField.Type]?.ToString();
+            internal string Source => _message?[TelemetryField.Source]?.ToString();
+            internal string EventName => _message?[TelemetryField.EventName]?.ToString();
+            internal string StatusCode => _message?[TelemetryField.StatusCode]?.ToString();
+            internal string DriverType => _message?[TelemetryField.DriverType]?.ToString();
+            internal string DriverVersion => _message?[TelemetryField.DriverVersion]?.ToString();
+            internal string Duration => _message?[TelemetryField.Duration]?.ToString();
+
+            internal string Tag(string tagName) => _message?[$"tag.{tagName}"]?.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -459,7 +459,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
 
         private List<JToken> GetWiremockRequestsTo(string urlPath, int alreadyRetriedCount = 0, bool noRequestsExpected = false)
         {
-            for (;;)
+            for (; ; )
             {
                 if (alreadyRetriedCount++ == 3) throw new TimeoutException("Wiremock returns no data!");
 

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -252,7 +252,7 @@ internal sealed class SessionTelemetryModuleTest
         var expectedToken1 = "test-token";
         _mockRestRequester.Verify(x => x.PostAsync<NullDataResponse>(It.Is<IRestRequest>(y => ((SFRestRequest)y).authorizationToken == $"Snowflake Token=\"{expectedToken1}\""), It.IsAny<CancellationToken>()), Times.Once);
 
-        var newToken  = "new-token";
+        var newToken = "new-token";
         module.UpdateToken(newToken);
         var activity2 = new Activity("whatever 2");
         activity2.Start();
@@ -289,7 +289,7 @@ internal sealed class SessionTelemetryModuleTest
 
     [TestCase(1)]
     [TestCase(3)]
-    public void TestSyncFlushOnDisposeDisablesTelemetryOnNonSuccessResponse(int  disposeCalls)
+    public void TestSyncFlushOnDisposeDisablesTelemetryOnNonSuccessResponse(int disposeCalls)
     {
         // Arrange
         var session = CreateSession();
@@ -453,7 +453,7 @@ internal sealed class SessionTelemetryModuleTest
         });
 
         await Task.Delay((int)timerSpan.TotalMilliseconds * 2).ConfigureAwait(false);
-        Assert.That(logsSent, Is.EqualTo(bufferSize-1));
+        Assert.That(logsSent, Is.EqualTo(bufferSize - 1));
 
         var activity = new Activity($"whatever {bufferSize}");
         activity.Start();

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -62,9 +62,9 @@ internal sealed class SessionTelemetryModuleTest
     [TestCase(null, null, null, "UNSET", 1, TestName = "Eventless activity with UNSET status")]
     [TestCase(null, null, ActivityStatusCode.Ok, "OK", 1, TestName = "Eventless activity with OK status")]
     [TestCase(null, null, ActivityStatusCode.Error, "ERROR", 1, TestName = "Eventless activity with ERROR status")]
-    [TestCase("EventA", null, null, "UNSET", 1, TestName = "Activity with one event")]
-    [TestCase("EventA", "EventB", null, "UNSET", 2, TestName = "Activity with two events produces two log entries")]
-    [TestCase("EventA", "EventB", ActivityStatusCode.Ok, "OK", 2, TestName = "Activity with events and OK status")]
+    [TestCase("EventA", null, null, "UNSET", 2, TestName = "Activity with one event")]
+    [TestCase("EventA", "EventB", null, "UNSET", 3, TestName = "Activity with two events produces three log entries")]
+    [TestCase("EventA", "EventB", ActivityStatusCode.Ok, "OK", 3, TestName = "Activity with events and OK status")]
     public async Task TestFlushAsyncConvertsActivityToTelemetryData(string event1, string event2, ActivityStatusCode? status, string expectedStatus, int expectedLogCount)
     {
         // Arrange
@@ -94,6 +94,8 @@ internal sealed class SessionTelemetryModuleTest
         // Assert
         Assert.IsNotNull(capturedBody);
         Assert.AreEqual(expectedLogCount, capturedBody.Logs.Count);
+        // First entry is always the synthetic activity event
+        Assert.AreEqual("TestOp", capturedBody.Logs[0].Message[TelemetryField.EventName]);
         foreach (var log in capturedBody.Logs)
         {
             Assert.AreEqual("client_activity", log.Message[TelemetryField.Type]);
@@ -102,9 +104,9 @@ internal sealed class SessionTelemetryModuleTest
             Assert.NotNull(log.Message[TelemetryField.DriverVersion]);
         }
         if (event1 != null)
-            Assert.AreEqual(event1, capturedBody.Logs[0].Message[TelemetryField.EventName]);
+            Assert.AreEqual(event1, capturedBody.Logs[1].Message[TelemetryField.EventName]);
         if (event2 != null)
-            Assert.AreEqual(event2, capturedBody.Logs[1].Message[TelemetryField.EventName]);
+            Assert.AreEqual(event2, capturedBody.Logs[2].Message[TelemetryField.EventName]);
     }
 
     [Test]
@@ -526,6 +528,49 @@ internal sealed class SessionTelemetryModuleTest
         var log = capturedBody.Logs.First();
         Assert.IsTrue(log.Message.ContainsKey("tag.present"));
         Assert.IsFalse(log.Message.ContainsKey("tag.absent"));
+    }
+
+    [Test]
+    public async Task TestActivityTagsOnSyntheticEventAndEventTagsOnExplicitEvents()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) =>
+            {
+                capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody;
+            })
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("MyOp");
+        activity.Start();
+        activity.SetTag("session.tag", "session_value");
+        activity.AddEvent(new ActivityEvent("Step1", tags: new ActivityTagsCollection(new[]
+        {
+            new KeyValuePair<string, object>("event.tag", "event_value"),
+        })));
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        Assert.AreEqual(2, capturedBody.Logs.Count);
+
+        // Synthetic event carries activity-level tags
+        var syntheticLog = capturedBody.Logs[0];
+        Assert.AreEqual("MyOp", syntheticLog.Message[TelemetryField.EventName]);
+        Assert.AreEqual("session_value", syntheticLog.Message["tag.session.tag"]);
+        Assert.IsFalse(syntheticLog.Message.ContainsKey("tag.event.tag"));
+
+        // Explicit event carries its own tags
+        var eventLog = capturedBody.Logs[1];
+        Assert.AreEqual("Step1", eventLog.Message[TelemetryField.EventName]);
+        Assert.AreEqual("event_value", eventLog.Message["tag.event.tag"]);
+        Assert.IsFalse(eventLog.Message.ContainsKey("tag.session.tag"));
     }
 
 

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -1,0 +1,550 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Telemetry;
+
+namespace Snowflake.Data.Tests.UnitTests.Telemetry;
+
+[TestFixture]
+internal sealed class SessionTelemetryModuleTest
+{
+    private Mock<IMockRestRequester> _mockRestRequester;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRestRequester = new Mock<IMockRestRequester>();
+    }
+
+    [Test]
+    public void TestDisposeIsIdempotent()
+    {
+        var session = CreateSession();
+        var module = new SessionTelemetryModule(session);
+
+        // Act - double dispose should not throw
+        Assert.DoesNotThrow(() =>
+        {
+            module.Dispose();
+            module.Dispose();
+        });
+    }
+
+    [Test]
+    public void TestDisposeIsIdempotentWhenBuffer()
+    {
+        var session = CreateSession();
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("whatever");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+        Assert.AreEqual(1, ((ISessionTelemetryModule)module).CurrentBufferSize);
+
+        // Act - double dispose should not throw
+        Assert.DoesNotThrow(() =>
+        {
+            module.Dispose();
+            Assert.AreEqual(0, ((ISessionTelemetryModule)module).CurrentBufferSize);
+            module.Dispose();
+        });
+    }
+
+    [Test]
+    [TestCase(null, null, null, "UNSET", 1, TestName = "Eventless activity with UNSET status")]
+    [TestCase(null, null, ActivityStatusCode.Ok, "OK", 1, TestName = "Eventless activity with OK status")]
+    [TestCase(null, null, ActivityStatusCode.Error, "ERROR", 1, TestName = "Eventless activity with ERROR status")]
+    [TestCase("EventA", null, null, "UNSET", 1, TestName = "Activity with one event")]
+    [TestCase("EventA", "EventB", null, "UNSET", 2, TestName = "Activity with two events produces two log entries")]
+    [TestCase("EventA", "EventB", ActivityStatusCode.Ok, "OK", 2, TestName = "Activity with events and OK status")]
+    public async Task TestFlushAsyncConvertsActivityToTelemetryData(string event1, string event2, ActivityStatusCode? status, string expectedStatus, int expectedLogCount)
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) => capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody)
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("TestOp");
+        activity.Start();
+        if (status.HasValue)
+            activity.SetStatus(status.Value);
+        if (event1 != null)
+            activity.AddEvent(new ActivityEvent(event1));
+        if (event2 != null)
+            activity.AddEvent(new ActivityEvent(event2));
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        Assert.AreEqual(expectedLogCount, capturedBody.Logs.Count);
+        foreach (var log in capturedBody.Logs)
+        {
+            Assert.AreEqual("client_activity", log.Message[TelemetryField.Type]);
+            Assert.AreEqual(".NET", log.Message[TelemetryField.DriverType]);
+            Assert.AreEqual(expectedStatus, log.Message[TelemetryField.StatusCode]);
+            Assert.NotNull(log.Message[TelemetryField.DriverVersion]);
+        }
+        if (event1 != null)
+            Assert.AreEqual(event1, capturedBody.Logs[0].Message[TelemetryField.EventName]);
+        if (event2 != null)
+            Assert.AreEqual(event2, capturedBody.Logs[1].Message[TelemetryField.EventName]);
+    }
+
+    [Test]
+    public async Task TestFlushAsyncSendsMultipleActivities()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) => capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody)
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        foreach (var name in new[] { "Op1", "Op2", "Op3" })
+        {
+            var a = new Activity(name);
+            a.Start();
+            module.OnActivityStoppedImpl(a);
+        }
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        Assert.AreEqual(3, capturedBody.Logs.Count);
+        Assert.AreEqual("Op1", capturedBody.Logs[0].Message[TelemetryField.EventName]);
+        Assert.AreEqual("Op2", capturedBody.Logs[1].Message[TelemetryField.EventName]);
+        Assert.AreEqual("Op3", capturedBody.Logs[2].Message[TelemetryField.EventName]);
+    }
+
+    [Test]
+    public async Task TestFlushAsyncSendsMultipleNestedActivities()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) => capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody)
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        using (var a1 = new Activity("Op1"))
+        {
+            a1.Start();
+            using (var a2 = new Activity("Op2"))
+            {
+                using (var a3 = new Activity("Op3"))
+                {
+                    a2.Start();
+                    a3.Start();
+                    module.OnActivityStoppedImpl(a1);
+                    module.OnActivityStoppedImpl(a2);
+                    module.OnActivityStoppedImpl(a3);
+                }
+            }
+        }
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        Assert.AreEqual(3, capturedBody.Logs.Count);
+        Assert.AreEqual("Op1", capturedBody.Logs[0].Message[TelemetryField.EventName]);
+        Assert.AreEqual("Op2", capturedBody.Logs[1].Message[TelemetryField.EventName]);
+        Assert.AreEqual("Op3", capturedBody.Logs[2].Message[TelemetryField.EventName]);
+    }
+
+    [Test]
+    public async Task TestFlushAsyncRecordsActivitySourceName()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) => capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody)
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var source = new ActivitySource("MyApp.Instrumentation");
+        using var listener = new ActivityListener // listener is needed, otherwise Starting activity may return null
+        {
+            ShouldListenTo = s => s.Name == "MyApp.Instrumentation",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+        var activity = source.StartActivity("CustomSourceOp");
+        Assert.IsNotNull(activity);
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        Assert.AreEqual("MyApp.Instrumentation", capturedBody.Logs.Single().Message[TelemetryField.Source]);
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task TestFlushAsyncDisablesTelemetryAfterFailure(bool throwException)
+    {
+        // Arrange
+        var session = CreateSession();
+        if (throwException)
+            _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Network error"));
+        else
+            _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new NullDataResponse { success = false });
+
+        var module = new SessionTelemetryModule(session);
+        var activity1 = new Activity("FirstOp");
+        activity1.Start();
+        module.OnActivityStoppedImpl(activity1);
+
+        // Act — first flush triggers the failure
+        await module.FlushAsync(CancellationToken.None);
+
+        // Buffer more data and flush again — should be a no-op
+        var activity2 = new Activity("SecondOp");
+        activity2.Start();
+        module.OnActivityStoppedImpl(activity2);
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert — Post was attempted only once
+        _mockRestRequester.Verify(
+            r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once());
+
+        module.Dispose();
+    }
+
+    [Test]
+    public async Task TestFlushAsyncSendsBufferedDataWithChangedToken()
+    {
+        var session = CreateSession();
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("whatever");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+
+        await module.FlushAsync(CancellationToken.None);
+        var expectedToken1 = "test-token";
+        _mockRestRequester.Verify(x => x.PostAsync<NullDataResponse>(It.Is<IRestRequest>(y => ((SFRestRequest)y).authorizationToken == $"Snowflake Token=\"{expectedToken1}\""), It.IsAny<CancellationToken>()), Times.Once);
+
+        var newToken  = "new-token";
+        module.UpdateToken(newToken);
+        var activity2 = new Activity("whatever 2");
+        activity2.Start();
+        module.OnActivityStoppedImpl(activity2);
+        await module.FlushAsync(CancellationToken.None);
+        _mockRestRequester.Verify(x => x.PostAsync<NullDataResponse>(It.Is<IRestRequest>(y => ((SFRestRequest)y).authorizationToken == $"Snowflake Token=\"{newToken}\""), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestCase(1)]
+    [TestCase(3)]
+    public void TestSyncFlushOnDisposeOnFailure(int disposeCalls)
+    {
+        // Arrange
+        var session = CreateSession();
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Throws(new Exception("Network error"));
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("whatever");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+
+        // Act - dispose triggers sync Flush which hits the exception
+        for (; disposeCalls > 0; disposeCalls--) Assert.DoesNotThrow(module.Dispose);
+
+        // Verify Post was attempted once during dispose
+        _mockRestRequester.Verify(
+            r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()),
+            Times.Once());
+
+        Assert.True(((ISessionTelemetryModule)module).IsDisposed);
+        Assert.False(((ISessionTelemetryModule)module).IsServiceAvailable);
+    }
+
+    [TestCase(1)]
+    [TestCase(3)]
+    public void TestSyncFlushOnDisposeDisablesTelemetryOnNonSuccessResponse(int  disposeCalls)
+    {
+        // Arrange
+        var session = CreateSession();
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = false });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("whatever");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+
+        // Act - dispose calls sync Flush
+        for (; disposeCalls > 0; disposeCalls--) module.Dispose();
+
+        // Assert - Post was called once; the non-success disabled further telemetry
+        _mockRestRequester.Verify(
+            r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()),
+            Times.Once());
+
+        Assert.True(((ISessionTelemetryModule)module).IsDisposed);
+        Assert.False(((ISessionTelemetryModule)module).IsServiceAvailable);
+    }
+
+    [Test]
+    public async Task TestFlushAsyncWithEmptyBufferDoesNotPost()
+    {
+        // Arrange
+        var session = CreateSession();
+        var module = new SessionTelemetryModule(session);
+
+        // Act - no data added
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        _mockRestRequester.Verify(
+            r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+
+        module.Dispose();
+    }
+
+    [Test]
+    public void TestDisposeFlushesBufferedData()
+    {
+        // Arrange
+        var session = CreateSession();
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("whatever");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        module.Dispose();
+
+        // Assert
+        _mockRestRequester.Verify(
+            r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()),
+            Times.Once());
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void TestBufferOverflowFlushesBufferedData()
+    {
+        // Arrange
+        var session = CreateSession();
+        var datapointsCounter = 0;
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true }).Callback<IRestRequest>(r =>
+            {
+                var sfRestRequest = (SFRestRequest)r;
+                var jsonBody = (TelemetryRequest)sfRestRequest.jsonBody;
+                var logsCount = jsonBody.Logs.Count;
+                Interlocked.Add(ref datapointsCounter, logsCount);
+            });
+
+        var module = new SessionTelemetryModule(session);
+
+        var bufferSize = TelemetryTransport.TelemetryFlushSize;
+        const int BuffersToSend = 12;
+
+        var totalPoints = (BuffersToSend + 1) * bufferSize - 1;
+        Parallel.For(1, totalPoints, i =>
+        {
+            var activity = new Activity($"whatever {i}");
+            activity.Start();
+            module.OnActivityStoppedImpl(activity);
+        });
+
+        SpinWait.SpinUntil(() => datapointsCounter >= BuffersToSend * bufferSize, TimeSpan.FromSeconds(10));
+        Assert.That(datapointsCounter, Is.LessThanOrEqualTo(totalPoints));
+    }
+
+    [Test]
+    public void TestConcurrentAutoFlushDoesNotFireMultipleFlushes()
+    {
+        // Arrange
+        var session = CreateSession();
+        var flushCount = 0;
+        var mrse = new ManualResetEventSlim(false);
+        var mrse2 = new ManualResetEventSlim(false);
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(() =>
+            {
+                mrse2.Set();
+                Interlocked.Increment(ref flushCount);
+                mrse.Wait(TimeSpan.FromSeconds(15));
+                return new NullDataResponse { success = true };
+            });
+
+        var module = new SessionTelemetryModule(session);
+
+        // Act
+        const int ActivitiesCount = 30;
+        for (var i = 0; i < ActivitiesCount; i++)
+        {
+            var activity = new Activity($"op{i}");
+            activity.Start();
+            module.OnActivityStoppedImpl(activity);
+        }
+        mrse.Set();
+
+        var lastActivity = new Activity($"op{ActivitiesCount}");
+        lastActivity.Start();
+        module.OnActivityStoppedImpl(lastActivity);
+
+        // Wait for the flush to complete
+        SpinWait.SpinUntil(() => !((ISessionTelemetryModule)module).IsFlushInProgress, TimeSpan.FromSeconds(5));
+
+        // Assert — only one concurrent flush should have fired despite passing the threshold multiple times
+        Assert.That(flushCount, Is.AtMost(2));
+    }
+
+    [Test]
+    public async Task TimeShouldFlushPeriodically()
+    {
+        // Arrange
+        var session = CreateSession();
+        var logsSent = 0;
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true }).Callback<IRestRequest>(r =>
+            {
+                var sfRestRequest = (SFRestRequest)r;
+                var jsonBody = (TelemetryRequest)sfRestRequest.jsonBody;
+                var logsCount = jsonBody.Logs.Count;
+                Interlocked.Add(ref logsSent, logsCount);
+            });
+
+        var timerSpan = TimeSpan.FromMilliseconds(500);
+        var module = new SessionTelemetryModule(session, timerSpan);
+
+        var bufferSize = TelemetryTransport.TelemetryFlushSize;
+        Parallel.For(0, bufferSize - 1, i =>
+        {
+            var activity = new Activity($"whatever {i}");
+            activity.Start();
+            module.OnActivityStoppedImpl(activity);
+        });
+
+        await Task.Delay(timerSpan*2).ConfigureAwait(false);
+        Assert.That(logsSent, Is.EqualTo(bufferSize-1));
+
+        var activity = new Activity($"whatever {bufferSize}");
+        activity.Start();
+        module.OnActivityStoppedImpl(activity);
+        await Task.Delay(timerSpan*2).ConfigureAwait(false);
+
+        Assert.That(logsSent, Is.EqualTo(bufferSize));
+    }
+
+    [Test]
+    public async Task TestActivityTagValuesAreMaskedBySecretDetector()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) =>
+            {
+                capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody;
+            })
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("SecretTest");
+        activity.Start();
+        activity.SetTag("safe.tag", "hello");
+        activity.SetTag("credential", "password=SuperSecret123");
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        var log = capturedBody.Logs.First();
+        Assert.AreEqual("hello", log.Message["tag.safe.tag"]);
+        // The password value should be masked by SecretDetector
+        Assert.AreEqual("password=****", log.Message["tag.credential"]);
+    }
+
+    [Test]
+    public async Task TestActivityTagWithNullValueIsSkipped()
+    {
+        // Arrange
+        var session = CreateSession();
+        TelemetryRequest capturedBody = null;
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRestRequest, CancellationToken>((req, _) =>
+            {
+                capturedBody = (TelemetryRequest)((SFRestRequest)req).jsonBody;
+            })
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        var module = new SessionTelemetryModule(session);
+        var activity = new Activity("NullTagTest");
+        activity.Start();
+        activity.SetTag("present", "value");
+        activity.SetTag("absent", null);
+        module.OnActivityStoppedImpl(activity);
+
+        // Act
+        await module.FlushAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(capturedBody);
+        var log = capturedBody.Logs.First();
+        Assert.IsTrue(log.Message.ContainsKey("tag.present"));
+        Assert.IsFalse(log.Message.ContainsKey("tag.absent"));
+    }
+
+
+    private SFSession CreateSession()
+    {
+        var connectionStr = new StringBuilder()
+            .Append("authenticator=snowflake;account=some_account;user=some_user;")
+            .Append("password=fake_pwd")
+            .Append("db=testDb;role=dummyrole;warehouse=test;host=localhost;port=997;scheme=http;")
+            .Append("token=test-token")
+            .ToString();
+        var session = new Mock<SFSession>(connectionStr, new SessionPropertiesContext(), _mockRestRequester.Object)
+        {
+            Object =
+            {
+                sessionId = "test-session-id",
+                warehouse = "WH",
+                role = "ROLE",
+                database = "DB",
+                sessionToken = "test-token"
+            }
+        };
+
+        return session.Object;
+    }
+}

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -47,6 +47,7 @@ internal sealed class SessionTelemetryModuleTest
         activity.Start();
         module.OnActivityStoppedImpl(activity);
         Assert.AreEqual(1, ((ISessionTelemetryModule)module).CurrentBufferSize);
+        GC.KeepAlive(module);
 
         // Act - double dispose should not throw
         Assert.DoesNotThrow(() =>

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -377,7 +377,7 @@ internal sealed class SessionTelemetryModuleTest
 
         var module = new SessionTelemetryModule(session);
 
-        var bufferSize = TelemetryTransport.TelemetryFlushSize;
+        const int bufferSize = 100;
         const int BuffersToSend = 12;
 
         var totalPoints = (BuffersToSend + 1) * bufferSize - 1;
@@ -448,9 +448,9 @@ internal sealed class SessionTelemetryModuleTest
             });
 
         var timerSpan = TimeSpan.FromMilliseconds(500);
-        var module = new SessionTelemetryModule(session, timerSpan);
+        const int bufferSize = 100;
+        var module = new SessionTelemetryModule(session, bufferSize, timerSpan);
 
-        var bufferSize = TelemetryTransport.TelemetryFlushSize;
         Parallel.For(0, bufferSize - 1, i =>
         {
             var activity = new Activity($"whatever {i}");
@@ -573,6 +573,120 @@ internal sealed class SessionTelemetryModuleTest
         Assert.IsFalse(eventLog.Message.ContainsKey("tag.session.tag"));
     }
 
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(-100)]
+    public void TestSetFlushSizeThrowsOnInvalidValue(int invalidSize)
+    {
+        Assert.Throws<ArgumentException>(() => SessionTelemetryModuleFacade.SetFlushSize(invalidSize));
+    }
+
+    [Test]
+    [TestCase(1)]
+    [TestCase(50)]
+    [TestCase(500)]
+    public void TestSetFlushSizeAcceptsValidValue(int validSize)
+    {
+        Assert.DoesNotThrow(() => SessionTelemetryModuleFacade.SetFlushSize(validSize));
+        SessionTelemetryModuleFacade.SetFlushSize(100);
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(-1000)]
+    public void TestSetFlushIntervalThrowsOnInvalidValue(int invalidInterval)
+    {
+        Assert.Throws<ArgumentException>(() => SessionTelemetryModule.SetFlushInterval(invalidInterval));
+    }
+
+    [Test]
+    [TestCase(1)]
+    [TestCase(1000)]
+    [TestCase(120_000)]
+    public void TestSetFlushIntervalAcceptsValidValue(int validInterval)
+    {
+        Assert.DoesNotThrow(() => SessionTelemetryModule.SetFlushInterval(validInterval));
+        SessionTelemetryModuleFacade.SetFlushInterval(1_000 * 60);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void TestSetFlushSizeAffectsAutoFlushThreshold()
+    {
+        // Arrange
+        var session = CreateSession();
+        var flushed = false;
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true })
+            .Callback(() => flushed = true);
+
+        SessionTelemetryModuleFacade.SetFlushSize(5);
+        try
+        {
+            var module = new SessionTelemetryModule(session);
+
+            // Act - add exactly 5 items to trigger auto-flush at the new threshold
+            for (var i = 0; i < 5; i++)
+            {
+                var activity = new Activity($"op{i}");
+                activity.Start();
+                module.OnActivityStoppedImpl(activity);
+            }
+
+            SpinWait.SpinUntil(() => flushed, TimeSpan.FromSeconds(5));
+
+            // Assert
+            Assert.IsTrue(flushed);
+            module.Dispose();
+        }
+        finally
+        {
+            SessionTelemetryModule.SetFlushSize(100);
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void TestSetFlushIntervalAffectsAutoFlushInterval()
+    {
+        // Arrange
+        var session = CreateSession();
+        var flushedCount = 0;
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true })
+            .Callback<IRestRequest>(r =>
+            {
+                var sfRestRequest = (SFRestRequest)r;
+                var jsonBody = (TelemetryRequest)sfRestRequest.jsonBody;
+                var logsCount = jsonBody.Logs.Count;
+                Interlocked.Add(ref flushedCount, logsCount);
+            });
+
+        SessionTelemetryModuleFacade.SetFlushInterval(100);
+        try
+        {
+            var module = new SessionTelemetryModule(session);
+            for (var i = 0; i < 5; i++)
+            {
+                var activity = new Activity($"op{i}");
+                activity.Start();
+                module.OnActivityStoppedImpl(activity);
+            }
+
+            var result = SpinWait.SpinUntil(() => flushedCount == 5, TimeSpan.FromSeconds(5));
+
+            // Assert
+            Assert.IsTrue(result);
+            module.Dispose();
+        }
+        finally
+        {
+            SessionTelemetryModule.SetFlushInterval(1_000 * 60);
+        }
+    }
 
     private SFSession CreateSession()
     {

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -452,13 +452,13 @@ internal sealed class SessionTelemetryModuleTest
             module.OnActivityStoppedImpl(activity);
         });
 
-        await Task.Delay(timerSpan*2).ConfigureAwait(false);
+        await Task.Delay((int)timerSpan.TotalMilliseconds * 2).ConfigureAwait(false);
         Assert.That(logsSent, Is.EqualTo(bufferSize-1));
 
         var activity = new Activity($"whatever {bufferSize}");
         activity.Start();
         module.OnActivityStoppedImpl(activity);
-        await Task.Delay(timerSpan*2).ConfigureAwait(false);
+        await Task.Delay((int)timerSpan.TotalMilliseconds * 2).ConfigureAwait(false);
 
         Assert.That(logsSent, Is.EqualTo(bufferSize));
     }

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -78,7 +78,10 @@ internal sealed class SessionTelemetryModuleTest
         var activity = new Activity("TestOp");
         activity.Start();
         if (status.HasValue)
+        {
             activity.SetStatus(status.Value);
+            activity.SetTag(TelemetryTags.StatusCode, expectedStatus);
+        }
         if (event1 != null)
             activity.AddEvent(new ActivityEvent(event1));
         if (event2 != null)

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SnowflakeTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SnowflakeTelemetryModuleTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Data;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Telemetry;
+
+namespace Snowflake.Data.Tests.UnitTests.Telemetry;
+
+[TestFixture]
+public sealed class SnowflakeTelemetryModuleTest
+{
+    private Mock<IMockRestRequester> _mockRestRequester;
+    private ActivityListener _listener;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRestRequester = new Mock<IMockRestRequester>();
+        _mockRestRequester.Setup(r => r.Post<NullDataResponse>(It.IsAny<IRestRequest>()))
+            .Returns(new NullDataResponse { success = true });
+        _mockRestRequester.Setup(r => r.PostAsync<NullDataResponse>(It.IsAny<IRestRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NullDataResponse { success = true });
+
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivityStarter.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _listener?.Dispose();
+    }
+
+    [Test]
+    public void TestRegisterCreatesSessionModule()
+    {
+        // Arrange
+        var sessionId = "register-test-1";
+        var session = CreateSession(ref sessionId);
+
+        // Act & Assert - should not throw
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Register(session));
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule);
+        Assert.AreEqual(session.sessionToken, sessionModule.SessionToken);
+
+        // Cleanup
+        SnowflakeTelemetryModule.Unregister(sessionId);
+    }
+
+    [Test]
+    public void TestRegisterSameSessionUpdatesToken()
+    {
+        // Arrange
+        var sessionId = "register-test-2";
+        var session = CreateSession(ref sessionId);
+        SnowflakeTelemetryModule.Register(session);
+        var staleSessionToken = session.sessionToken;
+
+        // Update token on session
+        session.sessionToken = $"new-token-456-{Guid.NewGuid()}";
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule);
+        Assert.AreEqual(staleSessionToken, sessionModule.SessionToken);
+
+        // Act - second register should update token, not create new module
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Register(session));
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule2);
+        Assert.AreEqual(sessionModule, sessionModule2);
+
+        // Cleanup
+        SnowflakeTelemetryModule.Unregister(sessionId);
+    }
+
+    [Test]
+    public void TestUnregisterNonExistentSessionDoesNotThrow()
+    {
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Unregister("non-existent-session"));
+    }
+
+    [Test]
+    public void TestUnregisterDisposesModule()
+    {
+        // Arrange
+        var sessionId = "unregister-test-1";
+        var session = CreateSession(ref sessionId);
+        SnowflakeTelemetryModule.Register(session);
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule);
+        Assert.False(sessionModule.IsDisposed);
+
+        // Act & Assert - should not throw
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Unregister(sessionId));
+        Assert.False(SnowflakeTelemetryModule.TryGetSession(session.sessionId, out _));
+        Assert.True(sessionModule.IsDisposed);
+
+        // Unregistering again should be a no-op
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Unregister(sessionId));
+        Assert.False(SnowflakeTelemetryModule.TryGetSession(session.sessionId, out _));
+        Assert.True(sessionModule.IsDisposed);
+    }
+
+    [Test]
+    public async Task TestUnregisterAsyncFlushesAndDisposes()
+    {
+        // Arrange
+        var sessionId = "unregister-async-test-1";
+        var session = CreateSession(ref sessionId);
+        SnowflakeTelemetryModule.Register(session);
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule);
+        var activity = new Activity("whatever");
+        activity.Start();
+        sessionModule.OnActivityStopped(activity);
+
+        // Act
+        Assert.AreEqual(1, sessionModule.CurrentBufferSize);
+        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None);
+        Assert.True(sessionModule.IsDisposed);
+        Assert.AreEqual(0, sessionModule.CurrentBufferSize);
+
+        // Assert - calling again should be no-op
+        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TestUnregisterAsyncForNonExistentSessionDoesNotThrow()
+    {
+        await SnowflakeTelemetryModule.UnregisterAsync("non-existent-async", CancellationToken.None);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TestOnActivityStoppedRoutesToCorrectSession(bool useCustomClientTelemetry)
+    {
+        // Arrange
+        var sessionId = "routing-test-1";
+        var sessionId2 = "routing-test-2";
+        var session = CreateSession(ref sessionId);
+        var session2 = CreateSession(ref sessionId2);
+        SnowflakeTelemetryModule.Register(session);
+        SnowflakeTelemetryModule.Register(session2);
+        SnowflakeTelemetryModule.TryGetSession(session.sessionId, out var sessionModule);
+        SnowflakeTelemetryModule.TryGetSession(session2.sessionId, out var sessionModule2);
+
+        // Act - create and stop an activity with the sessionId
+        var activity = useCustomClientTelemetry
+            ? CreateCommand(session).StartActivity("TestRoutingCustom")
+            : session.StartActivity("TestRouting");
+
+        Assert.IsNotNull(activity);
+        activity.SetSuccess();
+
+        if (!SpinWait.SpinUntil(() => sessionModule.CurrentBufferSize == 1, TimeSpan.FromMinutes(1)))
+            Assert.Fail("Expected to observe activity!");
+
+        Assert.AreEqual(0, sessionModule2.CurrentBufferSize);
+
+        // Cleanup
+        SnowflakeTelemetryModule.Unregister(sessionId);
+        SnowflakeTelemetryModule.Unregister(sessionId2);
+    }
+
+    [Test]
+    public void TestRegisterWithTelemetryDisabledDoesNotCreateModule()
+    {
+        // Arrange - session with telemetry disabled
+        var sessionId = "disabled-test-1";
+        var session = CreateSession(ref sessionId, telemetryEnabled: false);
+
+        // Act - Register should return early without creating a module
+        SnowflakeTelemetryModule.Register(session);
+
+        // Assert - Unregister is a no-op (no module was created),
+        // and creating an activity for this session doesn't crash
+        var source = new ActivitySource(ActivityStarter.ActivitySourceName);
+        using var activity = source.StartActivity("ShouldNotRoute", ActivityKind.Client);
+        activity?.SetTag(TelemetryTags.SessionId, sessionId);
+        activity?.Stop();
+
+        // Cleanup - should be a no-op since nothing was registered
+        Assert.DoesNotThrow(() => SnowflakeTelemetryModule.Unregister(sessionId));
+    }
+
+    private SnowflakeDbCommand CreateCommand(SFSession session)
+    {
+        var snowflakeDbConnection = new SnowflakeDbConnection("someConnectionString")
+        {
+            SfSession = session,
+            _connectionState = ConnectionState.Open
+        };
+        return new SnowflakeDbCommand(snowflakeDbConnection);
+    }
+
+    private SFSession CreateSession(ref string sessionId, bool telemetryEnabled = true)
+    {
+        var connectionStr = new StringBuilder()
+            .Append("authenticator=snowflake;account=some_account;user=some_user;")
+            .Append("password=fake_pwd;")
+            .Append("db=testDb;role=WHATEVER_ROLE;warehouse=testWarehouse;host=localhost;port=443;scheme=https")
+            .ToString();
+
+        var distinctSuffix = Guid.NewGuid().ToString("N");
+        sessionId += distinctSuffix;
+
+        var session = new Mock<SFSession>(connectionStr, new SessionPropertiesContext(), _mockRestRequester.Object)
+        {
+            Object =
+            {
+                sessionId = sessionId,
+                warehouse = "WH",
+                role = "ROLE",
+                database = "DB",
+                sessionToken = $"token-{sessionId}"
+            }
+        };
+        session.Setup(x => x.IsClientTelemetryEnabled()).Returns(telemetryEnabled);
+
+        return session.Object;
+    }
+}

--- a/Snowflake.Data.Tests/wiremock/Telemetry/failing_query.json
+++ b/Snowflake.Data.Tests/wiremock/Telemetry/failing_query.json
@@ -1,0 +1,22 @@
+{
+    "mappings": [
+        {
+            "name": "Query execution - error",
+            "priority": 1,
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": { },
+                    "code": "002003",
+                    "message": "SQL compilation error: Object does not exist.",
+                    "success": false
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data.Tests/wiremock/Telemetry/login_and_telemetry.json
+++ b/Snowflake.Data.Tests/wiremock/Telemetry/login_and_telemetry.json
@@ -1,0 +1,123 @@
+{
+    "mappings": [
+        {
+            "name": "Successful password login",
+            "request": {
+                "urlPathPattern": "/session/v1/login-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": {
+                        "masterToken": "master-token",
+                        "token": "session-token",
+                        "sessionId": "telemetry-test-session",
+                        "parameters": [
+                            { "name": "CLIENT_SESSION_KEEP_ALIVE", "value": false },
+                            { "name": "CLIENT_TELEMETRY_ENABLED", "value": true },
+                            { "name": "QUERY_CONTEXT_CACHE_SIZE", "value": 5 },
+                            { "name": "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD", "value": 65280 },
+                            { "name": "TIMEZONE", "value": "America/Los_Angeles" },
+                            { "name": "DATE_OUTPUT_FORMAT", "value": "YYYY-MM-DD" },
+                            { "name": "TIME_OUTPUT_FORMAT", "value": "HH24:MI:SS" }
+                        ],
+                        "sessionInfo": {
+                            "databaseName": "TEST_DB",
+                            "schemaName": "PUBLIC",
+                            "warehouseName": "TEST_WH",
+                            "roleName": "TEST_ROLE"
+                        },
+                        "idToken": null,
+                        "mfaToken": null
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Query execution - SELECT 1",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": {
+                        "parameters": [],
+                        "rowtype": [
+                            {
+                                "name": "1",
+                                "database": "",
+                                "schema": "",
+                                "table": "",
+                                "type": "fixed",
+                                "scale": 0,
+                                "precision": 1,
+                                "byteLength": null,
+                                "length": null,
+                                "nullable": false
+                            }
+                        ],
+                        "rowset": [["1"]],
+                        "total": 1,
+                        "returned": 1,
+                        "queryId": "fake-query-id-1234",
+                        "sqlState": "00000",
+                        "databaseProvider": null,
+                        "finalDatabaseName": "TEST_DB",
+                        "finalSchemaName": "PUBLIC",
+                        "finalWarehouseName": "TEST_WH",
+                        "finalRoleName": "TEST_ROLE",
+                        "statementTypeId": 4096,
+                        "version": 1,
+                        "sendResultTime": 0,
+                        "queryResultFormat": "json"
+                    },
+                    "code": "090000",
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Telemetry send",
+            "request": {
+                "urlPathPattern": "/telemetry/send",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": null,
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Session close",
+            "request": {
+                "urlPathPattern": "/session",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": null,
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data.Tests/wiremock/Telemetry/login_telemetry_disabled.json
+++ b/Snowflake.Data.Tests/wiremock/Telemetry/login_telemetry_disabled.json
@@ -1,0 +1,106 @@
+{
+    "mappings": [
+        {
+            "name": "Successful password login - telemetry disabled by server",
+            "request": {
+                "urlPathPattern": "/session/v1/login-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": {
+                        "masterToken": "master-token",
+                        "token": "session-token",
+                        "sessionId": "telemetry-disabled-session",
+                        "parameters": [
+                            { "name": "CLIENT_SESSION_KEEP_ALIVE", "value": false },
+                            { "name": "CLIENT_TELEMETRY_ENABLED", "value": false },
+                            { "name": "QUERY_CONTEXT_CACHE_SIZE", "value": 5 },
+                            { "name": "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD", "value": 65280 },
+                            { "name": "TIMEZONE", "value": "America/Los_Angeles" },
+                            { "name": "DATE_OUTPUT_FORMAT", "value": "YYYY-MM-DD" },
+                            { "name": "TIME_OUTPUT_FORMAT", "value": "HH24:MI:SS" }
+                        ],
+                        "sessionInfo": {
+                            "databaseName": "TEST_DB",
+                            "schemaName": "PUBLIC",
+                            "warehouseName": "TEST_WH",
+                            "roleName": "TEST_ROLE"
+                        },
+                        "idToken": null,
+                        "mfaToken": null
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Query execution - SELECT 1",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": {
+                        "parameters": [],
+                        "rowtype": [
+                            {
+                                "name": "1",
+                                "database": "",
+                                "schema": "",
+                                "table": "",
+                                "type": "fixed",
+                                "scale": 0,
+                                "precision": 1,
+                                "byteLength": null,
+                                "length": null,
+                                "nullable": false
+                            }
+                        ],
+                        "rowset": [["1"]],
+                        "total": 1,
+                        "returned": 1,
+                        "queryId": "fake-query-id-1234",
+                        "sqlState": "00000",
+                        "databaseProvider": null,
+                        "finalDatabaseName": "TEST_DB",
+                        "finalSchemaName": "PUBLIC",
+                        "finalWarehouseName": "TEST_WH",
+                        "finalRoleName": "TEST_ROLE",
+                        "statementTypeId": 4096,
+                        "version": 1,
+                        "sendResultTime": 0,
+                        "queryResultFormat": "json"
+                    },
+                    "code": "090000",
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Session close",
+            "request": {
+                "urlPathPattern": "/session",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": { "Content-Type": "application/json" },
+                "jsonBody": {
+                    "data": null,
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Snowflake.Data.Log;
+using Snowflake.Data.Telemetry;
 
 namespace Snowflake.Data.Client
 {
@@ -161,78 +162,135 @@ namespace Snowflake.Data.Client
 
         public override int ExecuteNonQuery()
         {
-            logger.Debug($"ExecuteNonQuery");
-            SFBaseResultSet resultSet = ExecuteInternal();
-            long total = 0;
-            do
+            logger.Debug("ExecuteNonQuery");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteNonQuery);
+            try
             {
-                if (resultSet.IsDQL()) continue;
-                int count = resultSet.CalculateUpdateCount();
-                if (count < 0)
+                SFBaseResultSet resultSet = ExecuteInternal();
+                long total = 0;
+                do
                 {
-                    // exceeded max int, return -1
-                    return -1;
+                    if (resultSet.IsDQL())
+                    {
+                        activity?.AddTelemetryEvent(TelemetryEvents.DqlResultSetSkipped);
+                        continue;
+                    }
+                    int count = resultSet.CalculateUpdateCount();
+                    if (count < 0)
+                    {
+                        // exceeded max int, return -1
+                        activity?.AddTelemetryEvent(TelemetryEvents.RowCountNegative);
+                        return -1;
+                    }
+                    total += count;
+                    if (total > int.MaxValue)
+                    {
+                        activity?.AddTelemetryEvent(TelemetryEvents.RowCountOverflow);
+                        return -1;
+                    }
                 }
-                total += count;
-                if (total > int.MaxValue)
-                {
-                    return -1;
-                }
-            }
-            while (resultSet.NextResult());
+                while (resultSet.NextResult());
 
-            return (int)total;
+                activity?.SetSuccess();
+                return (int)total;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
-            logger.Debug($"ExecuteNonQueryAsync");
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var resultSet = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
-            long total = 0;
-            do
+            logger.Debug("ExecuteNonQueryAsync");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteNonQueryAsync);
+            try
             {
-                if (resultSet.IsDQL()) continue;
-                int count = resultSet.CalculateUpdateCount();
-                if (count < 0)
-                {
-                    // exceeded max int, return -1
-                    return -1;
-                }
-                total += count;
-                if (total > int.MaxValue)
-                {
-                    return -1;
-                }
-            }
-            while (await resultSet.NextResultAsync(cancellationToken).ConfigureAwait(false));
+                cancellationToken.ThrowIfCancellationRequested();
 
-            return (int)total;
+                var resultSet = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
+                long total = 0;
+                do
+                {
+                    if (resultSet.IsDQL())
+                    {
+                        activity?.AddTelemetryEvent(TelemetryEvents.DqlResultSetSkipped);
+                        continue;
+                    }
+                    int count = resultSet.CalculateUpdateCount();
+                    if (count < 0)
+                    {
+                        activity?.AddTelemetryEvent(TelemetryEvents.RowCountNegative);
+                        return -1;
+                    }
+                    total += count;
+                    if (total > int.MaxValue)
+                    {
+                        activity?.AddTelemetryEvent(TelemetryEvents.RowCountOverflow);
+                        return -1;
+                    }
+                }
+                while (await resultSet.NextResultAsync(cancellationToken).ConfigureAwait(false));
+
+                activity?.SetSuccess();
+                return (int)total;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         public override object ExecuteScalar()
         {
-            logger.Debug($"ExecuteScalar");
-            SFBaseResultSet resultSet = ExecuteInternal();
+            logger.Debug("ExecuteScalar");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteScalar);
+            try
+            {
+                var resultSet = ExecuteInternal();
 
-            if (resultSet.Next())
-                return resultSet.GetValue(0);
-            else
-                return DBNull.Value;
+                object result;
+                if (resultSet.Next())
+                    result = resultSet.GetValue(0);
+                else
+                    result = DBNull.Value;
+
+                activity?.SetSuccess();
+                return result;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
-            logger.Debug($"ExecuteScalarAsync");
-            cancellationToken.ThrowIfCancellationRequested();
+            logger.Debug("ExecuteScalarAsync");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteScalarAsync);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
+                var resultSet = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
 
-            if (await result.NextAsync().ConfigureAwait(false))
-                return result.GetValue(0);
-            else
-                return DBNull.Value;
+                object result;
+                if (await resultSet.NextAsync().ConfigureAwait(false))
+                    result = resultSet.GetValue(0);
+                else
+                    result = DBNull.Value;
+
+                activity?.SetSuccess();
+                return result;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -259,21 +317,34 @@ namespace Snowflake.Data.Client
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            logger.Debug($"ExecuteDbDataReader");
-            SFBaseResultSet resultSet = ExecuteInternal();
-            return new SnowflakeDbDataReader(this, resultSet);
+            logger.Debug("ExecuteDbDataReader");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteDbDataReader);
+            try
+            {
+                SFBaseResultSet resultSet = ExecuteInternal();
+                activity?.SetSuccess();
+                return new SnowflakeDbDataReader(this, resultSet);
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            logger.Debug($"ExecuteDbDataReaderAsync");
+            logger.Debug("ExecuteDbDataReaderAsync");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteDbDataReaderAsync);
             try
             {
                 var result = await ExecuteInternalAsync(cancellationToken).ConfigureAwait(false);
+                activity?.SetSuccess();
                 return new SnowflakeDbDataReader(this, result);
             }
             catch (Exception ex)
             {
+                activity?.SetException(ex);
                 logger.Error("The command failed to execute.", ex);
                 throw;
             }
@@ -286,9 +357,19 @@ namespace Snowflake.Data.Client
         /// <returns>The query id.</returns>
         public string ExecuteInAsyncMode()
         {
-            logger.Debug($"ExecuteInAsyncMode");
-            SFBaseResultSet resultSet = ExecuteInternal(asyncExec: true);
-            return resultSet.queryId;
+            logger.Debug("ExecuteInAsyncMode");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteInAsyncMode);
+            try
+            {
+                SFBaseResultSet resultSet = ExecuteInternal(asyncExec: true);
+                activity?.SetSuccess();
+                return resultSet.queryId;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -299,9 +380,19 @@ namespace Snowflake.Data.Client
         /// <returns>The query id.</returns>
         public async Task<string> ExecuteAsyncInAsyncMode(CancellationToken cancellationToken)
         {
-            logger.Debug($"ExecuteAsyncInAsyncMode");
-            var resultSet = await ExecuteInternalAsync(cancellationToken, asyncExec: true).ConfigureAwait(false);
-            return resultSet.queryId;
+            logger.Debug("ExecuteAsyncInAsyncMode");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.ExecuteAsyncInAsyncMode);
+            try
+            {
+                var resultSet = await ExecuteInternalAsync(cancellationToken, asyncExec: true).ConfigureAwait(false);
+                activity?.SetSuccess();
+                return resultSet.queryId;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -311,8 +402,19 @@ namespace Snowflake.Data.Client
         /// <returns>The query status.</returns>
         public QueryStatus GetQueryStatus(string queryId)
         {
-            logger.Debug($"GetQueryStatus");
-            return _queryResultsAwaiter.GetQueryStatus(connection, queryId);
+            logger.Debug("GetQueryStatus");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.GetQueryStatus);
+            try
+            {
+                var status = _queryResultsAwaiter.GetQueryStatus(connection, queryId);
+                activity?.SetSuccess();
+                return status;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -323,8 +425,19 @@ namespace Snowflake.Data.Client
         /// <returns>The query status.</returns>
         public async Task<QueryStatus> GetQueryStatusAsync(string queryId, CancellationToken cancellationToken)
         {
-            logger.Debug($"GetQueryStatusAsync");
-            return await _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken);
+            logger.Debug("GetQueryStatusAsync");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.GetQueryStatusAsync);
+            try
+            {
+                var status = await _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken);
+                activity?.SetSuccess();
+                return status;
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -334,14 +447,24 @@ namespace Snowflake.Data.Client
         /// <returns>The query results.</returns>
         public DbDataReader GetResultsFromQueryId(string queryId)
         {
-            logger.Debug($"GetResultsFromQueryId");
+            logger.Debug("GetResultsFromQueryId");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.GetResultsFromQueryId);
 
-            Task task = _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, CancellationToken.None, false);
-            task.Wait();
+            try
+            {
+                Task task = _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, CancellationToken.None, false);
+                task.Wait();
 
-            SFBaseResultSet resultSet = sfStatement.GetResultWithId(queryId);
+                SFBaseResultSet resultSet = sfStatement.GetResultWithId(queryId);
 
-            return new SnowflakeDbDataReader(this, resultSet);
+                activity?.SetSuccess();
+                return new SnowflakeDbDataReader(this, resultSet);
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         /// <summary>
@@ -352,13 +475,23 @@ namespace Snowflake.Data.Client
         /// <returns>The query results.</returns>
         public async Task<DbDataReader> GetResultsFromQueryIdAsync(string queryId, CancellationToken cancellationToken)
         {
-            logger.Debug($"GetResultsFromQueryIdAsync");
+            logger.Debug("GetResultsFromQueryIdAsync");
+            using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.GetResultsFromQueryIdAsync);
 
-            await _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true);
+            try
+            {
+                await _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true);
 
-            SFBaseResultSet resultSet = await sfStatement.GetResultWithIdAsync(queryId, cancellationToken).ConfigureAwait(false);
+                SFBaseResultSet resultSet = await sfStatement.GetResultWithIdAsync(queryId, cancellationToken).ConfigureAwait(false);
 
-            return new SnowflakeDbDataReader(this, resultSet);
+                activity?.SetSuccess();
+                return new SnowflakeDbDataReader(this, resultSet);
+            }
+            catch (Exception ex)
+            {
+                activity?.SetException(ex);
+                throw;
+            }
         }
 
         private static Dictionary<string, BindingDTO> convertToBindList(List<SnowflakeDbParameter> parameters)

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -321,13 +321,13 @@ namespace Snowflake.Data.Client
                 ConnectionString = _tomlConnectionBuilder.GetConnectionStringFromToml();
         }
 
-        public override async Task OpenAsync(CancellationToken cancellationToken)
+        public override Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Connection Async.");
             if (_connectionState != ConnectionState.Closed)
             {
                 logger.Debug($"Open with a connection already opened: {_connectionState}");
-                return;
+                return Task.CompletedTask;
             }
             OnSessionConnecting();
             FillConnectionStringFromTomlConfigIfNotSet();
@@ -339,30 +339,36 @@ namespace Snowflake.Data.Client
                 Token = Token
             };
 
-            try
-            {
-                SfSession = await SnowflakeDbConnectionPool.GetSessionAsync(ConnectionString, sessionContext, cancellationToken).ConfigureAwait(false);
-                // Only continue if the session was opened successfully
-                logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
-                OnSessionEstablished();
-            }
-            catch (OperationCanceledException)
-            {
-                _connectionState = ConnectionState.Closed;
-                logger.Debug("Connection canceled");
-                throw new TaskCanceledException("Connecting was cancelled");
-            }
-            catch (Exception sfSessionEx)
-            {
-                // Exception from SfSession.OpenAsync
-                _connectionState = ConnectionState.Closed;
-                logger.Error("Unable to connect", sfSessionEx);
-                throw new SnowflakeDbException(
-                    sfSessionEx,
-                    SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
-                    SFError.INTERNAL_ERROR,
-                    "Unable to connect");
-            }
+            return SnowflakeDbConnectionPool
+                .GetSessionAsync(ConnectionString, sessionContext, cancellationToken)
+                .ContinueWith(previousTask =>
+                {
+                    if (previousTask.IsFaulted)
+                    {
+                        // Exception from SfSession.OpenAsync
+                        Exception sfSessionEx = previousTask.Exception;
+                        _connectionState = ConnectionState.Closed;
+                        logger.Error("Unable to connect", sfSessionEx);
+                        throw new SnowflakeDbException(
+                            sfSessionEx,
+                            SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
+                            SFError.INTERNAL_ERROR,
+                            "Unable to connect");
+                    }
+                    else if (previousTask.IsCanceled)
+                    {
+                        _connectionState = ConnectionState.Closed;
+                        logger.Debug("Connection canceled");
+                        throw new TaskCanceledException("Connecting was cancelled");
+                    }
+                    else
+                    {
+                        // Only continue if the session was opened successfully
+                        SfSession = previousTask.Result;
+                        logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
+                        OnSessionEstablished();
+                    }
+                }, TaskContinuationOptions.None); // this continuation should be executed always (even if the whole operation was canceled) because it sets the proper state of the connection
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -303,10 +303,10 @@ namespace Snowflake.Data.Client
                 // Otherwise when Dispose() is called, the close request would timeout.
                 _connectionState = ConnectionState.Closed;
                 logger.Error("Unable to connect: ", e);
+
                 if (e is SnowflakeDbException)
-                {
                     throw;
-                }
+
                 throw new SnowflakeDbException(
                         e,
                         SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
@@ -318,18 +318,16 @@ namespace Snowflake.Data.Client
         internal void FillConnectionStringFromTomlConfigIfNotSet()
         {
             if (string.IsNullOrEmpty(ConnectionString))
-            {
                 ConnectionString = _tomlConnectionBuilder.GetConnectionStringFromToml();
-            }
         }
 
-        public override Task OpenAsync(CancellationToken cancellationToken)
+        public override async Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Connection Async.");
             if (_connectionState != ConnectionState.Closed)
             {
                 logger.Debug($"Open with a connection already opened: {_connectionState}");
-                return Task.CompletedTask;
+                return;
             }
             OnSessionConnecting();
             FillConnectionStringFromTomlConfigIfNotSet();
@@ -340,36 +338,31 @@ namespace Snowflake.Data.Client
                 OAuthClientSecret = OAuthClientSecret,
                 Token = Token
             };
-            return SnowflakeDbConnectionPool
-                .GetSessionAsync(ConnectionString, sessionContext, cancellationToken)
-                .ContinueWith(previousTask =>
-                {
-                    if (previousTask.IsFaulted)
-                    {
-                        // Exception from SfSession.OpenAsync
-                        Exception sfSessionEx = previousTask.Exception;
-                        _connectionState = ConnectionState.Closed;
-                        logger.Error("Unable to connect", sfSessionEx);
-                        throw new SnowflakeDbException(
-                           sfSessionEx,
-                           SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
-                           SFError.INTERNAL_ERROR,
-                           "Unable to connect");
-                    }
-                    else if (previousTask.IsCanceled)
-                    {
-                        _connectionState = ConnectionState.Closed;
-                        logger.Debug("Connection canceled");
-                        throw new TaskCanceledException("Connecting was cancelled");
-                    }
-                    else
-                    {
-                        // Only continue if the session was opened successfully
-                        SfSession = previousTask.Result;
-                        logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
-                        OnSessionEstablished();
-                    }
-                }, TaskContinuationOptions.None); // this continuation should be executed always (even if the whole operation was canceled) because it sets the proper state of the connection
+
+            try
+            {
+                SfSession = await SnowflakeDbConnectionPool.GetSessionAsync(ConnectionString, sessionContext, cancellationToken).ConfigureAwait(false);
+                // Only continue if the session was opened successfully
+                logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
+                OnSessionEstablished();
+            }
+            catch (OperationCanceledException)
+            {
+                _connectionState = ConnectionState.Closed;
+                logger.Debug("Connection canceled");
+                throw new TaskCanceledException("Connecting was cancelled");
+            }
+            catch (Exception sfSessionEx)
+            {
+                // Exception from SfSession.OpenAsync
+                _connectionState = ConnectionState.Closed;
+                logger.Error("Unable to connect", sfSessionEx);
+                throw new SnowflakeDbException(
+                    sfSessionEx,
+                    SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
+                    SFError.INTERNAL_ERROR,
+                    "Unable to connect");
+            }
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Core.FileTransfer
             byte[] header = new byte[MAX_MAGIC_BYTES];
             using (FileStream fs = File.OpenRead(filePath))
             {
-                fs.Read(header, 0, header.Length);
+                fs.ReadExactly(header);
             }
 
             foreach (SFFileCompressionType compType in compressionTypes)

--- a/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileCompressionTypes.cs
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Core.FileTransfer
             byte[] header = new byte[MAX_MAGIC_BYTES];
             using (FileStream fs = File.OpenRead(filePath))
             {
-                fs.ReadExactly(header);
+                fs.Read(header, 0, header.Length);
             }
 
             foreach (SFFileCompressionType compType in compressionTypes)

--- a/Snowflake.Data/Core/RestParams.cs
+++ b/Snowflake.Data/Core/RestParams.cs
@@ -46,6 +46,8 @@ namespace Snowflake.Data.Core
 
         internal const string SF_SESSION_HEARTBEAT_PATH = SF_SESSION_PATH + "/heartbeat";
 
+        internal const string SF_TELEMETRY_PATH = "/telemetry/send";
+
         internal const string SF_CONSOLE_LOGIN = "/console/login";
     }
 

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -101,7 +101,7 @@ namespace Snowflake.Data.Core
 
         internal SecureString _mfaToken;
 
-        private readonly bool _isClientTelemetryEnabled;
+        private bool _isClientTelemetryEnabled;
 
         private bool _honorSessionTimezone = false;
 
@@ -547,6 +547,11 @@ namespace Snowflake.Data.Core
                 string val = ParameterMap[SFSessionParameter.QUERY_CONTEXT_CACHE_SIZE].ToString();
                 _queryContextCacheSize = Int32.Parse(val);
                 _queryContextCache.SetCapacity(_queryContextCacheSize);
+            }
+
+            if (ParameterMap.TryGetValue(SFSessionParameter.CLIENT_TELEMETRY_ENABLED, out var clientTelemetryEnabledObj) && bool.TryParse(clientTelemetryEnabledObj.ToString(), out var clientTelemetryEnabled))
+            {
+                _isClientTelemetryEnabled = clientTelemetryEnabled;
             }
         }
 

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -14,6 +14,7 @@ using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Core.Extensions;
 using Snowflake.Data.Core.Session;
 using Snowflake.Data.Core.Tools;
+using Snowflake.Data.Telemetry;
 
 namespace Snowflake.Data.Core
 {
@@ -100,6 +101,8 @@ namespace Snowflake.Data.Core
 
         internal SecureString _mfaToken;
 
+        private readonly bool _isClientTelemetryEnabled;
+
         private bool _honorSessionTimezone = false;
 
         private volatile TimeZoneInfo _cachedSessionTimezone;
@@ -138,6 +141,7 @@ namespace Snowflake.Data.Core
                 logger.Debug($"Session opened: {sessionId}");
                 _startTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 _timeSinceLastRenew = _startTime;
+                SnowflakeTelemetryModule.Register(this);
             }
             else
             {
@@ -203,6 +207,7 @@ namespace Snowflake.Data.Core
             _disableConsoleLogin = bool.Parse(properties[SFSessionProperty.DISABLE_CONSOLE_LOGIN]);
             _honorSessionTimezone = bool.Parse(properties[SFSessionProperty.HONORSESSIONTIMEZONE]);
             properties.TryGetValue(SFSessionProperty.USER, out _user);
+            _isClientTelemetryEnabled = !bool.TryParse(properties[SFSessionProperty.CLIENT_TELEMETRY_ENABLED], out var clientTelemetryFlag) || clientTelemetryFlag;
             ValidateApplicationName(properties);
             try
             {
@@ -328,6 +333,7 @@ namespace Snowflake.Data.Core
             if (!IsEstablished()) return;
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
+            SnowflakeTelemetryModule.Unregister(sessionId);
             var closeSessionRequest = PrepareCloseSessionRequest();
             PostCloseSession(closeSessionRequest, restRequester);
             sessionToken = null;
@@ -340,7 +346,11 @@ namespace Snowflake.Data.Core
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
             var closeSessionRequest = PrepareCloseSessionRequest();
-            Task.Run(() => PostCloseSession(closeSessionRequest, restRequester));
+            Task.Run(() =>
+            {
+                SnowflakeTelemetryModule.Unregister(sessionId);
+                PostCloseSession(closeSessionRequest, restRequester);
+            });
             sessionToken = null;
         }
 
@@ -350,7 +360,7 @@ namespace Snowflake.Data.Core
             if (!IsEstablished()) return;
             logger.Debug($"Closing session with id: {sessionId}, user: {_user}, database: {database}, schema: {schema}, role: {role}, warehouse: {warehouse}, connection start timestamp: {_startTime}");
             stopHeartBeatForThisSession();
-
+            await SnowflakeTelemetryModule.UnregisterAsync(sessionId, cancellationToken).ConfigureAwait(false);
             var closeSessionRequest = PrepareCloseSessionRequest();
 
             logger.Debug($"Closing session async");
@@ -417,6 +427,7 @@ namespace Snowflake.Data.Core
                 _timeSinceLastRenew = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 sessionToken = response.data.sessionToken;
                 masterToken = response.data.masterToken;
+                SnowflakeTelemetryModule.Register(this);
             }
         }
 
@@ -439,6 +450,7 @@ namespace Snowflake.Data.Core
             {
                 sessionToken = response.data.sessionToken;
                 masterToken = response.data.masterToken;
+                SnowflakeTelemetryModule.Register(this);
             }
         }
 
@@ -795,5 +807,7 @@ namespace Snowflake.Data.Core
         }
 
         internal virtual bool IsInvalidatedForPooling() => _invalidatedForPooling;
+
+        internal virtual bool IsClientTelemetryEnabled() => _isClientTelemetryEnabled;
     }
 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -808,6 +808,6 @@ namespace Snowflake.Data.Core
 
         internal virtual bool IsInvalidatedForPooling() => _invalidatedForPooling;
 
-        internal virtual bool IsClientTelemetryEnabled() => _isClientTelemetryEnabled;
+        internal virtual bool IsClientTelemetryEnabled() => !string.IsNullOrEmpty(sessionId) && _isClientTelemetryEnabled;
     }
 }

--- a/Snowflake.Data/Core/Session/SFSessionParameter.cs
+++ b/Snowflake.Data/Core/Session/SFSessionParameter.cs
@@ -12,6 +12,7 @@ namespace Snowflake.Data.Core
         TIME_OUTPUT_FORMAT,
         CLIENT_REQUEST_MFA_TOKEN,
         CLIENT_STORE_TEMPORARY_CREDENTIAL,
-        TIMEZONE
+        TIMEZONE,
+        CLIENT_TELEMETRY_ENABLED
     }
 }

--- a/Snowflake.Data/Core/Session/SFSessionProperty.cs
+++ b/Snowflake.Data/Core/Session/SFSessionProperty.cs
@@ -154,6 +154,8 @@ namespace Snowflake.Data.Core
         MAXTLS,
         [SFSessionPropertyAttr(required = false, defaultValue = "false")]
         HONORSESSIONTIMEZONE,
+        [SFSessionPropertyAttr(required = false, defaultValue = "true")]
+        CLIENT_TELEMETRY_ENABLED
     }
 
     class SFSessionPropertyAttr : Attribute

--- a/Snowflake.Data/Logger/SFLogger.cs
+++ b/Snowflake.Data/Logger/SFLogger.cs
@@ -4,6 +4,8 @@ namespace Snowflake.Data.Log
 {
     internal interface SFLogger
     {
+        bool IsTraceEnabled();
+
         bool IsDebugEnabled();
 
         bool IsInfoEnabled();
@@ -11,6 +13,8 @@ namespace Snowflake.Data.Log
         bool IsWarnEnabled();
 
         bool IsErrorEnabled();
+
+        void Trace(string msg, Exception ex = null);
 
         void Debug(string msg, Exception ex = null);
 

--- a/Snowflake.Data/Logger/SFLoggerImpl.cs
+++ b/Snowflake.Data/Logger/SFLoggerImpl.cs
@@ -9,6 +9,7 @@ namespace Snowflake.Data.Log
         internal static List<SFAppender> s_appenders = new List<SFAppender>();
         internal static LoggingEvent s_level = LoggingEvent.OFF;
         private static readonly object s_lock = new object();
+        private static bool s_isTraceEnabled = false;
         private static bool s_isDebugEnabled = false;
         private static bool s_isInfoEnabled = false;
         private static bool s_isWarnEnabled = false;
@@ -31,6 +32,7 @@ namespace Snowflake.Data.Log
         private static void SetEnableValues()
         {
             var enabled = s_level != LoggingEvent.OFF;
+            var isTraceEnabled = enabled;
             var isDebugEnabled = enabled;
             var isInfoEnabled = enabled;
             var isWarnEnabled = enabled;
@@ -41,27 +43,38 @@ namespace Snowflake.Data.Log
                 switch (s_level)
                 {
                     case LoggingEvent.TRACE:
+                        break;
                     case LoggingEvent.DEBUG:
+                        isTraceEnabled = false;
+                        break;
+                    case LoggingEvent.INFO:
+                        isDebugEnabled = false;
+                        isTraceEnabled = false;
+                        break;
+                    case LoggingEvent.WARN:
+                        isInfoEnabled = false;
+                        isDebugEnabled = false;
+                        isTraceEnabled = false;
                         break;
                     case LoggingEvent.ERROR:
                         isWarnEnabled = false;
                         isInfoEnabled = false;
                         isDebugEnabled = false;
-                        break;
-                    case LoggingEvent.WARN:
-                        isInfoEnabled = false;
-                        isDebugEnabled = false;
-                        break;
-                    case LoggingEvent.INFO:
-                        isDebugEnabled = false;
+                        isTraceEnabled = false;
                         break;
                 }
             }
 
+            s_isTraceEnabled = isTraceEnabled;
             s_isDebugEnabled = isDebugEnabled;
             s_isInfoEnabled = isInfoEnabled;
             s_isWarnEnabled = isWarnEnabled;
             s_isErrorEnabled = isErrorEnabled;
+        }
+
+        public bool IsTraceEnabled()
+        {
+            return s_isTraceEnabled;
         }
 
         public bool IsDebugEnabled()
@@ -82,6 +95,14 @@ namespace Snowflake.Data.Log
         public bool IsErrorEnabled()
         {
             return s_isErrorEnabled;
+        }
+
+        public void Trace(string msg, Exception ex = null)
+        {
+            if (IsTraceEnabled())
+            {
+                Log(LoggingEvent.TRACE.ToString(), msg, ex);
+            }
         }
 
         public void Debug(string msg, Exception ex = null)

--- a/Snowflake.Data/Logger/SFLoggerPair.cs
+++ b/Snowflake.Data/Logger/SFLoggerPair.cs
@@ -14,6 +14,15 @@ namespace Snowflake.Data.Log
             _snowflakeLogger = snowflakeLogger;
         }
 
+        public void Trace(string message, Exception ex = null)
+        {
+            if (!IsTraceEnabled())
+                return;
+            message = SecretDetector.MaskSecrets(message).maskedText;
+            _snowflakeLogger.Trace(message, new MaskedException(ex));
+            SFLoggerFactory.s_customLogger.LogTrace(FormatBrackets(message), new MaskedException(ex));
+        }
+
         public void Debug(string message, Exception ex = null)
         {
             if (!IsDebugEnabled())
@@ -48,6 +57,12 @@ namespace Snowflake.Data.Log
             message = SecretDetector.MaskSecrets(message).maskedText;
             _snowflakeLogger.Error(message, new MaskedException(ex));
             SFLoggerFactory.s_customLogger.LogError(FormatBrackets(message), new MaskedException(ex));
+        }
+
+        public bool IsTraceEnabled()
+        {
+            return _snowflakeLogger.IsTraceEnabled() ||
+                   SFLoggerFactory.s_customLogger.IsEnabled(LogLevel.Trace);
         }
 
         public bool IsDebugEnabled()

--- a/Snowflake.Data/Logger/SecretDetector.cs
+++ b/Snowflake.Data/Logger/SecretDetector.cs
@@ -78,17 +78,17 @@ namespace Snowflake.Data.Log
          * The characters are special character group element.
          * To match them in a character group, they must be escaped.
          */
-        private const string AwsKeyPattern = @"(aws_key_id|aws_secret_key|access_key_id|secret_access_key)('|"")?(\s*[:=]\s*)'([^']+)'";
-        private const string AwsTokenPattern = @"(accessToken|tempToken|keySecret)\""\s*:\s*\""([a-z0-9/+]{32,}={0,2})\""";
-        private const string AwsServerSidePattern = @"((x-amz-server-side-encryption)([a-z0-9\-])*)\s*(:|=)\s*([a-z0-9/_\-+:=])+";
-        private const string SasTokenPattern = @"(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})";
-        private const string PrivateKeyPattern = @"-----BEGIN PRIVATE KEY-----\n([a-z0-9/+=\n]{32,})\n-----END PRIVATE KEY-----"; // pragma: allowlist secret
-        private const string PrivateKeyDataPattern = @"""privateKeyData"": ""([a-z0-9/+=\n]{10,})""";
-        private const string PrivateKeyPropertyPrefixPattern = @"(private_key\s*=)";
-        private const string ConnectionTokenPattern = @"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})";
-        private const string TokenPropertyPattern = @"(token)(\s*=)(.*)";
-        private const string PasswordPattern = @"(password|passcode|client_?secret|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})";
-        private const string PasswordPropertyPattern = @"(password|passcode|oauthclientsecret|proxypassword|private_key_pwd)(\s*=)(.*)";
+        private static readonly Regex s_awsKeyPattern = new (@"(aws_key_id|aws_secret_key|access_key_id|secret_access_key)('|"")?(\s*[:=]\s*)'([^']+)'", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_awsTokenPattern = new (@"(accessToken|tempToken|keySecret)\""\s*:\s*\""([a-z0-9/+]{32,}={0,2})\""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_awsServerSidePattern = new (@"((x-amz-server-side-encryption)([a-z0-9\-])*)\s*(:|=)\s*([a-z0-9/_\-+:=])+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_sasTokenPattern = new (@"(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_privateKeyPattern = new (@"-----BEGIN PRIVATE KEY-----\n([a-z0-9/+=\n]{32,})\n-----END PRIVATE KEY-----", RegexOptions.IgnoreCase | RegexOptions.Multiline); // pragma: allowlist secret
+        private static readonly Regex s_privateKeyDataPattern = new (@"""privateKeyData"": ""([a-z0-9/+=\n]{10,})""", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_privateKeyPropertyPrefixPattern = new (@"(private_key\s*=)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_connectionTokenPattern = new (@"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})", RegexOptions.IgnoreCase  | RegexOptions.Compiled);
+        private static readonly Regex s_tokenPropertyPattern = new (@"(token)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_passwordPattern = new (@"(password|passcode|client_?secret|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_passwordPropertyPattern = new (@"(password|passcode|oauthclientsecret|proxypassword|private_key_pwd)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Func<string, string>[] s_maskFunctions = {
             MaskAWSServerSide,
@@ -104,39 +104,19 @@ namespace Snowflake.Data.Log
             MaskTokenProperty
         };
 
-        private static string MaskAWSKeys(string text)
-        {
-            return Regex.Replace(text, AwsKeyPattern, @"$1$2$3'****'",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskAWSKeys(string text) => s_awsKeyPattern.Replace(text, @"$1$2$3'****'");
 
-        private static string MaskAWSTokens(string text)
-        {
-            return Regex.Replace(text, AwsTokenPattern, @"$1"":""XXXX""",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskAWSTokens(string text) => s_awsTokenPattern.Replace(text, @"$1"":""XXXX""");
 
-        private static string MaskAWSServerSide(string text)
-        {
-            return Regex.Replace(text, AwsServerSidePattern, @"$1:....",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskAWSServerSide(string text) => s_awsServerSidePattern.Replace(text, @"$1:....");
 
-        private static string MaskSASTokens(string text)
-        {
-            return Regex.Replace(text, SasTokenPattern, @"$1=****",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskSASTokens(string text) => s_sasTokenPattern.Replace(text, @"$1=****");
 
-        private static string MaskPrivateKey(string text)
-        {
-            return Regex.Replace(text, PrivateKeyPattern, "-----BEGIN PRIVATE KEY-----\\\\nXXXX\\\\n-----END PRIVATE KEY-----", // pragma: allowlist secret
-                                         RegexOptions.IgnoreCase | RegexOptions.Multiline);
-        }
+        private static string MaskPrivateKey(string text) => s_privateKeyPattern.Replace(text, "-----BEGIN PRIVATE KEY-----\\\\nXXXX\\\\n-----END PRIVATE KEY-----");
 
         private static string MaskPrivateKeyProperty(string text)
         {
-            var match = Regex.Match(text, PrivateKeyPropertyPrefixPattern, RegexOptions.IgnoreCase);
+            var match = s_privateKeyPropertyPrefixPattern.Match(text);
             if (match.Success)
             {
                 int length = match.Index + match.Value.Length;
@@ -145,33 +125,15 @@ namespace Snowflake.Data.Log
             return text;
         }
 
-        private static string MaskPrivateKeyData(string text)
-        {
-            return Regex.Replace(text, PrivateKeyDataPattern, @"""privateKeyData"": ""XXXX""",
-                                         RegexOptions.IgnoreCase | RegexOptions.Multiline);
-        }
+        private static string MaskPrivateKeyData(string text) => s_privateKeyDataPattern.Replace(text, @"""privateKeyData"": ""XXXX""");
 
-        private static string MaskConnectionTokens(string text)
-        {
-            return Regex.Replace(text, ConnectionTokenPattern, @"$1$2****",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskConnectionTokens(string text) => s_connectionTokenPattern.Replace(text, @"$1$2****");
 
-        private static string MaskPassword(string text)
-        {
-            return Regex.Replace(text, PasswordPattern, @"$1$2****",
-                                         RegexOptions.IgnoreCase);
-        }
+        private static string MaskPassword(string text) => s_passwordPattern.Replace(text, @"$1$2****");
 
-        private static string MaskPasswordProperty(string text)
-        {
-            return Regex.Replace(text, PasswordPropertyPattern, @"$1$2****", RegexOptions.IgnoreCase);
-        }
+        private static string MaskPasswordProperty(string text) => s_passwordPropertyPattern.Replace(text, @"$1$2****");
 
-        private static string MaskTokenProperty(string text)
-        {
-            return Regex.Replace(text, TokenPropertyPattern, @"$1$2****", RegexOptions.IgnoreCase);
-        }
+        private static string MaskTokenProperty(string text) => s_tokenPropertyPattern.Replace(text, @"$1$2****");
 
         public static Mask MaskSecrets(string text)
         {

--- a/Snowflake.Data/Logger/SecretDetector.cs
+++ b/Snowflake.Data/Logger/SecretDetector.cs
@@ -78,17 +78,17 @@ namespace Snowflake.Data.Log
          * The characters are special character group element.
          * To match them in a character group, they must be escaped.
          */
-        private static readonly Regex s_awsKeyPattern = new (@"(aws_key_id|aws_secret_key|access_key_id|secret_access_key)('|"")?(\s*[:=]\s*)'([^']+)'", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_awsTokenPattern = new (@"(accessToken|tempToken|keySecret)\""\s*:\s*\""([a-z0-9/+]{32,}={0,2})\""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_awsServerSidePattern = new (@"((x-amz-server-side-encryption)([a-z0-9\-])*)\s*(:|=)\s*([a-z0-9/_\-+:=])+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_sasTokenPattern = new (@"(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_privateKeyPattern = new (@"-----BEGIN PRIVATE KEY-----\n([a-z0-9/+=\n]{32,})\n-----END PRIVATE KEY-----", RegexOptions.IgnoreCase | RegexOptions.Multiline); // pragma: allowlist secret
-        private static readonly Regex s_privateKeyDataPattern = new (@"""privateKeyData"": ""([a-z0-9/+=\n]{10,})""", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
-        private static readonly Regex s_privateKeyPropertyPrefixPattern = new (@"(private_key\s*=)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_connectionTokenPattern = new (@"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})", RegexOptions.IgnoreCase  | RegexOptions.Compiled);
-        private static readonly Regex s_tokenPropertyPattern = new (@"(token)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_passwordPattern = new (@"(password|passcode|client_?secret|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex s_passwordPropertyPattern = new (@"(password|passcode|oauthclientsecret|proxypassword|private_key_pwd)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_awsKeyPattern = new(@"(aws_key_id|aws_secret_key|access_key_id|secret_access_key)('|"")?(\s*[:=]\s*)'([^']+)'", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_awsTokenPattern = new(@"(accessToken|tempToken|keySecret)\""\s*:\s*\""([a-z0-9/+]{32,}={0,2})\""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_awsServerSidePattern = new(@"((x-amz-server-side-encryption)([a-z0-9\-])*)\s*(:|=)\s*([a-z0-9/_\-+:=])+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_sasTokenPattern = new(@"(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_privateKeyPattern = new(@"-----BEGIN PRIVATE KEY-----\n([a-z0-9/+=\n]{32,})\n-----END PRIVATE KEY-----", RegexOptions.IgnoreCase | RegexOptions.Multiline); // pragma: allowlist secret
+        private static readonly Regex s_privateKeyDataPattern = new(@"""privateKeyData"": ""([a-z0-9/+=\n]{10,})""", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex s_privateKeyPropertyPrefixPattern = new(@"(private_key\s*=)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_connectionTokenPattern = new(@"(token|assertion content)(['""\s:=]+)([a-z0-9=/_\-+:]{8,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_tokenPropertyPattern = new(@"(token)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_passwordPattern = new(@"(password|passcode|client_?secret|pwd|proxypassword|private_key_pwd)(['""\s:=]+)([a-z0-9!""#$%&'\()*+,-./:;<=>?@\[\]\^_`{|}~]{6,})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_passwordPropertyPattern = new(@"(password|passcode|oauthclientsecret|proxypassword|private_key_pwd)(\s*=)(.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Func<string, string>[] s_maskFunctions = {
             MaskAWSServerSide,

--- a/Snowflake.Data/Telemetry/ActivityExtensions.cs
+++ b/Snowflake.Data/Telemetry/ActivityExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Snowflake.Data.Client;
 using Snowflake.Data.Core;
-using Snowflake.Data.Log;
 
 namespace Snowflake.Data.Telemetry;
 
@@ -47,22 +46,16 @@ internal static class ActivityExtensions
         if (activity is null)
             return;
 
-        var description = exception != null
-            ? SecretDetector.MaskSecrets(exception.Message).maskedText
-            : "Unknown error";
-
 #if NET6_0_OR_GREATER
-        activity.SetStatus(ActivityStatusCode.Error, description);
+        activity.SetStatus(ActivityStatusCode.Error, "ERROR");
 #endif
         activity.SetTag(TelemetryTags.StatusCode, "ERROR");
-        activity.SetTag(TelemetryTags.StatusDescription, description);
 
         if (exception != null)
         {
             var tagsCollection = new ActivityTagsCollection
             {
                 { TelemetryTags.Exception, exception.GetType().FullName },
-                { TelemetryTags.ExceptionMessage, description },
             };
 
             if (TryGetErrorCode(exception, out var code))

--- a/Snowflake.Data/Telemetry/ActivityExtensions.cs
+++ b/Snowflake.Data/Telemetry/ActivityExtensions.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Telemetry;
+
+internal static class ActivityExtensions
+{
+    internal static void SetSessionProperties(this Activity activity, SFSession session)
+    {
+        activity.SetTag(TelemetryTags.DbSystem, TelemetryTags.Snowflake);
+        activity.SetTag(TelemetryTags.DbWarehouse, session.warehouse);
+        activity.SetTag(TelemetryTags.DbRole, session.role);
+        activity.SetTag(TelemetryTags.DbName, session.database);
+        activity.SetTag(TelemetryTags.SessionId, session.sessionId);
+    }
+
+    public static void SetSuccess(this Activity activity)
+    {
+        if (activity is null)
+            return;
+
+#if NET6_0_OR_GREATER
+        activity.SetStatus(ActivityStatusCode.Ok);
+#endif
+        activity.SetTag(TelemetryTags.StatusCode, "OK");
+        activity.Stop();
+    }
+
+
+    internal static void AddTelemetryEvent(this Activity activity, string name)
+    {
+        if (activity is null)
+            return;
+
+        if (string.IsNullOrEmpty(name))
+            return;
+
+        activity.AddEvent(new ActivityEvent(name));
+    }
+
+    public static void SetException(this Activity activity, Exception exception)
+    {
+        if (activity is null)
+            return;
+
+        var description = exception != null
+            ? SecretDetector.MaskSecrets(exception.Message).maskedText
+            : "Unknown error";
+
+#if NET6_0_OR_GREATER
+        activity.SetStatus(ActivityStatusCode.Error, description);
+#endif
+        activity.SetTag(TelemetryTags.StatusCode, "ERROR");
+        activity.SetTag(TelemetryTags.StatusDescription, description);
+
+        if (exception != null)
+        {
+            var tagsCollection = new ActivityTagsCollection
+            {
+                { TelemetryTags.Exception, exception.GetType().FullName },
+                { TelemetryTags.ExceptionMessage, description },
+            };
+
+            if (TryGetErrorCode(exception, out var code))
+                tagsCollection.Add(TelemetryTags.ExceptionErrorCode, code);
+
+            activity.AddEvent(new ActivityEvent("exception", tags: tagsCollection));
+        }
+
+        activity.Stop();
+    }
+
+    private static bool TryGetErrorCode(Exception exception, out string snowflakeDbException)
+    {
+        if (exception is SnowflakeDbException dbEx)
+        {
+            snowflakeDbException = dbEx.ErrorCode.ToString();
+            return true;
+        }
+
+        if (exception is not AggregateException aggEx)
+        {
+            snowflakeDbException = string.Empty;
+            return false;
+        }
+
+        var aggregationExceptionsVisited = 0;
+        var aggregateExceptions = new List<AggregateException> { aggEx };
+        while (aggregateExceptions.Count > aggregationExceptionsVisited && aggregationExceptionsVisited < MaxAggregateExceptionDepth)
+        {
+            var currentAggException = aggregateExceptions[aggregationExceptionsVisited++];
+
+            foreach (var innerException in currentAggException.InnerExceptions)
+            {
+                switch (innerException)
+                {
+                    case SnowflakeDbException nestedDbEx:
+                        snowflakeDbException = nestedDbEx.ErrorCode.ToString();
+                        return true;
+                    case AggregateException aex:
+                        aggregateExceptions.Add(aex);
+                        break;
+                }
+            }
+        }
+
+        snowflakeDbException = string.Empty;
+        return false;
+    }
+
+    private const int MaxAggregateExceptionDepth = 3;
+}

--- a/Snowflake.Data/Telemetry/ActivityExtensions.cs
+++ b/Snowflake.Data/Telemetry/ActivityExtensions.cs
@@ -17,6 +17,10 @@ internal static class ActivityExtensions
         activity.SetTag(TelemetryTags.SessionId, session.sessionId);
     }
 
+    /// <summary>
+    /// Marks the activity as successful, sets the status code tag to "OK", and stops the activity.
+    /// </summary>
+    /// <param name="activity">The activity to mark as successful. If null, the call is a no-op.</param>
     public static void SetSuccess(this Activity activity)
     {
         if (activity is null)
@@ -29,6 +33,13 @@ internal static class ActivityExtensions
         activity.Stop();
     }
 
+    /// <summary>
+    /// This API is intended for internal Snowflake client use and is subject to breaking changes without notice.
+    /// Adds a named telemetry event to the activity with optional tags.
+    /// </summary>
+    /// <param name="activity">The activity to add the event to. If null, the call is a no-op.</param>
+    /// <param name="name">The name of the event. If null or empty, the call is a no-op.</param>
+    /// <param name="tags">Optional key-value pairs to attach to the event.</param>
     public static void AddTelemetryEvent(this Activity activity, string name, params IEnumerable<KeyValuePair<string, object>> tags)
     {
         if (activity is null)
@@ -40,6 +51,11 @@ internal static class ActivityExtensions
         activity.AddEvent(new ActivityEvent(name, tags: new ActivityTagsCollection(tags)));
     }
 
+    /// <summary>
+    /// Marks the activity as failed, records the exception details as an event, and stops the activity.
+    /// </summary>
+    /// <param name="activity">The activity to mark as failed. If null, the call is a no-op.</param>
+    /// <param name="exception">The exception to record. If null, only the error status is set.</param>
     public static void SetException(this Activity activity, Exception exception)
     {
         if (activity is null)

--- a/Snowflake.Data/Telemetry/ActivityExtensions.cs
+++ b/Snowflake.Data/Telemetry/ActivityExtensions.cs
@@ -29,8 +29,7 @@ internal static class ActivityExtensions
         activity.Stop();
     }
 
-
-    internal static void AddTelemetryEvent(this Activity activity, string name)
+    public static void AddTelemetryEvent(this Activity activity, string name, params IEnumerable<KeyValuePair<string, object>> tags)
     {
         if (activity is null)
             return;
@@ -38,7 +37,7 @@ internal static class ActivityExtensions
         if (string.IsNullOrEmpty(name))
             return;
 
-        activity.AddEvent(new ActivityEvent(name));
+        activity.AddEvent(new ActivityEvent(name, tags: new ActivityTagsCollection(tags)));
     }
 
     public static void SetException(this Activity activity, Exception exception)

--- a/Snowflake.Data/Telemetry/ActivityStarter.cs
+++ b/Snowflake.Data/Telemetry/ActivityStarter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using Snowflake.Data.Client;
+using Snowflake.Data.Core;
+
+namespace Snowflake.Data.Telemetry;
+
+/// <summary>
+/// Provides helpers for starting <see cref="Activity"/> instances enriched
+/// with Snowflake session context (warehouse, role, database, session id).
+/// Activities are created with <see cref="ActivityKind.Client"/> and tagged
+/// following OpenTelemetry semantic conventions.
+/// </summary>
+public static class ActivityStarter
+{
+    internal const string ActivitySourceName = "Snowflake_dotnet_activity";
+    internal const string ClientDefinedTelemetrySourceName = "Client_custom_activity";
+
+    private static readonly ActivitySource s_internalActivitySource = new (ActivitySourceName, SFEnvironment.DriverVersion);
+    private static readonly ActivitySource s_customActivitySource = new (ClientDefinedTelemetrySourceName, SFEnvironment.DriverVersion);
+
+    /// <summary>
+    /// Starts a client-side <see cref="Activity"/> using the custom activity source,
+    /// enriched with session context from the command's open connection.
+    /// </summary>
+    /// <param name="command">
+    /// A <see cref="SnowflakeDbCommand"/> whose connection must be open and
+    /// have client telemetry enabled.
+    /// </param>
+    /// <param name="name">The operation name for the activity.</param>
+    /// <returns>A started <see cref="Activity"/>, or <c>null</c> if no listener is sampling.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the connection is not open or client telemetry is not enabled.
+    /// </exception>
+    public static Activity StartActivity(this SnowflakeDbCommand command, string name)
+    {
+        if (command?.Connection is not SnowflakeDbConnection connection || !connection.IsOpen())
+            throw new ArgumentException($"{nameof(StartActivity)} can only be called on open connections!");
+
+        if (!connection.SfSession.IsClientTelemetryEnabled())
+            throw new ArgumentException($"Client telemetry needs to be enabled to call {nameof(StartActivity)}!");
+
+        return StartActivity(connection.SfSession, name, s_customActivitySource);
+    }
+
+    internal static Activity StartActivity(this SFSession session, string name) => StartActivity(session, name, s_internalActivitySource);
+
+    private static Activity StartActivity(this SFSession session, string name, ActivitySource activitySource)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException(@"Activity name cannot be null or empty.", nameof(name));
+
+        var activity = activitySource.StartActivity(name, ActivityKind.Client);
+        if (activity is null)
+            return null;
+
+        activity.SetSessionProperties(session);
+
+        return activity;
+    }
+}

--- a/Snowflake.Data/Telemetry/ActivityStarter.cs
+++ b/Snowflake.Data/Telemetry/ActivityStarter.cs
@@ -16,8 +16,8 @@ public static class ActivityStarter
     internal const string ActivitySourceName = "Snowflake_dotnet_activity";
     internal const string ClientDefinedTelemetrySourceName = "Client_custom_activity";
 
-    private static readonly ActivitySource s_internalActivitySource = new (ActivitySourceName, SFEnvironment.DriverVersion);
-    private static readonly ActivitySource s_customActivitySource = new (ClientDefinedTelemetrySourceName, SFEnvironment.DriverVersion);
+    private static readonly ActivitySource s_internalActivitySource = new(ActivitySourceName, SFEnvironment.DriverVersion);
+    private static readonly ActivitySource s_customActivitySource = new(ClientDefinedTelemetrySourceName, SFEnvironment.DriverVersion);
 
     /// <summary>
     /// Starts a client-side <see cref="Activity"/> using the custom activity source,

--- a/Snowflake.Data/Telemetry/ISessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/ISessionTelemetryModule.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+
+namespace Snowflake.Data.Telemetry;
+
+internal interface ISessionTelemetryModule : IDisposable
+{
+    internal string SessionId { get; }
+    internal string SessionToken { get; }
+    internal bool IsDisposed { get; }
+
+    internal int CurrentBufferSize { get; }
+
+    internal bool IsServiceAvailable { get; }
+
+    internal bool IsFlushInProgress { get; }
+
+    internal void OnActivityStopped(Activity activity);
+}

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -22,9 +22,8 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
 
     private static readonly int s_flushSize = TelemetryTransport.TelemetryFlushSize;
     private static readonly TimeSpan s_flushInterval = TimeSpan.FromMilliseconds(TelemetryTransport.TelemetryFlushIntervalInMs);
-    private static readonly TimeSpan s_sendTimeout = TimeSpan.FromSeconds(30);
-    private static readonly TimeSpan s_sendHttpTimeout = TimeSpan.FromSeconds(10);
 
+    private readonly TimeSpan _sendTimeout;
     private readonly LockObject _lock = new();
     private readonly string _sessionId;
     private readonly IRestRequester _restRequester;
@@ -48,6 +47,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
         _sessionToken = session.sessionToken;
         _restRequester = session.restRequester;
         _url = session.BuildUri(RestPath.SF_TELEMETRY_PATH);
+        _sendTimeout = session.connectionTimeout;
         _flushTimer = new Timer(_ => FlushTimerCallback(), null, flushInterval, flushInterval);
     }
 
@@ -72,7 +72,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
         {
             if (!IsTelemetryEnabled())
             {
-                s_logger.Debug($"Recorded activity, but client telemetry is disabled. Activity will be ignored.");
+                s_logger.Trace($"Recorded activity, but client telemetry is disabled. Activity will be ignored.");
                 return;
             }
 
@@ -89,7 +89,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     {
         if (!IsTelemetryEnabled())
         {
-            s_logger.Debug("Trying to flush telemetry, but client telemetry is disabled.");
+            s_logger.Trace("Trying to flush telemetry, but client telemetry is disabled.");
             return;
         }
 
@@ -128,7 +128,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     {
         if (!_isServiceAvailable || (!isCallingFromDispose && IsDisposed()))
         {
-            s_logger.Debug("Trying to flush telemetry, but client telemetry is disabled.");
+            s_logger.Trace("Trying to flush telemetry, but client telemetry is disabled.");
             return;
         }
 
@@ -204,7 +204,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     {
         if (!IsTelemetryEnabled())
         {
-            s_logger.Debug($"Timer tries to flush client telemetry, but client telemetry is disabled.");
+            s_logger.Trace("Timer tries to flush client telemetry, but client telemetry is disabled.");
             return;
         }
 
@@ -271,8 +271,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
             authorizationToken = $"Snowflake Token=\"{_sessionToken}\"",
             jsonBody = new TelemetryRequest(data),
             sid = _sessionId,
-            RestTimeout = s_sendTimeout,
-            HttpTimeout = s_sendHttpTimeout,
+            RestTimeout = _sendTimeout,
         };
     }
 

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -20,9 +20,10 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
 {
     private static readonly SFLogger s_logger = SFLoggerFactory.GetSFLogger<SessionTelemetryModule>();
 
-    private static readonly int s_flushSize = TelemetryTransport.TelemetryFlushSize;
-    private static readonly TimeSpan s_flushInterval = TimeSpan.FromMilliseconds(TelemetryTransport.TelemetryFlushIntervalInMs);
+    private static volatile int s_flushSize = 100;
+    private static volatile int s_flushIntervalMs = 60 * 1_000;
 
+    private readonly int _flushSize;
     private readonly TimeSpan _sendTimeout;
     private readonly LockObject _lock = new();
     private readonly string _sessionId;
@@ -38,17 +39,35 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     private volatile int _flushInProgress;
     private bool IsDisposed() => _disposed != 0;
 
-    internal SessionTelemetryModule(SFSession session) : this(session, s_flushInterval)
-    { }
-
-    internal SessionTelemetryModule(SFSession session, TimeSpan flushInterval)
+    internal SessionTelemetryModule(SFSession session) : this(session, s_flushSize, TimeSpan.FromMilliseconds(s_flushIntervalMs))
     {
+    }
+
+    internal SessionTelemetryModule(SFSession session, int flushSize, TimeSpan flushInterval)
+    {
+        _flushSize = flushSize;
         _sessionId = session.sessionId;
         _sessionToken = session.sessionToken;
         _restRequester = session.restRequester;
         _url = session.BuildUri(RestPath.SF_TELEMETRY_PATH);
         _sendTimeout = session.connectionTimeout;
         _flushTimer = new Timer(_ => FlushTimerCallback(), null, flushInterval, flushInterval);
+    }
+
+    public static void SetFlushSize(int flushSize)
+    {
+        if (flushSize <= 0)
+            throw new ArgumentException("Flush size must be greater than 0.");
+
+        Interlocked.Exchange(ref s_flushSize, flushSize);
+    }
+
+    public static void SetFlushInterval(int flushIntervalInMilliseconds)
+    {
+        if (flushIntervalInMilliseconds <= 0)
+            throw new ArgumentException("Flush interval must be greater than 0.");
+
+        Interlocked.Exchange(ref s_flushIntervalMs, flushIntervalInMilliseconds);
     }
 
     public void Dispose()
@@ -100,7 +119,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
                 return;
 
             toSend = _buffer;
-            _buffer = new List<TelemetryData>(s_flushSize);
+            _buffer = new List<TelemetryData>(_flushSize);
         }
 
         try
@@ -139,7 +158,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
                 return;
 
             toSend = _buffer;
-            _buffer = new List<TelemetryData>(s_flushSize);
+            _buffer = new List<TelemetryData>(_flushSize);
         }
 
         try
@@ -173,7 +192,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
             count = _buffer.Count;
         }
 
-        if (count < s_flushSize)
+        if (count < _flushSize)
             return;
 
         if (Interlocked.CompareExchange(ref _flushInProgress, 1, 0) != 0)

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -221,8 +221,8 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     private static IEnumerable<TelemetryData> ConvertActivityToTelemetryData(Activity activity)
     {
         var timestamp = new DateTimeOffset(activity.StartTimeUtc);
-        var events = activity.Events;
-        events = events.Any() ? events : [new(activity.DisplayName, timestamp)];
+        var activityEvent = new ActivityEvent(activity.DisplayName, timestamp, new ActivityTagsCollection(activity.TagObjects));
+        var events = activity.Events.Prepend(activityEvent);
         foreach (var @event in events)
         {
             var message = new Dictionary<string, string>
@@ -238,7 +238,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
                 { TelemetryField.EventTime, @event.Timestamp.ToString()}
             };
 
-            foreach (var tag in activity.TagObjects)
+            foreach (var tag in @event.Tags)
             {
                 if (tag.Value is null)
                     continue;

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -195,7 +195,9 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     private void DisableTelemetry()
     {
         _isServiceAvailable = false;
-        _flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
+
+        if (!IsDisposed())
+            _flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
     }
 
     private void FlushTimerCallback()
@@ -253,7 +255,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
             _ => "UNSET"
         };
 #else
-            var statusTag = activity.GetTagItem("otel.status_code");
+            var statusTag = activity.GetTagItem(TelemetryTags.StatusCode);
             message[TelemetryField.StatusCode] = statusTag?.ToString() ?? "UNSET";
 #endif
 

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -220,7 +220,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
     {
         var timestamp = new DateTimeOffset(activity.StartTimeUtc);
         var events = activity.Events;
-        events = events.Any() ? events : [new (activity.DisplayName, timestamp)];
+        events = events.Any() ? events : [new(activity.DisplayName, timestamp)];
         foreach (var @event in events)
         {
             var message = new Dictionary<string, string>
@@ -257,7 +257,7 @@ internal sealed class SessionTelemetryModule : ISessionTelemetryModule
             message[TelemetryField.StatusCode] = statusTag?.ToString() ?? "UNSET";
 #endif
 
-             yield return new TelemetryData(message, @event.Timestamp.ToUnixTimeMilliseconds());
+            yield return new TelemetryData(message, @event.Timestamp.ToUnixTimeMilliseconds());
         }
     }
 

--- a/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModule.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Data.Core;
+using Snowflake.Data.Log;
+
+using LockObject =
+#if NET10_0_OR_GREATER
+System.Threading.Lock;
+#else
+System.Object;
+#endif
+
+namespace Snowflake.Data.Telemetry;
+
+internal sealed class SessionTelemetryModule : ISessionTelemetryModule
+{
+    private static readonly SFLogger s_logger = SFLoggerFactory.GetSFLogger<SessionTelemetryModule>();
+
+    private static readonly int s_flushSize = TelemetryTransport.TelemetryFlushSize;
+    private static readonly TimeSpan s_flushInterval = TimeSpan.FromMilliseconds(TelemetryTransport.TelemetryFlushIntervalInMs);
+    private static readonly TimeSpan s_sendTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_sendHttpTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly LockObject _lock = new();
+    private readonly string _sessionId;
+    private readonly IRestRequester _restRequester;
+    private volatile string _sessionToken;
+
+    private readonly Uri _url;
+    private readonly Timer _flushTimer;
+
+    private List<TelemetryData> _buffer = new(s_flushSize);
+    private volatile bool _isServiceAvailable = true;
+    private volatile int _disposed;
+    private volatile int _flushInProgress;
+    private bool IsDisposed() => _disposed != 0;
+
+    internal SessionTelemetryModule(SFSession session) : this(session, s_flushInterval)
+    { }
+
+    internal SessionTelemetryModule(SFSession session, TimeSpan flushInterval)
+    {
+        _sessionId = session.sessionId;
+        _sessionToken = session.sessionToken;
+        _restRequester = session.restRequester;
+        _url = session.BuildUri(RestPath.SF_TELEMETRY_PATH);
+        _flushTimer = new Timer(_ => FlushTimerCallback(), null, flushInterval, flushInterval);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            s_logger.Debug("Trying to dispose this component, but it is already disposed.");
+            return;
+        }
+
+        _flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        _flushTimer.Dispose();
+        Flush(true);
+    }
+
+    internal void UpdateToken(string sessionToken) => _sessionToken = sessionToken;
+
+    internal void OnActivityStoppedImpl(Activity activity)
+    {
+        try
+        {
+            if (!IsTelemetryEnabled())
+            {
+                s_logger.Debug($"Recorded activity, but client telemetry is disabled. Activity will be ignored.");
+                return;
+            }
+
+            var telemetryData = ConvertActivityToTelemetryData(activity);
+            AddData(telemetryData);
+        }
+        catch (Exception ex)
+        {
+            s_logger.Debug($"Failed to process activity telemetry for session {_sessionId}: {ex.Message}.");
+        }
+    }
+
+    internal async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        if (!IsTelemetryEnabled())
+        {
+            s_logger.Debug("Trying to flush telemetry, but client telemetry is disabled.");
+            return;
+        }
+
+        List<TelemetryData> toSend;
+        lock (_lock)
+        {
+            if (_buffer.Count == 0)
+                return;
+
+            toSend = _buffer;
+            _buffer = new List<TelemetryData>(s_flushSize);
+        }
+
+        try
+        {
+            var request = BuildSendRequest(toSend);
+            var response = await _restRequester.PostAsync<NullDataResponse>(request, cancellationToken).ConfigureAwait(false);
+
+            if (response is not { success: true })
+            {
+                s_logger.Warn($"Non-success response from telemetry server for session {_sessionId}. Disabling telemetry.");
+                DisableTelemetry();
+                return;
+            }
+
+            s_logger.Debug($"Successfully sent {toSend.Count} telemetry logs for session {_sessionId}.");
+        }
+        catch (Exception ex)
+        {
+            s_logger.Warn($"Failed to send telemetry for session {_sessionId}: {ex.Message}. Disabling telemetry.");
+            DisableTelemetry();
+        }
+    }
+
+    private void Flush(bool isCallingFromDispose = false)
+    {
+        if (!_isServiceAvailable || (!isCallingFromDispose && IsDisposed()))
+        {
+            s_logger.Debug("Trying to flush telemetry, but client telemetry is disabled.");
+            return;
+        }
+
+        List<TelemetryData> toSend;
+        lock (_lock)
+        {
+            if (_buffer.Count == 0)
+                return;
+
+            toSend = _buffer;
+            _buffer = new List<TelemetryData>(s_flushSize);
+        }
+
+        try
+        {
+            var request = BuildSendRequest(toSend);
+            var response = _restRequester.Post<NullDataResponse>(request);
+
+            if (response is not { success: true })
+            {
+                s_logger.Warn($"Non-success response from telemetry server for session {_sessionId}. Disabling telemetry.");
+                DisableTelemetry();
+                return;
+            }
+
+            s_logger.Debug($"Successfully sent {toSend.Count} telemetry logs for session {_sessionId}.");
+        }
+        catch (Exception ex)
+        {
+            s_logger.Warn($"Failed to send telemetry for session {_sessionId}: {ex.Message}. Disabling telemetry.");
+            DisableTelemetry();
+        }
+    }
+
+
+    private void AddData(IEnumerable<TelemetryData> data)
+    {
+        int count;
+        lock (_lock)
+        {
+            _buffer.AddRange(data);
+            count = _buffer.Count;
+        }
+
+        if (count < s_flushSize)
+            return;
+
+        if (Interlocked.CompareExchange(ref _flushInProgress, 1, 0) != 0)
+        {
+            s_logger.Debug($"Collected enough data to send, but previous flush is still in progress. Buffer will grow.");
+            return;
+        }
+
+        s_logger.Debug($"Auto-flushing telemetry batch of size {count} for session {_sessionId}.");
+        _ = Task.Run(() =>
+        {
+            try { Flush(); }
+            finally { Interlocked.Exchange(ref _flushInProgress, 0); }
+        });
+    }
+
+    private bool IsTelemetryEnabled() => _isServiceAvailable && !IsDisposed();
+
+    private void DisableTelemetry()
+    {
+        _isServiceAvailable = false;
+        _flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
+    }
+
+    private void FlushTimerCallback()
+    {
+        if (!IsTelemetryEnabled())
+        {
+            s_logger.Debug($"Timer tries to flush client telemetry, but client telemetry is disabled.");
+            return;
+        }
+
+        try
+        {
+            Flush();
+        }
+        catch (Exception ex)
+        {
+            s_logger.Warn($"Periodic flush failed for session {_sessionId}: {ex.Message}.");
+        }
+    }
+
+    private static IEnumerable<TelemetryData> ConvertActivityToTelemetryData(Activity activity)
+    {
+        var timestamp = new DateTimeOffset(activity.StartTimeUtc);
+        var events = activity.Events;
+        events = events.Any() ? events : [new (activity.DisplayName, timestamp)];
+        foreach (var @event in events)
+        {
+            var message = new Dictionary<string, string>
+            {
+                { TelemetryField.Type, "client_activity" },
+                { TelemetryField.Source, activity.Source.Name },
+                { TelemetryField.ScopeName, activity.Source.Name },
+                { TelemetryField.ScopeVersion, SFEnvironment.DriverVersion },
+                { TelemetryField.DriverType, SFEnvironment.DriverName },
+                { TelemetryField.DriverVersion, SFEnvironment.DriverVersion },
+                { TelemetryField.Duration, activity.Duration.TotalMilliseconds.ToString("F0") },
+                { TelemetryField.EventName, @event.Name},
+                { TelemetryField.EventTime, @event.Timestamp.ToString()}
+            };
+
+            foreach (var tag in activity.TagObjects)
+            {
+                if (tag.Value is null)
+                    continue;
+
+                var maskedTagValue = SecretDetector.MaskSecrets(tag.Value.ToString());
+                message[$"tag.{tag.Key}"] = maskedTagValue.maskedText;
+            }
+
+#if NET6_0_OR_GREATER
+        message[TelemetryField.StatusCode] = activity.Status switch
+        {
+            ActivityStatusCode.Error => "ERROR",
+            ActivityStatusCode.Ok => "OK",
+            _ => "UNSET"
+        };
+#else
+            var statusTag = activity.GetTagItem("otel.status_code");
+            message[TelemetryField.StatusCode] = statusTag?.ToString() ?? "UNSET";
+#endif
+
+             yield return new TelemetryData(message, @event.Timestamp.ToUnixTimeMilliseconds());
+        }
+    }
+
+    private SFRestRequest BuildSendRequest(List<TelemetryData> data)
+    {
+        return new SFRestRequest
+        {
+            Url = _url,
+            authorizationToken = $"Snowflake Token=\"{_sessionToken}\"",
+            jsonBody = new TelemetryRequest(data),
+            sid = _sessionId,
+            RestTimeout = s_sendTimeout,
+            HttpTimeout = s_sendHttpTimeout,
+        };
+    }
+
+    string ISessionTelemetryModule.SessionId => _sessionId;
+    string ISessionTelemetryModule.SessionToken => _sessionToken;
+    bool ISessionTelemetryModule.IsDisposed => IsDisposed();
+    bool ISessionTelemetryModule.IsServiceAvailable => _isServiceAvailable;
+    bool ISessionTelemetryModule.IsFlushInProgress => _flushInProgress != 0;
+
+    int ISessionTelemetryModule.CurrentBufferSize
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _buffer.Count;
+            }
+        }
+    }
+
+    void ISessionTelemetryModule.OnActivityStopped(Activity activity) => OnActivityStoppedImpl(activity);
+}

--- a/Snowflake.Data/Telemetry/SessionTelemetryModuleFacade.cs
+++ b/Snowflake.Data/Telemetry/SessionTelemetryModuleFacade.cs
@@ -1,0 +1,24 @@
+namespace Snowflake.Data.Telemetry;
+
+/// <summary>
+/// Provides public configuration methods for the session telemetry module.
+/// Changes apply only to sessions created after the configuration is set.
+/// </summary>
+public static class SessionTelemetryModuleFacade
+{
+    /// <summary>
+    /// Sets the number of buffered activities that triggers an automatic flush. Default is 100.
+    /// Only affects sessions created after this call.
+    /// </summary>
+    /// <param name="flushSize">The buffer size threshold. Must be greater than 0.</param>
+    /// <exception cref="System.ArgumentException">Thrown when <paramref name="flushSize"/> is less than or equal to 0.</exception>
+    public static void SetFlushSize(int flushSize) => SessionTelemetryModule.SetFlushSize(flushSize);
+
+    /// <summary>
+    /// Sets the periodic flush interval. Default is 60000 ms (1 minute).
+    /// Only affects sessions created after this call.
+    /// </summary>
+    /// <param name="flushIntervalInMilliseconds">The flush interval in milliseconds. Must be greater than 0.</param>
+    /// <exception cref="System.ArgumentException">Thrown when <paramref name="flushIntervalInMilliseconds"/> is less than or equal to 0.</exception>
+    public static void SetFlushInterval(int flushIntervalInMilliseconds) => SessionTelemetryModule.SetFlushInterval(flushIntervalInMilliseconds);
+}

--- a/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
@@ -43,7 +43,7 @@ internal static class SnowflakeTelemetryModule
     {
         if (!session.IsClientTelemetryEnabled())
         {
-            s_logger.Debug("Session tried to register to telemetry module, but it has client telemetry disabled!");
+            s_logger.Trace("Session tried to register to telemetry module, but it has client telemetry disabled!");
             return;
         }
 
@@ -51,12 +51,12 @@ internal static class SnowflakeTelemetryModule
         {
             if (s_sessions.TryGetValue(session.sessionId, out var existing))
             {
-                s_logger.Debug("Session re-registered in client telemetry module.");
+                s_logger.Trace("Session re-registered in client telemetry module.");
                 existing.UpdateToken(session.sessionToken);
                 return;
             }
 
-            s_logger.Debug("Session registering in client telemetry module.");
+            s_logger.Trace("Session registering in client telemetry module.");
             var module = new SessionTelemetryModule(session);
             s_sessions.Add(session.sessionId, module);
         }
@@ -99,11 +99,11 @@ internal static class SnowflakeTelemetryModule
         module = null;
         if (string.IsNullOrEmpty(sessionId))
         {
-            s_logger.Warn("Tried to unregister session without providing any id!");
+            s_logger.Debug("Tried to unregister session without providing any id!");
             return false;
         }
 
-        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
+        s_logger.Trace($"Unregistering session with id: {sessionId} from client telemetry module.");
         lock (s_lock)
         {
             if (!s_sessions.TryGetValue(sessionId, out module))
@@ -119,14 +119,14 @@ internal static class SnowflakeTelemetryModule
     {
         if (!s_activitySources.Contains(activity.Source.Name))
         {
-            s_logger.Debug($"Activity {activity.Source.Name} will not be handled by this component!");
+            s_logger.Trace($"Activity {activity.Source.Name} will not be handled by this component!");
             return;
         }
 
         var sessionId = activity.GetTagItem(TelemetryTags.SessionId) as string;
         if (string.IsNullOrEmpty(sessionId))
         {
-            s_logger.Warn($"Activity with no {TelemetryTags.SessionId} recorded!");
+            s_logger.Debug($"Activity with no {TelemetryTags.SessionId} recorded!");
             return;
         }
 
@@ -135,7 +135,7 @@ internal static class SnowflakeTelemetryModule
         {
             if (!s_sessions.TryGetValue(sessionId, out module))
             {
-                s_logger.Warn($"Activity with no matching session telemetry module recorded! SessionId: {sessionId}");
+                s_logger.Debug($"Activity with no matching session telemetry module recorded! SessionId: {sessionId}");
                 return;
             }
         }
@@ -146,7 +146,7 @@ internal static class SnowflakeTelemetryModule
     private static void OnActivityStarted(Activity activity)
     {
         var sessionId = activity.GetTagItem(TelemetryTags.SessionId) as string;
-        s_logger.Info($"Activity {activity.DisplayName} for session: {sessionId} started..");
+        s_logger.Debug($"Activity {activity.DisplayName} for session: {sessionId} started..");
     }
 
     private static ActivitySamplingResult Sample(ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;

--- a/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Data.Core;
+using Snowflake.Data.Log;
+using LockObject =
+#if NET10_0_OR_GREATER
+    System.Threading.Lock;
+#else
+System.Object;
+#endif
+
+namespace Snowflake.Data.Telemetry;
+
+/// <summary>
+/// Static coordinator that owns the ActivityListener and routes activity events
+/// to per-session <see cref="SessionTelemetryModule"/> instances.
+/// </summary>
+internal static class SnowflakeTelemetryModule
+{
+    private static readonly SFLogger s_logger = SFLoggerFactory.GetSFLogger<SessionTelemetryModule>();
+
+    private static readonly LockObject s_lock = new();
+    private static readonly Dictionary<string, SessionTelemetryModule> s_sessions = new();
+
+    private static readonly string[] s_activitySources = [ActivityStarter.ActivitySourceName, ActivityStarter.ClientDefinedTelemetrySourceName];
+
+    static SnowflakeTelemetryModule()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => s_activitySources.Contains(source?.Name),
+            ActivityStarted = OnActivityStarted,
+            ActivityStopped = OnActivityStopped,
+            Sample = Sample,
+        };
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    internal static void Register(SFSession session)
+    {
+        if (!session.IsClientTelemetryEnabled())
+        {
+            s_logger.Debug("Session tried to register to telemetry module, but it has client telemetry disabled!");
+            return;
+        }
+
+        lock (s_lock)
+        {
+            if (s_sessions.TryGetValue(session.sessionId, out var existing))
+            {
+                s_logger.Debug("Session re-registered in client telemetry module.");
+                existing.UpdateToken(session.sessionToken);
+                return;
+            }
+
+            s_logger.Debug("Session registering in client telemetry module.");
+            var module = new SessionTelemetryModule(session);
+            s_sessions.Add(session.sessionId, module);
+        }
+    }
+
+    internal static void Unregister(string sessionId)
+    {
+        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
+        SessionTelemetryModule module;
+        lock (s_lock)
+        {
+            if (!s_sessions.TryGetValue(sessionId, out module))
+                return;
+
+            s_sessions.Remove(sessionId);
+        }
+
+        module.Dispose();
+    }
+
+    internal static async Task UnregisterAsync(string sessionId, CancellationToken cancellationToken)
+    {
+        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
+        SessionTelemetryModule module;
+        lock (s_lock)
+        {
+            if (!s_sessions.TryGetValue(sessionId, out module))
+                return;
+
+            s_sessions.Remove(sessionId);
+        }
+
+        await module.FlushAsync(cancellationToken).ConfigureAwait(false);
+        module.Dispose();
+    }
+
+    internal static bool TryGetSession(string sessionId, out ISessionTelemetryModule module)
+    {
+        module = null;
+        SessionTelemetryModule concreteModule;
+        lock (s_lock)
+        {
+            if (!s_sessions.TryGetValue(sessionId, out concreteModule))
+                return false;
+        }
+
+        module = concreteModule;
+        return true;
+    }
+
+    private static void OnActivityStopped(Activity activity)
+    {
+        if (!s_activitySources.Contains(activity.Source.Name))
+        {
+            s_logger.Debug($"Activity {activity.Source.Name} will not be handled by this component!");
+            return;
+        }
+
+        var sessionId = activity.GetTagItem(TelemetryTags.SessionId) as string;
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            s_logger.Warn($"Activity with no {TelemetryTags.SessionId} recorded!");
+            return;
+        }
+
+        SessionTelemetryModule module;
+        lock (s_lock)
+        {
+            if (!s_sessions.TryGetValue(sessionId, out module))
+            {
+                s_logger.Warn($"Activity with no matching session telemetry module recorded! SessionId: {sessionId}");
+                return;
+            }
+        }
+
+        module.OnActivityStoppedImpl(activity);
+    }
+
+    private static void OnActivityStarted(Activity activity)
+    {
+        var sessionId = activity.GetTagItem(TelemetryTags.SessionId) as string;
+        s_logger.Info($"Activity {activity.DisplayName} for session: {sessionId} started..");
+    }
+
+    private static ActivitySamplingResult Sample(ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+}

--- a/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
+++ b/Snowflake.Data/Telemetry/SnowflakeTelemetryModule.cs
@@ -62,32 +62,19 @@ internal static class SnowflakeTelemetryModule
         }
     }
 
+
     internal static void Unregister(string sessionId)
     {
-        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
-        SessionTelemetryModule module;
-        lock (s_lock)
-        {
-            if (!s_sessions.TryGetValue(sessionId, out module))
-                return;
-
-            s_sessions.Remove(sessionId);
-        }
+        if (!TryRemoveSessionModule(sessionId, out var module))
+            return;
 
         module.Dispose();
     }
 
     internal static async Task UnregisterAsync(string sessionId, CancellationToken cancellationToken)
     {
-        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
-        SessionTelemetryModule module;
-        lock (s_lock)
-        {
-            if (!s_sessions.TryGetValue(sessionId, out module))
-                return;
-
-            s_sessions.Remove(sessionId);
-        }
+        if (!TryRemoveSessionModule(sessionId, out var module))
+            return;
 
         await module.FlushAsync(cancellationToken).ConfigureAwait(false);
         module.Dispose();
@@ -104,6 +91,27 @@ internal static class SnowflakeTelemetryModule
         }
 
         module = concreteModule;
+        return true;
+    }
+
+    private static bool TryRemoveSessionModule(string sessionId, out SessionTelemetryModule module)
+    {
+        module = null;
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            s_logger.Warn("Tried to unregister session without providing any id!");
+            return false;
+        }
+
+        s_logger.Debug($"Unregistering session with id: {sessionId} from client telemetry module.");
+        lock (s_lock)
+        {
+            if (!s_sessions.TryGetValue(sessionId, out module))
+                return false;
+
+            s_sessions.Remove(sessionId);
+        }
+
         return true;
     }
 

--- a/Snowflake.Data/Telemetry/TelemetryConstants.cs
+++ b/Snowflake.Data/Telemetry/TelemetryConstants.cs
@@ -1,0 +1,68 @@
+namespace Snowflake.Data.Telemetry;
+
+/// <summary>
+/// Methods constructing an activity
+/// </summary>
+internal static class TelemetryActivities
+{
+    internal const string ExecuteNonQuery = "ExecuteNonQuery";
+    internal const string ExecuteNonQueryAsync = "ExecuteNonQueryAsync";
+    internal const string ExecuteScalar = "ExecuteScalar";
+    internal const string ExecuteScalarAsync = "ExecuteScalarAsync";
+    internal const string ExecuteDbDataReader = "ExecuteDbDataReader";
+    internal const string ExecuteDbDataReaderAsync = "ExecuteDbDataReaderAsync";
+    internal const string ExecuteInAsyncMode = "ExecuteInAsyncMode";
+    internal const string ExecuteAsyncInAsyncMode = "ExecuteAsyncInAsyncMode";
+    internal const string GetQueryStatus = "GetQueryStatus";
+    internal const string GetQueryStatusAsync = "GetQueryStatusAsync";
+    internal const string GetResultsFromQueryId = "GetResultsFromQueryId";
+    internal const string GetResultsFromQueryIdAsync = "GetResultsFromQueryIdAsync";
+}
+
+/// <summary>
+/// Field keys used in telemetry message payloads.
+/// </summary>
+internal static class TelemetryField
+{
+    internal const string Type = "type";
+    internal const string DriverType = "DriverType";
+    internal const string DriverVersion = "DriverVersion";
+    internal const string Source = "Source";
+    internal const string Duration = "DurationMs";
+
+    // OT
+    internal const string ScopeName = "otel.scope.name";
+    internal const string ScopeVersion = "otel.scope.version";
+    internal const string StatusCode = "otel.status_code";
+    internal const string EventName = "otel.event.name";
+
+    internal const string EventTime = "EventTime";
+}
+
+internal static class TelemetryTags
+{
+    internal const string DbSystem = "db.system";
+    internal const string DbName = "db.namespace";
+    internal const string DbWarehouse = "snowflake.warehouse";
+    internal const string DbRole = "snowflake.role";
+    internal const string SessionId = "snowflake.session.id";
+    internal const string Snowflake = "snowflake";
+    internal const string StatusCode = "status.code";
+    internal const string StatusDescription = "status.description";
+    internal const string Exception = "exception";
+    internal const string ExceptionMessage = "exception.message";
+    internal const string ExceptionErrorCode = "exception.errorcode";
+}
+
+internal static class TelemetryEvents
+{
+    internal const string RowCountOverflow = "RowCountOverflow";
+    internal const string RowCountNegative = "RowCountNegative";
+    internal const string DqlResultSetSkipped = "DqlResultSetSkipped";
+}
+
+internal static class TelemetryTransport
+{
+    internal const int TelemetryFlushSize = 10;
+    internal const int TelemetryFlushIntervalInMs = 1000 * 60;
+}

--- a/Snowflake.Data/Telemetry/TelemetryConstants.cs
+++ b/Snowflake.Data/Telemetry/TelemetryConstants.cs
@@ -58,9 +58,3 @@ internal static class TelemetryEvents
     internal const string RowCountNegative = "RowCountNegative";
     internal const string DqlResultSetSkipped = "DqlResultSetSkipped";
 }
-
-internal static class TelemetryTransport
-{
-    internal const int TelemetryFlushSize = 100;
-    internal const int TelemetryFlushIntervalInMs = 1000 * 60;
-}

--- a/Snowflake.Data/Telemetry/TelemetryConstants.cs
+++ b/Snowflake.Data/Telemetry/TelemetryConstants.cs
@@ -48,9 +48,7 @@ internal static class TelemetryTags
     internal const string SessionId = "snowflake.session.id";
     internal const string Snowflake = "snowflake";
     internal const string StatusCode = "status.code";
-    internal const string StatusDescription = "status.description";
     internal const string Exception = "exception";
-    internal const string ExceptionMessage = "exception.message";
     internal const string ExceptionErrorCode = "exception.errorcode";
 }
 
@@ -63,6 +61,6 @@ internal static class TelemetryEvents
 
 internal static class TelemetryTransport
 {
-    internal const int TelemetryFlushSize = 10;
+    internal const int TelemetryFlushSize = 100;
     internal const int TelemetryFlushIntervalInMs = 1000 * 60;
 }

--- a/Snowflake.Data/Telemetry/TelemetryData.cs
+++ b/Snowflake.Data/Telemetry/TelemetryData.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Snowflake.Data.Telemetry;
+
+/// <summary>
+/// A single telemetry log entry consisting of a message and a timestamp.
+/// Matches the wire format expected by the /telemetry/send endpoint.
+/// </summary>
+internal sealed class TelemetryData
+{
+    [JsonProperty(PropertyName = "message")]
+    internal Dictionary<string, string> Message { get; }
+
+    [JsonProperty(PropertyName = "timestamp")]
+    internal long Timestamp { get; }
+
+    internal TelemetryData(Dictionary<string, string> message, long timestampMs)
+    {
+        Message = message;
+        Timestamp = timestampMs;
+    }
+}
+
+/// <summary>
+/// Wrapper for the telemetry send request body: {"logs": [...]}.
+/// </summary>
+internal sealed class TelemetryRequest
+{
+    [JsonProperty(PropertyName = "logs")]
+    internal List<TelemetryData> Logs { get; }
+
+    internal TelemetryRequest(List<TelemetryData> logs)
+    {
+        Logs = logs;
+    }
+}

--- a/doc/Client/Telemetry.md
+++ b/doc/Client/Telemetry.md
@@ -9,9 +9,20 @@ You can also create your own custom activities to instrument application-level o
 Client telemetry is controlled by the `CLIENT_TELEMETRY_ENABLED` parameter. It can be set in two ways:
 
 1. **Connection string** (client-side default): `client_telemetry_enabled=true` in the connection string. Defaults to `true`.
-2. **Server session parameter**: The server sends `CLIENT_TELEMETRY_ENABLED` in the login response, which overrides the connection string value.
+2. **Server session parameter**: The server sends `CLIENT_TELEMETRY_ENABLED` in the login response, which overrides the connection string value. This parameter can be set at the account, database, or session level:
 
+```sql
+-- Disable at account level
+ALTER ACCOUNT SET CLIENT_TELEMETRY_ENABLED = FALSE;
+
+-- Disable at database level
+ALTER DATABASE my_db SET CLIENT_TELEMETRY_ENABLED = FALSE;
+
+-- Disable for current session
+ALTER SESSION SET CLIENT_TELEMETRY_ENABLED = FALSE;
 ```
+
+```csharp
 // Explicitly enable (this is also the default)
 var connectionString = "account=myaccount;user=myuser;password=mypass;client_telemetry_enabled=true;";
 
@@ -48,11 +59,104 @@ activity?.SetTag("app.batch_size", "500");
 // Add named events within the activity
 activity?.AddTelemetryEvent("ValidationComplete");
 
+// Add events with tags
+activity?.AddTelemetryEvent("BatchProcessed",
+    new KeyValuePair<string, object>("batch.size", 500),
+    new KeyValuePair<string, object>("batch.duration_ms", 1234));
+
 // On success:
 activity?.SetSuccess();
 
 // Or on failure:
 // activity?.SetException(exception);
+```
+
+### Server payload format
+
+When the driver flushes telemetry to Snowflake's `/telemetry/send` endpoint, each activity event is converted to a JSON log entry. Below are examples showing how the C# API calls map to the server-side payload.
+
+**Example 1: Activity with a simple event**
+
+```csharp
+using var activity = command.StartActivity("MyCustomOperation");
+activity?.SetTag("app.module", "billing");
+activity?.AddTelemetryEvent("ValidationComplete");
+activity?.SetSuccess();
+```
+
+Produces two log entries — a synthetic activity event (carrying activity-level tags) and the explicit event:
+```json
+[
+    { "message": { "otel.event.name": "MyCustomOperation", "otel.status_code": "OK", "tag.app.module": "billing", "tag.db.system": "snowflake", "tag.snowflake.session.id": <session_id>, ... } },
+    { "message": { "otel.event.name": "ValidationComplete", "otel.status_code": "OK", ... } }
+]
+```
+
+**Example 2: Activity with multiple events (produces multiple log entries)**
+
+```csharp
+using var activity = command.StartActivity("MultiStepImport");
+activity?.AddTelemetryEvent("StepOneComplete");
+activity?.AddTelemetryEvent("StepTwoComplete");
+activity?.SetSuccess();
+```
+
+Produces **three** log entries — synthetic activity event + one per explicit event:
+```json
+[
+    { "message": { "otel.event.name": "MultiStepImport", "otel.status_code": "OK", "tag.db.system": "snowflake", "tag.snowflake.session.id": <session_id>, ... } },
+    { "message": { "otel.event.name": "StepOneComplete", "otel.status_code": "OK", ... } },
+    { "message": { "otel.event.name": "StepTwoComplete", "otel.status_code": "OK", ... } }
+]
+```
+
+**Example 3: Activity with no explicit events (synthetic event)**
+
+If no events are added, only the synthetic activity event is produced:
+```csharp
+using var activity = command.StartActivity("SimpleQuery");
+activity?.SetSuccess();
+```
+
+```json
+{ "message": { "otel.event.name": "SimpleQuery", "otel.status_code": "OK", "tag.db.system": "snowflake", "tag.snowflake.session.id": <session_id>, ... } }
+```
+
+**Example 4: Failed activity**
+
+```csharp
+using var activity = command.StartActivity("FailedOp");
+activity?.SetException(new InvalidOperationException("something broke"));
+```
+
+Produces two log entries — synthetic activity event + the exception event:
+```json
+[
+    { "message": { "otel.event.name": "FailedOp", "otel.status_code": "ERROR", "tag.status.code": "ERROR", "tag.db.system": "snowflake", ... } },
+    { "message": { "otel.event.name": "exception", "otel.status_code": "ERROR", "tag.exception": "System.InvalidOperationException", ... } }
+]
+```
+
+**Example 5: Activity with detailed events**
+```csharp
+using var activity = command.StartActivity("MyCustomOperationWithEvents");
+activity?.SetTag("app.module", "billing_extra");
+activity?.AddTelemetryEvent("ValidationStarted", new KeyValuePair<string, object>("Mode", "Basic"));
+activity?.AddTelemetryEvent("ValidationConfirmed", new Dictionary<string, object>
+{
+    ["Mode"] = "Advanced",
+    ["ConfirmedBy"] = "John"
+});
+activity?.AddTelemetryEvent("ValidationComplete");
+activity?.SetSuccess();
+```
+
+Produces four log entries — synthetic activity event (with activity tags) + one per explicit event (with event tags):
+```json
+{ "message": { "otel.event.name": "MyCustomOperationWithEvents", "otel.status_code": "OK", "tag.app.module": "billing_extra", "tag.db.system": "snowflake", ... } }
+{ "message": { "otel.event.name": "ValidationStarted", "otel.status_code": "OK", "tag.Mode": "Basic", ... } }
+{ "message": { "otel.event.name": "ValidationConfirmed", "otel.status_code": "OK", "tag.Mode": "Advanced", "tag.ConfirmedBy": "John", ... } }
+{ "message": { "otel.event.name": "ValidationComplete", "otel.status_code": "OK", ... } }
 ```
 
 ### Listening to activities externally

--- a/doc/Client/Telemetry.md
+++ b/doc/Client/Telemetry.md
@@ -1,0 +1,110 @@
+## Telemetry
+
+The Snowflake Connector for .NET supports client-side telemetry based on `System.Diagnostics.Activity` (OpenTelemetry-compatible). When enabled, the driver automatically instruments command executions (queries, non-queries, async operations) and sends telemetry data to Snowflake.
+
+You can also create your own custom activities to instrument application-level operations and have them sent to Snowflake alongside the driver's internal telemetry.
+
+### Enabling telemetry
+
+Client telemetry is controlled by the `CLIENT_TELEMETRY_ENABLED` parameter. It can be set in two ways:
+
+1. **Connection string** (client-side default): `client_telemetry_enabled=true` in the connection string. Defaults to `true`.
+2. **Server session parameter**: The server sends `CLIENT_TELEMETRY_ENABLED` in the login response, which overrides the connection string value.
+
+```
+// Explicitly enable (this is also the default)
+var connectionString = "account=myaccount;user=myuser;password=mypass;client_telemetry_enabled=true;";
+
+// Explicitly disable
+var connectionString = "account=myaccount;user=myuser;password=mypass;client_telemetry_enabled=false;";
+```
+
+The driver automatically:
+- Creates activities for every command execution (`ExecuteNonQuery`, `ExecuteScalar`, `ExecuteReader`, etc.)
+- Enriches activities with session context (warehouse, role, database, session id)
+- Buffers and sends telemetry data to Snowflake's `/telemetry/send` endpoint
+
+### Sending custom telemetry events
+
+You can create your own activities using the public `StartActivity` extension method on `SnowflakeDbCommand`. These activities are emitted on a separate activity source (`Client_custom_activity`) and are **sent to Snowflake** through the same telemetry pipeline as internal driver activities.
+
+```csharp
+using System.Diagnostics;
+using Snowflake.Data.Client;
+using Snowflake.Data.Telemetry;
+
+using var connection = new SnowflakeDbConnection("account=myaccount;user=myuser;password=mypass;");
+connection.Open();
+
+using var command = (SnowflakeDbCommand)connection.CreateCommand();
+
+// Start a custom activity — requires an open connection with telemetry enabled
+using var activity = command.StartActivity("MyCustomOperation");
+
+// Add your own tags
+activity?.SetTag("app.module", "billing");
+activity?.SetTag("app.batch_size", "500");
+
+// Add named events within the activity
+activity?.AddTelemetryEvent("ValidationComplete");
+
+// On success:
+activity?.SetSuccess();
+
+// Or on failure:
+// activity?.SetException(exception);
+```
+
+### Listening to activities externally
+
+In addition to the built-in Snowflake telemetry pipeline, you can subscribe to either activity source with your own `ActivityListener` or OpenTelemetry SDK — for example, to export spans to your own observability backend.
+
+```csharp
+using System.Diagnostics;
+using Snowflake.Data.Telemetry;
+
+var listener = new ActivityListener
+{
+    ShouldListenTo = source => source.Name == ActivityStarter.CustomSourceName,
+    Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+    ActivityStopped = activity =>
+    {
+        Console.WriteLine($"Activity: {activity.OperationName}");
+        Console.WriteLine($"  Duration: {activity.Duration.TotalMilliseconds}ms");
+        Console.WriteLine($"  Session: {activity.GetTagItem(TelemetryTags.SessionId)}");
+        Console.WriteLine($"  Status: {activity.GetTagItem(TelemetryTags.StatusCode)}");
+    }
+};
+ActivitySource.AddActivityListener(listener);
+```
+
+If you use the OpenTelemetry SDK, add the source name to your tracer provider configuration:
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource(ActivityStarter.CustomSourceName)  // "Client_custom_activity"
+    .AddConsoleExporter()
+    .Build();
+```
+
+### Activity sources
+
+| Source name | Description |
+|---|---|
+| `Snowflake_dotnet_activity` | Internal driver telemetry (auto-instrumented commands). Sent to Snowflake. |
+| `Client_custom_activity` | User-created activities via `command.StartActivity()`. Also sent to Snowflake. You can additionally subscribe with your own listener or OTel SDK. |
+
+### Session tags
+
+Every activity (internal and custom) is automatically enriched with:
+
+| Tag | Description |
+|---|---|
+| `db.system` | Always `"snowflake"` |
+| `db.namespace` | Database name |
+| `snowflake.warehouse` | Warehouse name |
+| `snowflake.role` | Role name |
+| `snowflake.session.id` | Session identifier |

--- a/doc/Client/Telemetry.md
+++ b/doc/Client/Telemetry.md
@@ -194,6 +194,27 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
+### Configuring flush behavior
+
+The telemetry module buffers activities in memory and flushes them to Snowflake either when the buffer reaches a size threshold or on a periodic timer interval. Both values can be configured at application level:
+
+```csharp
+using Snowflake.Data.Telemetry;
+
+// Set the number of buffered activities that triggers an automatic flush (default: 100)
+SessionTelemetryModuleFacade.SetFlushSize(50);
+
+// Set the periodic flush interval in milliseconds (default: 60000 ms / 1 minute)
+SessionTelemetryModuleFacade.SetFlushInterval(30_000);
+```
+
+These settings are global and affect all sessions created **after** the call. Sessions that are already open continue using the values that were active when they were created.
+
+| Method | Default | Constraint |
+|---|---|---|
+| `SetFlushSize(int)` | 100 | Must be greater than 0 |
+| `SetFlushInterval(int)` | 60 000 ms | Must be greater than 0 |
+
 ### Activity sources
 
 | Source name | Description |


### PR DESCRIPTION
## Summary
  - Adds client-side telemetry based on `System.Diagnostics.Activity` (OTel-compatible) that instruments all command
  execution methods and sends structured telemetry to Snowflake via `/telemetry/send`
  - Introduces public `SnowflakeDbCommand.StartActivity()` API for custom client-defined activities with session
  context enrichment
  - Telemetry is controlled by `CLIENT_TELEMETRY_ENABLED` connection string property (defaults to `true`)

  ## Architecture
  - **ActivityStarter** — creates `Activity` instances from two sources: `Snowflake_dotnet_activity` (internal) and
  `Client_custom_activity` (public API)
  - **SnowflakeTelemetryModule** — static coordinator that owns a global `ActivityListener` and routes completed
  activities to per-session modules. Both internal and custom client's activities are forwarded to the server.
  - **SessionTelemetryModule** — per-session buffer + flush pipeline that converts activities to telemetry payloads
  and POSTs to `/telemetry/send` on timer tick, buffer threshold, or session close
  - **ActivityExtensions** — `SetSuccess()`, `SetException()`, `AddTelemetryEvent()` with secret masking and
  `SnowflakeDbException` error code extraction (including `AggregateException` unwrapping)

  ## Key design decisions
  - Telemetry is opt-out (enabled by default) via connection string property `CLIENT_TELEMETRY_ENABLED`
  - Custom activities (public API) are sent to Snowflake — they stay client-side on a separate activity source. They might be used by other  OTel subscribers as well.
  - Internal activities are session-scoped and filtered by session ID to prevent cross-session contamination in
  parallel test runs
  - Flush is triggered by buffer size threshold, periodic timer, or session close (dispose)

  ## Test plan
  - [x] Unit tests: `ActivityStarterTest` — activity creation, success/error status, exception unwrapping, secret
  masking, null safety
  - [x] Unit tests: `SessionTelemetryModuleTest` — buffer/flush lifecycle, auto-flush threshold, periodic flush,
  disable on server error, concurrent flush guard
  - [x] Unit tests: `SnowflakeTelemetryModuleTest` — session registration/unregistration, activity routing, token
  refresh
  - [x] Wiremock Integration Tests: `ClientTelemetryWiremockTest` — full pipeline through wiremock verifying sync/async commands,
  session tags, driver metadata, auth token, error status, disabled telemetry, public StartActivity API with nested
  activities
  - [x] Integration tests: `SFDbCommandIT` telemetry test cases — verify against real Snowflake with
  session-ID-scoped activity capture


something is going through
<img width="1112" height="262" alt="image" src="https://github.com/user-attachments/assets/3c180d4f-8bd0-4ee3-92fa-a0d24ad60538" />

