### PR TITLE
SNOW-3422038 Add Retry from transient errors when sf returns invalid, truncated response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.6.0
+    - Bug fix: Fixed handling of transient server issues resulting in sending truncated JSON response.
     - Added .NET 10 support. Changed LangVersion to C#13.
     - Added `DbType.AnsiStringFixedLength` to the set of types mapped to Snowflake `TEXT`, matching existing support for `AnsiString`, `String`, and `StringFixedLength`.
     - Extended login-request telemetry with libc detection (`LIBC_FAMILY`, `LIBC_VERSION`). On Linux, the driver now reports whether the runtime uses glibc and includes the library version.

--- a/Snowflake.Data.Tests/Mock/MockRestRequesterUnauthorizedOnQuery.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestRequesterUnauthorizedOnQuery.cs
@@ -17,10 +17,10 @@ namespace Snowflake.Data.Tests.Mock
 
         public Task<T> PostAsync<T>(IRestRequest postRequest, CancellationToken cancellationToken)
         {
-            SFRestRequest sfRequest = (SFRestRequest)postRequest;
+            var sfRequest = (SFRestRequest)postRequest;
             if (sfRequest.jsonBody is LoginRequest)
             {
-                LoginResponse authnResponse = new LoginResponse
+                var authnResponse = new LoginResponse
                 {
                     data = new LoginResponseData()
                     {
@@ -31,7 +31,7 @@ namespace Snowflake.Data.Tests.Mock
                     },
                     success = true
                 };
-                return Task.FromResult<T>((T)(object)authnResponse);
+                return Task.FromResult((T)(object)authnResponse);
             }
 
             if (sfRequest.jsonBody is QueryRequest)
@@ -43,10 +43,10 @@ namespace Snowflake.Data.Tests.Mock
 
             if (sfRequest.jsonBody == null && typeof(T) == typeof(CloseResponse))
             {
-                return Task.FromResult<T>((T)(object)new CloseResponse { success = true });
+                return Task.FromResult((T)(object)new CloseResponse { success = true });
             }
 
-            return Task.FromResult<T>((T)(object)null);
+            return Task.FromResult((T)(object)null);
         }
 
         public T Get<T>(IRestRequest request)
@@ -56,7 +56,7 @@ namespace Snowflake.Data.Tests.Mock
 
         public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
         {
-            return Task.FromResult<T>((T)(object)null);
+            return Task.FromResult((T)(object)null);
         }
 
         public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)

--- a/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
+++ b/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Data.Tests.Mock
 
         public void setHttpClient(HttpClient httpClient)
         {
-            base._HttpClient = httpClient;
+            HttpClient = httpClient;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message,

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterTest.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using Snowflake.Data.Core;
 
@@ -112,16 +113,122 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.IsFalse(RestRequester.HasUnauthorizedStatusCode(new Exception("no http info")));
         }
 
-        private static IRestRequest CreateMockRestRequest()
+        [Test]
+        public async Task TestPostAsyncDeserializesValidJsonWithoutRetry()
         {
-            var message = new HttpRequestMessage(HttpMethod.Get, "https://test.snowflakecomputing.com/session");
-#pragma warning disable CS0618
-            message.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY] = TimeSpan.FromSeconds(16);
-            message.Properties[BaseRestRequest.REST_REQUEST_TIMEOUT_KEY] = TimeSpan.FromSeconds(120);
-#pragma warning restore CS0618
+            // arrange
+            var validJson = "{\"message\":\"Some message!\",\"code\":0,\"success\":true}";
+            var httpClient = CreateHttpClientWithSequentialResponses(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(validJson) });
+            var restRequester = new RestRequester(httpClient);
+            var request = CreateMockRestRequest(HttpMethod.Post);
 
