### PR TITLE
NO-SNOW Foundation for Xunit shift

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/ConnectionCacheManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionCacheManagerTest.cs
@@ -17,14 +17,14 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             s_poolConfig = new PoolConfig();
             SnowflakeDbConnectionPool.ForceConnectionPoolVersion(ConnectionPoolType.SingleConnectionCache);
-            SessionPool.SessionFactory = new MockSessionFactory();
+            SessionPool.s_sessionFactorySingleton = new MockSessionFactory();
         }
 
         [OneTimeTearDown]
         public static void AfterAllTests()
         {
             s_poolConfig.Reset();
-            SessionPool.SessionFactory = new SessionFactory();
+            SessionPool.s_sessionFactorySingleton = new SessionFactory();
         }
 
         [SetUp]

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
@@ -23,14 +23,14 @@ namespace Snowflake.Data.Tests.UnitTests
             s_poolConfig = new PoolConfig();
             s_restRequester = new MockLoginMFATokenCacheRestRequester();
             SnowflakeDbConnectionPool.ForceConnectionPoolVersion(ConnectionPoolType.MultipleConnectionPool);
-            SessionPool.SessionFactory = new MockSessionFactoryMFA(s_restRequester);
+            SessionPool.s_sessionFactorySingleton = new MockSessionFactoryMFA(s_restRequester);
         }
 
         [OneTimeTearDown]
         public static void AfterAllTests()
         {
             s_poolConfig.Reset();
-            SessionPool.SessionFactory = new SessionFactory();
+            SessionPool.s_sessionFactorySingleton = new SessionFactory();
         }
 
         [SetUp]

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -27,14 +27,14 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             s_poolConfig = new PoolConfig();
             SnowflakeDbConnectionPool.ForceConnectionPoolVersion(ConnectionPoolType.MultipleConnectionPool);
-            SessionPool.SessionFactory = new MockSessionFactory();
+            SessionPool.s_sessionFactorySingleton = new MockSessionFactory();
         }
 
         [OneTimeTearDown]
         public static void AfterAllTests()
         {
             s_poolConfig.Reset();
-            SessionPool.SessionFactory = new SessionFactory();
+            SessionPool.s_sessionFactorySingleton = new SessionFactory();
         }
 
         [SetUp]

--- a/Snowflake.Data/Client/ConnectionManagerFactory.cs
+++ b/Snowflake.Data/Client/ConnectionManagerFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using Snowflake.Data.Core.Session;
+using Snowflake.Data.Log;
+
+namespace Snowflake.Data.Client;
+
+internal interface IConnectionManagerFactory
+{
+    IConnectionManager CreateConnectionManager(ConnectionPoolType requestedPoolType);
+}
+
+internal class ConnectionManagerFactory : IConnectionManagerFactory
+{
+    public static ConnectionManagerFactory Singleton { get; } = new();
+
+    private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<ConnectionManagerFactory>();
+
+    public IConnectionManager CreateConnectionManager(ConnectionPoolType requestedPoolType)
+    {
+        IConnectionManager result;
+        switch (requestedPoolType)
+        {
+            case ConnectionPoolType.MultipleConnectionPool:
+                result = new ConnectionPoolManager();
+                s_logger.Info("SnowflakeDbConnectionPool - multiple connection pools enabled");
+                break;
+            case ConnectionPoolType.SingleConnectionCache:
+                result = new ConnectionCacheManager();
+                s_logger.Warn("SnowflakeDbConnectionPool - connection cache enabled");
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(requestedPoolType), requestedPoolType, null);
+        }
+
+        return result;
+    }
+}

--- a/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnectionPool.cs
@@ -135,17 +135,7 @@ namespace Snowflake.Data.Client
                 if (s_connectionManager != null && !force)
                     return;
                 Diagnostics.LogDiagnostics();
