### PR TITLE
SNOW-3638165: validityInSecondsMT/ST int16 -> int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 # Changelog
 - v5.7.0
-    - Fixed `OverflowException` when converting rest response with master token validity more than ~9.1h.
     - Improved input handling in `ChangeDatabase` by using parameterized queries.
     - Improved input validation in `QueryResultsAwaiter` with stricter UUID format checks.
+    - Bug fix: `OverflowException` when converting rest response with master token validity more than ~9.1h.
     - Bug fix: Added path traversal protection for file downloads: destination paths are now validated against the target base directory before writing.
     - Bug fix: Replaced use of System.Random with a cryptographically secure random number generator in the authenticator challenge/proof key generation and file transfer encryption key/IV generation.
 - v5.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.7.0
+    - Fixed `OverflowException` when converting rest response with master token validity more than ~9.1h.
     - Improved input handling in `ChangeDatabase` by using parameterized queries.
     - Improved input validation in `QueryResultsAwaiter` with stricter UUID format checks.
     - Bug fix: Added path traversal protection for file downloads: destination paths are now validated against the target base directory before writing.

--- a/Snowflake.Data/Core/RestResponse.cs
+++ b/Snowflake.Data/Core/RestResponse.cs
@@ -119,13 +119,13 @@ namespace Snowflake.Data.Core
         internal string sessionToken { get; set; }
 
         [JsonProperty(PropertyName = "validityInSecondsST", NullValueHandling = NullValueHandling.Ignore)]
-        internal Int16 sessionTokenValidityInSeconds { get; set; }
+        internal int sessionTokenValidityInSeconds { get; set; }
 
         [JsonProperty(PropertyName = "masterToken", NullValueHandling = NullValueHandling.Ignore)]
         internal string masterToken { get; set; }
 
         [JsonProperty(PropertyName = "validityInSecondsMT", NullValueHandling = NullValueHandling.Ignore)]
-        internal Int16 masterTokenValidityInSeconds { get; set; }
+        internal int masterTokenValidityInSeconds { get; set; }
 
         [JsonProperty(PropertyName = "sessionId", NullValueHandling = NullValueHandling.Ignore)]
         internal Int64 sessionId { get; set; }


### PR DESCRIPTION
### Description
The current `Int16` type worked well for the session/master token until their value could not exceed the default 4 hours (14,400s) . But for a while it is customer configurable and sessions might live longer than 32,767s (~9.1h) and when such a validity is returned from Snowflake for the token, the driver still trie to parse it as `Int16` and fails:

```
Newtonsoft.Json.JsonSerializationException: Error converting value 43199 to type 'System.Int16'. Path 'data.validityInSecondsMT', line 6, position 31.
---> System.OverflowException: Value was either too large or too small for an Int16.
at System.Convert.ThrowInt16OverflowException()
at System.Convert.ToInt16(Int32 value)
at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
--- End of inner exception stack trace ---```
```

This fix aims to define a datatype for the token validity which can fit the current Snowflake server allowed values. 