+            // act
+            var result = await restRequester.PostAsync<NullDataResponse>(request, CancellationToken.None);
+
+            // assert
+            Assert.IsTrue(result.success);
+            Assert.AreEqual("Some message!", result.message);
+        }
+
+        [Test]
+        public async Task TestPostAsyncRetriesOnTruncatedJson()
+        {
+            // arrange
+            var truncatedJson = "{\"success\":tr";
+            var validJson = "{\"message\":\"Some message!\",\"code\":0,\"success\":true}";
+            var httpClient = CreateHttpClientWithSequentialResponses(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(validJson) });
+            var restRequester = new RestRequester(httpClient);
+            var request = CreateMockRestRequest(HttpMethod.Post);
+
+            // act
+            var result = await restRequester.PostAsync<NullDataResponse>(request, CancellationToken.None);
+
+            // assert
+            Assert.IsTrue(result.success);
+            Assert.AreEqual("Some message!", result.message);
+        }
+
+        [Test]
+        public void TestPostAsyncThrowsWhenBothAttemptsReturnTruncatedJson()
+        {
+            // arrange
+            var truncatedJson = "{\"success\":tr";
+            var httpClient = CreateHttpClientWithSequentialResponses(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) });
+            var restRequester = new RestRequester(httpClient);
+            var request = CreateMockRestRequest(HttpMethod.Post);
+
+            // act & assert
+            Assert.ThrowsAsync<JsonReaderException>(
+                () => restRequester.PostAsync<NullDataResponse>(request, CancellationToken.None));
+        }
+
+        [Test]
+        public async Task TestGetAsyncRetriesOnTruncatedJson()
+        {
+            // arrange
+            var truncatedJson = "{\"success\":tr";
+            var validJson = "{\"message\":\"Some message!\",\"code\":0,\"success\":true}";
+            var httpClient = CreateHttpClientWithSequentialResponses(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(validJson) });
+            var restRequester = new RestRequester(httpClient);
+            var request = CreateMockRestRequest(HttpMethod.Get);
+
+            // act
+            var result = await restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None);
+
+            // assert
+            Assert.IsTrue(result.success);
+            Assert.AreEqual("Some message!", result.message);
+        }
+
+        [Test]
+        public void TestGetAsyncThrowsWhenBothAttemptsReturnTruncatedJson()
+        {
+            // arrange
+            var truncatedJson = "{\"success\":tr";
+            var httpClient = CreateHttpClientWithSequentialResponses(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) },
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(truncatedJson) });
+            var restRequester = new RestRequester(httpClient);
+            var request = CreateMockRestRequest(HttpMethod.Get);
+
+            // act & assert
+            Assert.ThrowsAsync<JsonReaderException>(
+                () => restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None));
+        }
+
+        private static HttpClient CreateHttpClientWithSequentialResponses(params HttpResponseMessage[] responses)
+        {
+            var callCount = 0;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync( () => responses[callCount++]);
+            return new HttpClient(mockHandler.Object);
+        }
+
+        private static IRestRequest CreateMockRestRequest(HttpMethod method = null)
+        {
+            method ??= HttpMethod.Get;
             var mock = new Mock<IRestRequest>();
-            mock.Setup(r => r.ToRequestMessage(It.IsAny<HttpMethod>())).Returns(message);
+            mock.Setup(r => r.ToRequestMessage(It.IsAny<HttpMethod>())).Returns(() =>
+            {
+                var message = new HttpRequestMessage(method, "https://test.snowflakecomputing.com/session");
+#pragma warning disable CS0618
+                message.Properties[BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY] = TimeSpan.FromSeconds(16);
+                message.Properties[BaseRestRequest.REST_REQUEST_TIMEOUT_KEY] = TimeSpan.FromSeconds(120);
+#pragma warning restore CS0618
+                return message;
+            });
             mock.Setup(r => r.GetRestTimeout()).Returns(TimeSpan.FromSeconds(120));
             mock.Setup(r => r.getSid()).Returns("test-sid");
             return mock.Object;

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
@@ -81,7 +81,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
         private string BuildConnectionString()
         {
-            var uri = new Uri(_runner.Url);
+            var uri = new Uri(_runner.WiremockBaseHttpsUrl);
             return new StringBuilder()
                 .Append("account=")
                 .Append("testaccount")

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
@@ -81,7 +81,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
         private string BuildConnectionString()
         {
-            var uri = new Uri(_runner.WiremockBaseHttpsUrl);
+            var uri = new Uri(_runner.WiremockBaseHttpUrl);
             return new StringBuilder()
                 .Append("account=")
                 .Append("testaccount")

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Snowflake.Data.Client;
+using Snowflake.Data.Tests.Util;
+
+namespace Snowflake.Data.Tests.UnitTests
+{
+    [TestFixture, NonParallelizable]
+    public sealed class RestRequesterWiremockTest
+    {
+        private static readonly string s_mappingPath = Path.Combine("wiremock", "RestRequester");
+        private static readonly string s_loginMapping = Path.Combine(s_mappingPath, "login_success.json");
+        private static readonly string s_queryTruncatedThenValid = Path.Combine(s_mappingPath, "query_truncated_then_valid.json");
+        private static readonly string s_queryTruncatedAlways = Path.Combine(s_mappingPath, "query_truncated_always.json");
+
+        private WiremockRunner _runner;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            _runner = WiremockRunner.NewWiremock();
+        }
+
+        [SetUp]
+        public void BeforeEach()
+        {
+            _runner.ResetMapping();
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            _runner.Stop();
+        }
+
+        [Test]
+        public async Task TestExecuteReaderAsyncRetriesOnTruncatedJson()
+        {
+            // arrange
+            _runner.AddMappings(s_loginMapping);
+            _runner.AddMappings(s_queryTruncatedThenValid);
+
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = BuildConnectionString();
+            await conn.OpenAsync(CancellationToken.None);
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            // act
+            using var reader = await cmd.ExecuteReaderAsync(CancellationToken.None);
+
+            // assert
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("1", reader.GetString(0));
+        }
+
+        [Test]
+        public void TestExecuteReaderAsyncThrowsWhenAllRetriesFail()
+        {
+            // arrange
+            _runner.AddMappings(s_loginMapping);
+            _runner.AddMappings(s_queryTruncatedAlways);
+
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = BuildConnectionString();
+            conn.Open();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+
+            // act & assert
+            Assert.ThrowsAsync<JsonReaderException>(
+                () => cmd.ExecuteReaderAsync(CancellationToken.None));
+        }
+
+        private string BuildConnectionString()
+        {
+            var uri = new Uri(_runner.Url);
+            return new StringBuilder()
+                .Append("account=")
+                .Append("testaccount")
+                .Append(";user=")
+                .Append("test")
+                .Append(";password=")
+                .Append("test")
+                .Append(";host=")
+                .Append(uri.Host)
+                .Append(";port=")
+                .Append(uri.Port)
+                .Append(";scheme=")
+                .Append(uri.Scheme)
+                .Append(";")
+                .ToString();
+        }
+    }
+}

--- a/Snowflake.Data.Tests/wiremock/RestRequester/login_success.json
+++ b/Snowflake.Data.Tests/wiremock/RestRequester/login_success.json
@@ -1,0 +1,57 @@
+{
+    "mappings": [
+        {
+            "scenarioName": "Successful Snowflake login",
+            "request": {
+                "urlPathPattern": "/session/v1/login-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "masterToken": "masterToken123",
+                        "token": "sessionToken123",
+                        "sessionId": 1234567890,
+                        "parameters": [
+                            { "name": "CLIENT_PREFETCH_THREADS", "value": 4 },
+                            { "name": "CLIENT_RESULT_CHUNK_SIZE", "value": 16 },
+                            { "name": "CLIENT_SESSION_KEEP_ALIVE", "value": false },
+                            { "name": "CLIENT_OUT_OF_BAND_TELEMETRY_ENABLED", "value": false },
+                            { "name": "CLIENT_TELEMETRY_ENABLED", "value": false },
+                            { "name": "AUTOCOMMIT", "value": true },
+                            { "name": "CLIENT_DISABLE_INCIDENTS", "value": true },
+                            { "name": "CLIENT_RESULT_COLUMN_CASE_INSENSITIVE", "value": false },
+                            { "name": "CLIENT_METADATA_USE_SESSION_DATABASE", "value": false },
+                            { "name": "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "value": false },
+                            { "name": "CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ", "value": true },
+                            { "name": "CLIENT_USE_V1_QUERY_API", "value": true },
+                            { "name": "QUERY_CONTEXT_CACHE_SIZE", "value": 5 },
+                            { "name": "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1", "value": true },
+                            { "name": "CLIENT_TELEMETRY_SESSIONLESS_ENABLED", "value": false },
+                            { "name": "CLIENT_ENABLE_LOG_INFO_STATEMENT_PARAMETERS", "value": false },
+                            { "name": "CLIENT_SESSION_CLONE", "value": false }
+                        ],
+                        "sessionInfo": {
+                            "databaseName": null,
+                            "schemaName": null,
+                            "warehouseName": null,
+                            "roleName": null
+                        },
+                        "idToken": null,
+                        "idTokenValidityInSeconds": 0,
+                        "responseData": null,
+                        "mfaToken": null,
+                        "mfaTokenValidityInSeconds": 0
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_always.json
+++ b/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_always.json
@@ -1,13 +1,17 @@
 {
-    "request": {
-        "urlPathPattern": "/queries/v1/query-request",
-        "method": "POST"
-    },
-    "response": {
-        "status": 200,
-        "headers": {
-            "Content-Type": "application/json"
-        },
-        "body": "{\"data\":{\"queryId\":\"fail-q"
-    }
+    "mappings": [
+        {
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "body": "{\"data\":{\"queryId\":\"fail-q"
+            }
+        }
+    ]
 }

--- a/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_always.json
+++ b/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_always.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "urlPathPattern": "/queries/v1/query-request",
+        "method": "POST"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": "{\"data\":{\"queryId\":\"fail-q"
+    }
+}

--- a/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_then_valid.json
+++ b/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_then_valid.json
@@ -2,6 +2,7 @@
     "mappings": [
         {
             "scenarioName": "truncated-json-retry",
+            "requiredScenarioState": "Started",
             "newScenarioState": "first-attempt-failed",
             "request": {
                 "urlPathPattern": "/queries/v1/query-request",

--- a/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_then_valid.json
+++ b/Snowflake.Data.Tests/wiremock/RestRequester/query_truncated_then_valid.json
@@ -1,0 +1,46 @@
+{
+    "mappings": [
+        {
+            "scenarioName": "truncated-json-retry",
+            "newScenarioState": "first-attempt-failed",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "body": "{\"data\":{\"queryId\":\"retry-q"
+            }
+        },
+        {
+            "scenarioName": "truncated-json-retry",
+            "requiredScenarioState": "first-attempt-failed",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "queryId": "retry-query-id",
+                        "rowtype": [{ "name": "1", "type": "FIXED", "nullable": false }],
+                        "rowset": [["1"]],
+                        "total": 1,
+                        "returned": 1,
+                        "parameters": []
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data/Core/JsonUtils.cs
+++ b/Snowflake.Data/Core/JsonUtils.cs
@@ -3,20 +3,22 @@ using Newtonsoft.Json.Serialization;
 
 namespace Snowflake.Data.Core
 {
-    class JsonUtils
+    internal static class JsonUtils
     {
         /// <summary>
         /// Default serialization settings for JSON serialization and deserialization.
         /// This is to avoid issues when changes are made system wide to the default and keep
         /// our settings locals.
         /// </summary>
-        public static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
+        public static readonly JsonSerializerSettings JsonSettings = new()
         {
-            ContractResolver = new DefaultContractResolver()
+            ContractResolver = new DefaultContractResolver
             {
                 NamingStrategy = new DefaultNamingStrategy()
             },
             TypeNameHandling = TypeNameHandling.None
         };
+
+        public static readonly JsonSerializer Serializer = JsonSerializer.Create(JsonSettings);
     }
 }

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net;
 using Newtonsoft.Json;
 using System.Net.Http;
@@ -11,8 +12,9 @@ using Snowflake.Data.Log;
 namespace Snowflake.Data.Core
 {
     /// <summary>
-    /// The RestRequester is responsible to send out a rest request and receive response
-    /// No retry needed here since retry is made in HttpClient.RetryHandler (HttpUtil.cs)
+    /// The RestRequester is responsible to send out a rest request and receive response.
+    /// HTTP-level retry is handled by HttpClient.RetryHandler (HttpUtil.cs).
+    /// JSON deserialization retry (1 attempt) is handled here for transient responses.
     /// </summary>
     internal interface IRestRequester
     {
@@ -37,15 +39,15 @@ namespace Snowflake.Data.Core
 
     internal class RestRequester : IRestRequester
     {
-        private static SFLogger logger = SFLoggerFactory.GetLogger<RestRequester>();
+        private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<RestRequester>();
 
         internal const string HttpStatusCodeDataKey = "HttpStatusCode";
 
-        protected HttpClient _HttpClient;
+        protected HttpClient HttpClient;
 
         public RestRequester(HttpClient httpClient)
         {
-            _HttpClient = httpClient;
+            HttpClient = httpClient;
         }
 
         public T Post<T>(IRestRequest request)
@@ -54,14 +56,8 @@ namespace Snowflake.Data.Core
             return Task.Run(async () => await (PostAsync<T>(request, CancellationToken.None)).ConfigureAwait(false)).Result;
         }
 
-        public async Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken)
-        {
-            using (var response = await SendAsync(HttpMethod.Post, request, cancellationToken).ConfigureAwait(false))
-            {
-                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
-            }
-        }
+        public Task<T> PostAsync<T>(IRestRequest request, CancellationToken cancellationToken) =>
+            SendAsync<T>(HttpMethod.Post, request, cancellationToken);
 
         public T Get<T>(IRestRequest request)
         {
@@ -69,19 +65,11 @@ namespace Snowflake.Data.Core
             return Task.Run(async () => await (GetAsync<T>(request, CancellationToken.None)).ConfigureAwait(false)).Result;
         }
 
-        public async Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await GetAsync(request, cancellationToken).ConfigureAwait(false))
-            {
-                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return JsonConvert.DeserializeObject<T>(json, JsonUtils.JsonSettings);
-            }
-        }
+        public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken) =>
+            SendAsync<T>(HttpMethod.Get, request, cancellationToken);
 
-        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken)
-        {
-            return SendAsync(HttpMethod.Get, request, cancellationToken);
-        }
+        public Task<HttpResponseMessage> GetAsync(IRestRequest request, CancellationToken cancellationToken) =>
+            SendAsync(HttpMethod.Get, request, cancellationToken);
 
         public HttpResponseMessage Get(IRestRequest request)
         {
@@ -89,14 +77,29 @@ namespace Snowflake.Data.Core
             return Task.Run(async () => await (GetAsync(request, CancellationToken.None)).ConfigureAwait(false)).Result;
         }
 
-        private async Task<HttpResponseMessage> SendAsync(HttpMethod method,
+        private async Task<T> SendAsync<T>(HttpMethod method, IRestRequest request, CancellationToken cancellationToken)
+        {
+            using var response = await SendAsync(method, request, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await DeserializeResponseAsync<T>(response, cancellationToken).ConfigureAwait(false);
+            }
+            catch (JsonReaderException ex)
+            {
+                s_logger.Warn($"JSON deserialization failed for {method}, retrying request. Error: {ex.Message}.", ex);
+            }
+
+            // in rare instances server may return invalid response body (e.g. truncated one), whilst returning 2XX response. Those are mostly transient.
+            using var retryResponse = await SendAsync(method, request, cancellationToken).ConfigureAwait(false);
+            return await DeserializeResponseAsync<T>(retryResponse, cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task<HttpResponseMessage> SendAsync(HttpMethod method,
                                                           IRestRequest request,
                                                           CancellationToken externalCancellationToken)
         {
-            using (HttpRequestMessage message = request.ToRequestMessage(method))
-            {
-                return await SendAsync(message, request.GetRestTimeout(), externalCancellationToken, request.getSid()).ConfigureAwait(false);
-            }
+            var message = request.ToRequestMessage(method);
+            return SendAsync(message, request.GetRestTimeout(), externalCancellationToken, request.getSid());
         }
 
         protected virtual async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message,
@@ -105,71 +108,52 @@ namespace Snowflake.Data.Core
                                                               string sid = "")
         {
             // merge multiple cancellation token
-            using (CancellationTokenSource restRequestTimeout = new CancellationTokenSource(restTimeout))
+            using var restRequestTimeout = new CancellationTokenSource(restTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellationToken,
+                restRequestTimeout.Token);
+            HttpResponseMessage response = null;
+            s_logger.Debug($"Executing: {sid} {message.Method} {FormatUri(message.RequestUri)} HTTP/{message.Version}");
+            var watch = new Stopwatch();
+            int? failedHttpStatusCode = null;
+            try
             {
-                using (CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellationToken,
-                restRequestTimeout.Token))
+                watch.Start();
+                response = await HttpClient
+                    .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token)
+                    .ConfigureAwait(false);
+                watch.Stop();
+                if (!response.IsSuccessStatusCode)
                 {
-                    HttpResponseMessage response = null;
-#if SF_PUBLIC_ENVIRONMENT
-                    logger.Debug($"Executing: {sid} {message.Method} {message.RequestUri.AbsolutePath} HTTP/{message.Version}");
-#else
-                    logger.Debug($"Executing: {sid} {message.Method} {message.RequestUri} HTTP/{message.Version}");
-#endif
-                    var watch = new Stopwatch();
-                    int? failedHttpStatusCode = null;
-                    try
-                    {
-                        watch.Start();
-                        response = await _HttpClient
-                            .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token)
-                            .ConfigureAwait(false);
-                        watch.Stop();
-                        if (!response.IsSuccessStatusCode)
-                        {
-                            failedHttpStatusCode = (int)response.StatusCode;
-#if SF_PUBLIC_ENVIRONMENT
-                            logger.Error($"Failed response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {message.RequestUri.AbsolutePath} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
-#else
-                            logger.Error($"Failed response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {message.RequestUri} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
-#endif
-                        }
-                        else
-                        {
-#if SF_PUBLIC_ENVIRONMENT
-                            logger.Debug($"Succeeded response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {message.RequestUri.AbsolutePath}");
-#else
-                            logger.Debug($"Succeeded response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {message.RequestUri}");
-#endif
-                        }
-                        response.EnsureSuccessStatusCode();
-
-                        return response;
-                    }
-                    catch (Exception e)
-                    {
-                        if (watch.IsRunning)
-                        {
-                            watch.Stop();
-#if SF_PUBLIC_ENVIRONMENT
-                            logger.Error($"Response receiving interrupted by exception after {watch.ElapsedMilliseconds} ms. {sid} {message.Method} {message.RequestUri.AbsolutePath}");
-#else
-                            logger.Error($"Response receiving interrupted by exception after {watch.ElapsedMilliseconds} ms. {sid} {message.Method} {message.RequestUri}");
-#endif
-                        }
-                        if (failedHttpStatusCode.HasValue)
-                        {
-                            e.Data[HttpStatusCodeDataKey] = failedHttpStatusCode.Value;
-                        }
-                        // Disposing of the response if not null now that we don't need it anymore
-                        response?.Dispose();
-                        if (restRequestTimeout.IsCancellationRequested)
-                        {
-                            throw new SnowflakeDbException(e, SFError.REQUEST_TIMEOUT);
-                        }
-                        throw;
-                    }
+                    failedHttpStatusCode = (int)response.StatusCode;
+                    s_logger.Error($"Failed response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {FormatUri(message.RequestUri)} StatusCode: {(int)response.StatusCode}, ReasonPhrase: '{response.ReasonPhrase}'");
                 }
+                else
+                {
+                    s_logger.Debug($"Succeeded response after {watch.ElapsedMilliseconds} ms: {sid} {message.Method} {FormatUri(message.RequestUri)}");
+                }
+                response.EnsureSuccessStatusCode();
+
+                message?.Dispose();
+                return response;
+            }
+            catch (Exception e)
+            {
+                if (watch.IsRunning)
+                {
+                    watch.Stop();
+                    s_logger.Error($"Response receiving interrupted by exception after {watch.ElapsedMilliseconds} ms. {sid} {message.Method} {FormatUri(message.RequestUri)}");
+                }
+                if (failedHttpStatusCode.HasValue)
+                {
+                    e.Data[HttpStatusCodeDataKey] = failedHttpStatusCode.Value;
+                }
+                // Disposing of the response if not null now that we don't need it anymore
+                response?.Dispose();
+                if (restRequestTimeout.IsCancellationRequested)
+                {
+                    throw new SnowflakeDbException(e, SFError.REQUEST_TIMEOUT);
+                }
+                throw;
             }
         }
 
@@ -177,6 +161,29 @@ namespace Snowflake.Data.Core
         {
             var code = FindHttpStatusCode(ex);
             return code == (int)HttpStatusCode.Unauthorized;
+        }
+
+        private static string FormatUri(Uri uri)
+        {
+#if SF_PUBLIC_ENVIRONMENT
+            return uri.AbsolutePath;
+#else
+            return uri.ToString();
+#endif
+        }
+
+        private static async Task<T> DeserializeResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            #if NET5_0_OR_GREATER
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var streamReader = new StreamReader(stream);
+            await using var jsonReader = new JsonTextReader(streamReader);
+            #else
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var streamReader = new StreamReader(stream);
+            using var jsonReader = new JsonTextReader(streamReader);
+            #endif
+            return JsonUtils.Serializer.Deserialize<T>(jsonReader);
         }
 
         private static int? FindHttpStatusCode(Exception ex)

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -84,7 +84,7 @@ namespace Snowflake.Data.Core
             {
                 return await DeserializeResponseAsync<T>(response, cancellationToken).ConfigureAwait(false);
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
                 s_logger.Warn($"JSON deserialization failed for {method}, retrying request. Error: {ex.Message}.", ex);
             }

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Core
                 s_logger.Warn($"JSON deserialization failed for {method}, retrying request. Error: {ex.Message}.", ex);
             }
 
-            // in rare instances server may return invalid response body (e.g. truncated one), whilst returning 2XX response. Those are mostly transient.
+            // in rare instances server may return invalid response body (e.g. truncated one), whilst returning 2XX response. Those are mostly transient. See SNOW-3422038 for further details.
             using var retryResponse = await SendAsync(method, request, cancellationToken).ConfigureAwait(false);
             return await DeserializeResponseAsync<T>(retryResponse, cancellationToken).ConfigureAwait(false);
         }
@@ -174,7 +174,7 @@ namespace Snowflake.Data.Core
 
         private static async Task<T> DeserializeResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
         {
-            #if NET5_0_OR_GREATER
+            #if NET6_0_OR_GREATER
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var streamReader = new StreamReader(stream);
             await using var jsonReader = new JsonTextReader(streamReader);


### PR DESCRIPTION
Summary

  - Add a single retry when Snowflake returns HTTP 200 with a truncated/invalid JSON body (transient server-side
  issue observed in production)
  - Extract DeserializeResponseAsync<T> helper and centralize JsonSerializer instance in JsonUtils
  - Fix Wiremock test mapping files (missing scenario state, missing mappings wrapper)

  Changes

  - RestRequester.SendAsync<T> catches JsonReaderException on first deserialization attempt and re-sends the request
  once before propagating
  - JsonUtils.Serializer — shared JsonSerializer static field (thread-safe for reads) replaces per-call construction
  - New unit tests (Moq-based) covering: valid JSON without retry, retry-then-succeed, both-fail-throws for both GET
  and POST
  - New Wiremock integration tests covering full end-to-end retry through SnowflakeDbConnection
  - Minor cleanup: var usage in mocks, field rename _HttpClient → HttpClient

  Test plan

  - RestRequesterTest — 10 unit tests pass (net6.0, net10.0)
  - RestRequesterWiremockTest — 2 integration tests pass (net6.0, net10.0)
  - Verify no regression in existing integration test suite
  - Confirm retry behavior under real transient conditions (manual/staging)

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