-                s_connectionManager?.ClearAllPools();
-                if (requestedPoolType == ConnectionPoolType.MultipleConnectionPool)
-                {
-                    s_connectionManager = new ConnectionPoolManager();
-                    s_logger.Info("SnowflakeDbConnectionPool - multiple connection pools enabled");
-                }
-                if (requestedPoolType == ConnectionPoolType.SingleConnectionCache)
-                {
-                    s_connectionManager = new ConnectionCacheManager();
-                    s_logger.Warn("SnowflakeDbConnectionPool - connection cache enabled");
-                }
+                s_connectionManager = s_connectionManager?.Recycle(requestedPoolType) ?? ConnectionManagerFactory.Singleton.CreateConnectionManager(requestedPoolType);
             }
         }
 
@@ -154,18 +144,7 @@ namespace Snowflake.Data.Client
             SetConnectionPoolVersion(requestedPoolType, true);
         }
 
-        internal static ConnectionPoolType GetConnectionPoolVersion()
-        {
-            if (ConnectionManager != null)
-            {
-                switch (ConnectionManager)
-                {
-                    case ConnectionCacheManager _: return ConnectionPoolType.SingleConnectionCache;
-                    case ConnectionPoolManager _: return ConnectionPoolType.MultipleConnectionPool;
-                }
-            }
-            return DefaultConnectionPoolType;
-        }
+        internal static ConnectionPoolType GetConnectionPoolVersion() => ConnectionManager?.Type ?? DefaultConnectionPoolType;
 
         internal static IConnectionManager ReplaceConnectionManager(IConnectionManager connectionManager)
         {

--- a/Snowflake.Data/Core/ChunkParserFactory.cs
+++ b/Snowflake.Data/Core/ChunkParserFactory.cs
@@ -5,7 +5,7 @@ using Snowflake.Data.Log;
 
 namespace Snowflake.Data.Core
 {
-    class ChunkParserFactory : IChunkParserFactory
+    internal class ChunkParserFactory : IChunkParserFactory
     {
         private static SFLogger s_logger = SFLoggerFactory.GetLogger<ChunkParserFactory>();
         public static IChunkParserFactory Instance = new ChunkParserFactory();

--- a/Snowflake.Data/Core/RestRequester.cs
+++ b/Snowflake.Data/Core/RestRequester.cs
@@ -174,15 +174,15 @@ namespace Snowflake.Data.Core
 
         private static async Task<T> DeserializeResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
         {
-            #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var streamReader = new StreamReader(stream);
             await using var jsonReader = new JsonTextReader(streamReader);
-            #else
+#else
             using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             using var streamReader = new StreamReader(stream);
             using var jsonReader = new JsonTextReader(streamReader);
-            #endif
+#endif
             return JsonUtils.Serializer.Deserialize<T>(jsonReader);
         }
 

--- a/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionCacheManager.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Snowflake.Data.Client;
 
 namespace Snowflake.Data.Core.Session
 {
@@ -21,5 +22,13 @@ namespace Snowflake.Data.Core.Session
         public bool GetPooling() => _sessionPool.GetPooling();
         public SessionPool GetPool(string connectionString) => _sessionPool;
         public SessionPool GetPool(string connectionString, SessionPropertiesContext sessionContext) => _sessionPool;
+
+        public IConnectionManager Recycle(ConnectionPoolType requestedPoolType)
+        {
+            ClearAllPools();
+            return ConnectionManagerFactory.Singleton.CreateConnectionManager(requestedPoolType);
+        }
+
+        public ConnectionPoolType Type => ConnectionPoolType.SingleConnectionCache;
     }
 }

--- a/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
+++ b/Snowflake.Data/Core/Session/ConnectionPoolManager.cs
@@ -14,11 +14,19 @@ namespace Snowflake.Data.Core.Session
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<ConnectionPoolManager>();
         private static readonly Object s_poolsLock = new Object();
-        private static readonly Exception s_operationNotAvailable = new Exception("You cannot change connection pool parameters for all the pools. Instead you can change it on a particular pool");
+        private static readonly Exception s_operationNotAvailable = new("You cannot change connection pool parameters for all the pools. Instead you can change it on a particular pool");
         private readonly Dictionary<string, SessionPool> _pools;
+        private readonly SessionPoolFactory _sessionPoolFactory;
+        private readonly IConnectionManagerFactory _connectionManagerFactory;
 
-        internal ConnectionPoolManager()
+        internal ConnectionPoolManager() : this(DefaultSessionPoolFactory, ConnectionManagerFactory.Singleton)
         {
+        }
+
+        internal ConnectionPoolManager(SessionPoolFactory sessionPoolFactory, IConnectionManagerFactory connectionManagerFactory)
+        {
+            _sessionPoolFactory = sessionPoolFactory;
+            _connectionManagerFactory = connectionManagerFactory;
             lock (s_poolsLock)
             {
                 _pools = new Dictionary<string, SessionPool>();
@@ -52,11 +60,18 @@ namespace Snowflake.Data.Core.Session
         public void ClearAllPools()
         {
             s_logger.Debug("ConnectionPoolManager::ClearAllPools");
-            foreach (var sessionPool in _pools.Values)
+
+            SessionPool[] poolsToDestroy;
+            lock (s_poolsLock)
+            {
+                poolsToDestroy = _pools.Values.ToArray();
+                _pools.Clear();
+            }
+
+            foreach (var sessionPool in poolsToDestroy)
             {
                 sessionPool.DestroyPool();
             }
-            _pools.Clear();
         }
 
         public void SetMaxPoolSize(int maxPoolSize)
@@ -142,16 +157,27 @@ namespace Snowflake.Data.Core.Session
                     return poolCreatedWhileWaitingOnLock;
                 }
                 s_logger.Info($"Creating new pool");
-                var pool = SessionPool.CreateSessionPool(connectionString, password, oauthClientSecret, token);
+                var pool = _sessionPoolFactory(connectionString, password, oauthClientSecret, token);
                 _pools.Add(poolKey, pool);
                 return pool;
             }
         }
 
+        private static SessionPool DefaultSessionPoolFactory(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token) =>
+            SessionPool.CreateSessionPool(connectionString, password, oauthClientSecret, token);
+
+        internal delegate SessionPool SessionPoolFactory(string connectionString, SecureString password, SecureString clientSecret, SecureString token);
+
         public SessionPool GetPool(string connectionString)
         {
             s_logger.Debug("ConnectionPoolManager::GetPool with connection string");
             return GetPool(connectionString, new SessionPropertiesContext());
+        }
+
+        public IConnectionManager Recycle(ConnectionPoolType requestedPoolType)
+        {
+            ClearAllPools();
+            return _connectionManagerFactory.CreateConnectionManager(requestedPoolType);
         }
 
         private string GetPoolKey(string connectionString, SecureString password, SecureString clientSecret, SecureString token)
@@ -167,5 +193,7 @@ namespace Snowflake.Data.Core.Session
                 : ";token=;";
             return connectionString + passwordPart + clientSecretPart + tokenPart;
         }
+
+        public ConnectionPoolType Type => ConnectionPoolType.MultipleConnectionPool;
     }
 }

--- a/Snowflake.Data/Core/Session/IConnectionManager.cs
+++ b/Snowflake.Data/Core/Session/IConnectionManager.cs
@@ -20,5 +20,7 @@ namespace Snowflake.Data.Core.Session
         bool GetPooling();
         SessionPool GetPool(string connectionString);
         SessionPool GetPool(string connectionString, SessionPropertiesContext sessionContext);
+        IConnectionManager Recycle(ConnectionPoolType requestedPoolType);
+        ConnectionPoolType Type { get; }
     }
 }

--- a/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
+++ b/Snowflake.Data/Core/Session/SFSessionHttpClientProperties.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Data.Core
         public const bool DefaultPoolingEnabled = true;
         public const int DefaultMaxHttpRetries = 7;
         public const int DefaultConnectionLimit = 20;
-        public static readonly TimeSpan DefaultRetryTimeout = TimeSpan.FromSeconds(300);
+        public static TimeSpan DefaultRetryTimeout { get; internal set; } = TimeSpan.FromSeconds(300);
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SFSessionHttpClientProperties>();
         internal static readonly int MaxConnectionLimit = 1000;
 

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -16,7 +16,7 @@ namespace Snowflake.Data.Core.Session
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SessionPool>();
         private readonly object _sessionPoolLock = new object();
-        private static readonly ISessionFactory s_sessionFactorySingleton = new SessionFactory();
+        internal static ISessionFactory s_sessionFactorySingleton = new SessionFactory();
         private readonly ISessionFactory _instanceSessionFactory;
 
         private ISessionFactory SessionFactory => _instanceSessionFactory ?? s_sessionFactorySingleton;

--- a/Snowflake.Data/Core/Session/SessionPool.cs
+++ b/Snowflake.Data/Core/Session/SessionPool.cs
@@ -16,7 +16,10 @@ namespace Snowflake.Data.Core.Session
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SessionPool>();
         private readonly object _sessionPoolLock = new object();
-        private static ISessionFactory s_sessionFactory = new SessionFactory();
+        private static readonly ISessionFactory s_sessionFactorySingleton = new SessionFactory();
+        private readonly ISessionFactory _instanceSessionFactory;
+
+        private ISessionFactory SessionFactory => _instanceSessionFactory ?? s_sessionFactorySingleton;
 
         private readonly Guid _id = Guid.NewGuid();
         internal readonly List<SFSession> _idleSessions;
@@ -44,9 +47,10 @@ namespace Snowflake.Data.Core.Session
             _waitingForIdleSessionQueue = new NonWaitingQueue();
             _sessionCreationTokenCounter = new NonCountingSessionCreationTokenCounter();
             _poolConfig = new ConnectionPoolConfig();
+            _instanceSessionFactory = null;
         }
 
-        private SessionPool(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token, ConnectionPoolConfig poolConfig, string connectionStringWithoutSecrets)
+        private SessionPool(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token, ConnectionPoolConfig poolConfig, string connectionStringWithoutSecrets, ISessionFactory sessionFactory)
         {
             // acquiring a lock not needed because one is already acquired in ConnectionPoolManager
             _idleSessions = new List<SFSession>();
@@ -59,17 +63,21 @@ namespace Snowflake.Data.Core.Session
             _waitingForIdleSessionQueue = new WaitingQueue();
             _poolConfig = poolConfig;
             _sessionCreationTokenCounter = new SessionCreationTokenCounter(_poolConfig.ConnectionTimeout);
+            _instanceSessionFactory = sessionFactory;
         }
 
-        internal static SessionPool CreateSessionCache() => new SessionPool();
+        internal static SessionPool CreateSessionCache() => new();
 
-        internal static SessionPool CreateSessionPool(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token)
+        internal static SessionPool CreateSessionPool(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token) =>
+            CreateSessionPool(connectionString, password, oauthClientSecret, token, null);
+
+        internal static SessionPool CreateSessionPool(string connectionString, SecureString password, SecureString oauthClientSecret, SecureString token, ISessionFactory sessionFactory)
         {
             s_logger.Debug("Creating a connection pool");
             var propertiesContext = new SessionPropertiesContext { Password = password, OAuthClientSecret = oauthClientSecret, Token = token };
             var extracted = ExtractConfig(connectionString, propertiesContext);
             s_logger.Debug("Creating a connection pool identified by: " + extracted.Item2);
-            return new SessionPool(connectionString, password, oauthClientSecret, token, extracted.Item1, extracted.Item2);
+            return new SessionPool(connectionString, password, oauthClientSecret, token, extracted.Item1, extracted.Item2, sessionFactory);
         }
 
         ~SessionPool()
@@ -82,11 +90,6 @@ namespace Snowflake.Data.Core.Session
         public void Dispose()
         {
             DestroyPool();
-        }
-
-        internal static ISessionFactory SessionFactory
-        {
-            set => s_sessionFactory = value;
         }
 
         private void CleanExpiredSessions()
@@ -419,7 +422,7 @@ namespace Snowflake.Data.Core.Session
             s_logger.Debug("SessionPool::NewSession" + PoolIdentification());
             try
             {
-                var session = s_sessionFactory.NewSession(connectionString, sessionContext);
+                var session = SessionFactory.NewSession(connectionString, sessionContext);
                 session.Open();
                 s_logger.Debug("SessionPool::NewSession - opened" + PoolIdentification());
                 if (GetPooling() && !_underDestruction)
@@ -465,7 +468,7 @@ namespace Snowflake.Data.Core.Session
         private Task<SFSession> NewSessionAsync(String connectionString, SessionPropertiesContext sessionContext, SessionCreationToken sessionCreationToken, CancellationToken cancellationToken)
         {
             s_logger.Debug("SessionPool::NewSessionAsync" + PoolIdentification());
-            var session = s_sessionFactory.NewSession(connectionString, sessionContext);
+            var session = SessionFactory.NewSession(connectionString, sessionContext);
             return session
                 .OpenAsync(cancellationToken)
                 .ContinueWith(previousTask =>

--- a/Snowflake.Data/Core/Tools/ValidatorOperations.cs
+++ b/Snowflake.Data/Core/Tools/ValidatorOperations.cs
@@ -43,9 +43,11 @@ namespace Snowflake.Data.Core.Tools
                 ThrowSecurityException("Attempting to read or write a file not owned by the effective user of the current process");
         }
 
-        internal void ThrowSecurityException(string errorMessage)
+        internal void ThrowSecurityException(string errorMessage, bool shouldLog = true)
         {
-            s_logger.Error(errorMessage);
+            if (shouldLog) // it's possible we want to throw due to logger not having proper permissions
+                s_logger.Error(errorMessage);
+
             throw new SecurityException(errorMessage);
         }
     }

--- a/Snowflake.Data/Logger/EasyLoggerManager.cs
+++ b/Snowflake.Data/Logger/EasyLoggerManager.cs
@@ -23,9 +23,7 @@ namespace Snowflake.Data.Log
                 var appender = IsStdout(logsPath)
                     ? AddConsoleAppender()
                     : AddRollingFileAppender(logsPath);
-                RemoveOtherEasyLoggingAppenders(appender);
-                appender.ActivateOptions();
-                SFLoggerImpl.s_appenders.Add(appender);
+                SetEasyLoggingAppenders(appender);
             }
         }
 
@@ -41,7 +39,7 @@ namespace Snowflake.Data.Log
             {
                 SFLoggerImpl.SetLevel(sfLoggerLevel);
                 if (easyLoggingLogLevel == EasyLoggingLogLevel.Off)
-                    RemoveOtherEasyLoggingAppenders(null);
+                    SetEasyLoggingAppenders();
             }
         }
 
@@ -50,15 +48,13 @@ namespace Snowflake.Data.Log
             return SFLoggerImpl.s_appenders.Any();
         }
 
-        private static void RemoveOtherEasyLoggingAppenders(SFAppender appender)
+        private static void SetEasyLoggingAppenders(params SFAppender[] appenders)
         {
-            foreach (var existingAppender in SFLoggerImpl.s_appenders.ToArray())
-            {
-                if (existingAppender != appender)
-                {
-                    SFLoggerImpl.s_appenders.Remove(existingAppender);
-                }
-            }
+            SFLoggerImpl.s_appenders = [];
+            foreach (var appender in appenders)
+                appender.ActivateOptions();
+
+            SFLoggerImpl.s_appenders = appenders.ToList();
         }
 
         private static SFAppender AddRollingFileAppender(string directoryPath)

--- a/Snowflake.Data/Logger/EasyLoggerValidator.cs
+++ b/Snowflake.Data/Logger/EasyLoggerValidator.cs
@@ -12,7 +12,7 @@ namespace Snowflake.Data.Logger
         {
             ValidatorOperations.Instance.ValidateUserAndGroupPermissions(stream);
             if ((stream.FileAccessPermissions & ~EasyLoggingStarter.Instance._logFileUnixPermissions) != 0)
-                ValidatorOperations.Instance.ThrowSecurityException("Attempting to read or write to log file with too broad permissions assigned");
+                ValidatorOperations.Instance.ThrowSecurityException("Attempting to read or write to log file with too broad permissions assigned", false);
         }
     }
 }

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -16,10 +16,12 @@
     <Version>5.6.0</Version>
     <DebugType>Full</DebugType>
     <LangVersion>13</LangVersion>
+      <!-- SNOW-3560694 !-->
+    <NoWarn>$(NoWarn);CA2022</NoWarn>
   </PropertyGroup>
 
   <!-- Define WINDOWS_BUILD for all Windows-specific targets -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net8.0-windows' OR '$(TargetFramework)' == 'net9.0-windows' OR '$(TargetFramework)' == 'net10.0-windows'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net8.0-windows' OR '$(TargetFramework)' == 'net9.0-windows' OR '$(TargetFramework)' == 'net10.0-windows'">
     <DefineConstants>$(DefineConstants);WINDOWS_BUILD</DefineConstants>
     <WindowsBuild>True</WindowsBuild>
   </PropertyGroup>
@@ -40,7 +42,7 @@
   </ItemGroup>
 
   <!-- Mono.Unix dependency ONLY for Unix/Linux platforms (netstandard2.0, net8.0 and net10.0) -->
-  <!-- NOT included for versions Windows targets: net481, net8.0-windows, net10.0-windows -->
+  <!-- NOT included for versions Windows targets: net462, net471, net472, net481, net6.0-windows, net7.0-windows, net8.0-windows, net9.0-windows, net10.0-windows -->
   <!-- Mono is required as long as there's no System.IO support for file ownership changes -->
   <ItemGroup Condition="'$(WindowsBuild)' != 'True'">
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />


### PR DESCRIPTION
Production code foundation changes to support the upcoming xUnit migration, plus supporting test adjustments.

  Key Changes

  Architecture / Testability:
  - SessionPool: Replaced the static SessionFactory setter with an instance-level _instanceSessionFactory field
  (falls back to s_sessionFactorySingleton). Allows injecting per-pool session factories via CreateSessionPool
  overload — needed for xUnit parallel test isolation.
  - ConnectionPoolManager: Extracted SessionPoolFactory delegate and IConnectionManagerFactory dependency into
  constructor parameters. Enables DI for testing without relying on global static state.
  - ConnectionManagerFactory (new): Encapsulates pool-type switching logic previously inline in
  SnowflakeDbConnectionPool.
  - IConnectionManager: Added Recycle(ConnectionPoolType) and Type property to the interface; both managers implement
   them.

  Logging / Validator fixes:
  - EasyLoggerManager: Simplified appender lifecycle — SetEasyLoggingAppenders replaces
  RemoveOtherEasyLoggingAppenders + separate activate/add steps with an atomic swap.
  - ValidatorOperations.ThrowSecurityException: Added shouldLog parameter to avoid logging when the logger itself
  lacks permissions.

  Build / Compatibility:
  - Broadened WINDOWS_BUILD condition to cover net462/net471/net472/net48 frameworks.
  - Suppressed CA2022 warning (tracked under SNOW-3560694).
  - Minor whitespace fix in RestRequester.cs preprocessor directives.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
