### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2009

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -217,10 +217,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 catch (Exception e)
                 {
                     SnowflakeDbExceptionAssert.HasErrorCode(e, SFError.INTERNAL_ERROR);
-                    Assert.True(e.Message.Contains(
+                    Assert.Contains(
                         $"The retry count has reached its limit of {expectedMaxRetryCount} and " +
                         $"the timeout elapsed has reached its limit of {expectedMaxConnectionTimeout} " +
-                        "while trying to authenticate through Okta"));
+                        "while trying to authenticate through Okta", e.Message);
                 }
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -244,7 +244,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.Throws<AggregateException>(() => cmd.GetResultsFromQueryId(unknownQueryId));
 
                     // Assert
-                    Assert.True(thrown.InnerException.Message.Contains($"Max retry for no data is reached"));
+                    Assert.Contains("Max retry for no data is reached", thrown.InnerException.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None);
@@ -274,7 +274,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.Throws<AggregateException>(() => task.Wait());
 
                     // Assert
-                    Assert.True(thrown.InnerException.Message.Contains($"Max retry for no data is reached"));
+                    Assert.Contains("Max retry for no data is reached", thrown.InnerException.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
@@ -178,7 +178,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
 
                     // Assert
-                    Assert.True(thrown.Message.Contains("The operation was canceled"));
+                    Assert.Contains("The operation was canceled", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -271,7 +271,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         await cmd.GetResultsFromQueryIdAsync(queryId, CancellationToken.None).ConfigureAwait(false));
 
                     // Assert
-                    Assert.True(thrown.Message.Contains("'FAKE_TABLE' does not exist"));
+                    Assert.Contains("'FAKE_TABLE' does not exist", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -366,7 +366,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         await cmd.GetResultsFromQueryIdAsync(unknownQueryId, CancellationToken.None).ConfigureAwait(false));
 
                     // Assert
-                    Assert.True(thrown.Message.Contains($"Max retry for no data is reached"));
+                    Assert.Contains("Max retry for no data is reached", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -395,7 +395,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         await queryResultsAwaiter.RetryUntilQueryResultIsAvailable(conn, unknownQueryId, CancellationToken.None, true).ConfigureAwait(false));
 
                     // Assert
-                    Assert.True(thrown.Message.Contains($"Max retry for no data is reached"));
+                    Assert.Contains("Max retry for no data is reached", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1299,7 +1299,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.Throws<SnowflakeDbException>(() => cmd.GetResultsFromQueryId(queryId));
 
                     // Assert
-                    Assert.True(thrown.Message.Contains("'FAKE_TABLE' does not exist"));
+                    Assert.Contains("'FAKE_TABLE' does not exist", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None);
@@ -1323,7 +1323,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var thrown = Assert.Throws<NotImplementedException>(() => cmd.ExecuteInAsyncMode());
 
                     // Assert
-                    Assert.True(thrown.Message.Contains("Get and Put are not supported in async execution mode"));
+                    Assert.Contains("Get and Put are not supported in async execution mode", thrown.Message);
 
                     // Arrange
                     cmd.CommandText = "GET @~ file://C:\\tmp\\;";
@@ -1332,7 +1332,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     thrown = Assert.Throws<NotImplementedException>(() => cmd.ExecuteInAsyncMode());
 
                     // Assert
-                    Assert.True(thrown.Message.Contains("Get and Put are not supported in async execution mode"));
+                    Assert.Contains("Get and Put are not supported in async execution mode", thrown.Message);
                 }
 
                 await conn.CloseAsync(CancellationToken.None);

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn)xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn)xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
@@ -479,7 +479,7 @@ namespace Snowflake.Data.Tests.UnitTests
             };
 
             var exception = Assert.Throws<SnowflakeDbException>(() => new ArrowResultSet(responseData, PrepareStatement(), new CancellationToken()));
-            Assert.True(exception.Message.Contains($"Unknown column type: {UnknownDataType}"));
+            Assert.Contains($"Unknown column type: {UnknownDataType}", exception.Message);
         }
 
         [SFFact]
@@ -497,8 +497,8 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
             };
 
-            var exception = Assert.Throws<SnowflakeDbException>(() => new ArrowResultSet(responseData, PrepareStatement(), new CancellationToken()));
-            Assert.True(exception.Message.Contains($"Unknown column type: {SFDataType.None.ToString()}"));
+            var exception = Assert.Throws<SnowflakeDbException>(() => new ArrowResultSet(responseData, PrepareStatement(), CancellationToken.None));
+            Assert.Contains($"Unknown column type: {nameof(SFDataType.None)}", exception.Message);
         }
 
         private void PrepareTestCase(SFDataType sfType, long scale, object values)
@@ -507,7 +507,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var responseData = PrepareResponseData(_recordBatch, sfType, scale);
             var sfStatement = PrepareStatement();
 
-            _arrowResultSet = new ArrowResultSet(responseData, sfStatement, new CancellationToken());
+            _arrowResultSet = new ArrowResultSet(responseData, sfStatement, CancellationToken.None);
         }
 
         private QueryExecResponseData PrepareResponseData(RecordBatch recordBatch, SFDataType sfType, long scale)

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorAwsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorAwsTest.cs
@@ -118,7 +118,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             Assert.Equal("snowflakecomputing.com", signedRequest.Headers["X-Snowflake-Audience"]);
             Assert.Equal("20250527T142033Z", signedRequest.Headers["x-amz-date"]);
             Assert.Equal(AwsToken, signedRequest.Headers["x-amz-security-token"]);
-            Assert.True(signedRequest.Headers["authorization"].StartsWith($"AWS4-HMAC-SHA256 Credential={AwsAccessKey}/20250527/{AwsRegion}/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-snowflake-audience, Signature="));
+            Assert.StartsWith($"AWS4-HMAC-SHA256 Credential={AwsAccessKey}/20250527/{AwsRegion}/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-snowflake-audience, Signature=", signedRequest.Headers["authorization"]);
             Assert.Equal(64, ExtractSignature(signedRequest.Headers["authorization"]).Length);
             Assert.Equal(5, signedRequest.Headers.Count);
         }

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
 
             // assert
             Assert.NotNull(thrown);
-            Assert.True(thrown.Message.Contains("Finding easy logging configuration failed"));
+            Assert.Contains("Finding easy logging configuration failed", thrown.Message);
         }
 
         [SFTheory, MemberData(nameof(WrongConfigFiles))]

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -241,7 +241,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var exception = Assert.Throws<SnowflakeDbException>(() => connectionPoolManager.GetTimeout());
             Assert.NotNull(exception);
             Assert.Equal(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
-            Assert.True(exception.Message.Contains("Multiple pools have different Timeout values"));
+            Assert.Contains("Multiple pools have different Timeout values", exception.Message);
         }
 
         [SFFact]
@@ -272,7 +272,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var exception = Assert.Throws<SnowflakeDbException>(() => connectionPoolManager.GetMaxPoolSize());
             Assert.NotNull(exception);
             Assert.Equal(SFError.INCONSISTENT_RESULT_ERROR.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
-            Assert.True(exception.Message.Contains("Multiple pools have different Max Pool Size values"));
+            Assert.Contains("Multiple pools have different Max Pool Size values", exception.Message);
         }
 
         [SFFact]
@@ -371,7 +371,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var serializedPool = pool.ToString();
 
             // assert
-            Assert.False(serializedPool.Contains(password));
+            Assert.DoesNotContain(password, serializedPool);
         }
 
         private void EnsurePoolSize(string connectionString, SessionPropertiesContext sessionContext, int requiredCurrentSize)

--- a/Snowflake.Data.Tests/UnitTests/Logger/LoggerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/LoggerTest.cs
@@ -143,11 +143,11 @@ namespace Snowflake.Data.Tests.UnitTests.Logger
                 using (StreamReader logFileReader = new StreamReader(logFileStream))
                 {
                     string logLines = logFileReader.ReadToEnd();
-                    Assert.True(logLines.Contains(DebugMessage));
-                    Assert.True(logLines.Contains(InfoMessage));
-                    Assert.True(logLines.Contains(WarnMessage));
-                    Assert.True(logLines.Contains(ErrorMessage));
-                    Assert.True(logLines.Contains(CriticalMessage));
+                    Assert.Contains(DebugMessage, logLines);
+                    Assert.Contains(InfoMessage, logLines);
+                    Assert.Contains(WarnMessage, logLines);
+                    Assert.Contains(ErrorMessage, logLines);
+                    Assert.Contains(CriticalMessage, logLines);
                 }
             }
         }

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -359,8 +359,8 @@ namespace Snowflake.Data.Tests.UnitTests
                 // Assert the file is uploaded
                 Assert.Equal(ResultStatus.UPLOADED.ToString(), GetResultValue(result, SFResultSet.PutGetResponseRowTypeInfo.ResultStatus));
                 // Check the name of the source file and destination file are the same
-                Assert.True(GetResultValue(result, SFResultSet.PutGetResponseRowTypeInfo.SourceFileName).Contains(mockFileName));
-                Assert.True(GetResultValue(result, SFResultSet.PutGetResponseRowTypeInfo.DestinationFileName).Contains(mockFileName));
+                Assert.Contains(mockFileName, GetResultValue(result, SFResultSet.PutGetResponseRowTypeInfo.SourceFileName));
+                Assert.Contains(mockFileName, GetResultValue(result, SFResultSet.PutGetResponseRowTypeInfo.DestinationFileName));
 
                 File.Delete($"{mockFileName}{index}.{extension}");
             }

--- a/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionPropertyTest.cs
@@ -71,7 +71,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // assert
             Assert.Equal(SFError.INVALID_CONNECTION_PARAMETER_VALUE.GetAttribute<SFErrorAttr>().errorCode, exception.ErrorCode);
-            Assert.True(exception.Message.Contains(expectedErrorMessagePart));
+            Assert.Contains(expectedErrorMessagePart, exception.Message);
         }
 
         [SFTheory]
@@ -233,8 +233,8 @@ namespace Snowflake.Data.Tests.UnitTests
 
                 // Verify the Turkish culture issue exists
                 Assert.NotEqual(cultureDependent, cultureInvariant);
-                Assert.True(cultureDependent.Contains("İ"), "Turkish ToUpper() should contain Turkish dotted capital I");
-                Assert.True(cultureInvariant.Contains("I"), "Invariant ToUpper() should contain ASCII capital I");
+                Assert.Contains("İ", cultureDependent); // Turkish ToUpper() should contain Turkish dotted capital I
+                Assert.Contains("I", cultureInvariant); // Invariant ToUpper() should contain ASCII capital I
 
                 // Verify that invalid properties still throw exceptions even with Turkish culture
                 var invalidConnectionString = "ACCOUNT=testaccount;USER=testuser;PASSWORD=testpassword;invalidproperty=somevalue";

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -202,7 +202,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestGetQueryStatusByStringValueThrowsErrorForUnknownStatus(string stringValue)
         {
             var thrown = Assert.Throws<Exception>(() => QueryStatusExtensions.GetQueryStatusByStringValue(stringValue));
-            Assert.True(thrown.Message.Contains("The query status returned by the server is not recognized"));
+            Assert.Contains("The query status returned by the server is not recognized", thrown.Message);
         }
 
         [SFTheory]

--- a/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFUriUpdaterTest.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Data.Tests.UnitTests
             {
                 Uri newUri = updater.Update();
 
-                Assert.True(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_COUNT + "=" + retryCount));
+                Assert.Contains(RestParams.SF_QUERY_RETRY_COUNT + "=" + retryCount, newUri.Query);
             }
         }
 
@@ -31,7 +31,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             Uri newUri = updater.Update(429);
 
-            Assert.True(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_REASON + "=" + 429));
+            Assert.Contains(RestParams.SF_QUERY_RETRY_REASON + "=" + 429, newUri.Query);
         }
 
         [SFFact]
@@ -43,7 +43,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             Uri newUri = updater.Update(429);
 
-            Assert.False(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_REASON));
+            Assert.DoesNotContain(RestParams.SF_QUERY_RETRY_REASON, newUri.Query);
         }
 
         [SFFact]
@@ -56,7 +56,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             Uri newUri = updater.Update();
 
-            Assert.False(newUri.Query.Contains(RestParams.SF_QUERY_RETRY_COUNT));
+            Assert.DoesNotContain(RestParams.SF_QUERY_RETRY_COUNT, newUri.Query);
         }
 
         [SFFact]
@@ -78,8 +78,8 @@ namespace Snowflake.Data.Tests.UnitTests
             updater = new HttpUtil.UriUpdater(uri);
             newUri = updater.Update();
 
-            Assert.True(newUri.Query.Contains(RestParams.SF_QUERY_REQUEST_GUID));
-            Assert.False(newUri.Query.Contains(initialGuid));
+            Assert.Contains(RestParams.SF_QUERY_REQUEST_GUID, newUri.Query);
+            Assert.DoesNotContain(initialGuid, newUri.Query);
             Assert.Equal(newUri.ToString().Length, uri.ToString().Length);
 
         }

--- a/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SFHttpClientPropertiesTest.cs
@@ -138,7 +138,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // assert
             Assert.Equal(SFError.INVALID_CONNECTION_PARAMETER_VALUE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
-            Assert.True(thrown.Message.Contains(expectedErrorMessage));
+            Assert.Contains(expectedErrorMessage, thrown.Message);
         }
 
         [SFTheory]
@@ -252,7 +252,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         {
             // act & assert
             var exception = Assert.Throws<SnowflakeDbException>(() => SFSessionProperties.ParseConnectionString("account=test;user=test;password=test;minTls=tls13;maxTls=tls12", new SessionPropertiesContext()));
-            Assert.True(exception.Message.Contains("Connection string is invalid: Parameter MINTLS value cannot be higher than MAXTLS value."));
+            Assert.Contains("Connection string is invalid: Parameter MINTLS value cannot be higher than MAXTLS value.", exception.Message);
         }
 
         [SFFact]
@@ -260,7 +260,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         {
             // act & assert
             var exception = Assert.Throws<SnowflakeDbException>(() => SFSessionProperties.ParseConnectionString("account=test;user=test;password=test;minTls=tls11;maxTls=tls11", new SessionPropertiesContext()));
-            Assert.True(exception.Message.Contains("Connection string is invalid: Parameter MINTLS should have one of the following values: TLS12, TLS13."));
+            Assert.Contains("Connection string is invalid: Parameter MINTLS should have one of the following values: TLS12, TLS13.", exception.Message);
         }
 
         [SFTheory, MemberData(nameof(PropertiesProvider))]

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -107,7 +107,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // assert
             SnowflakeDbExceptionAssert.HasErrorCode(exception, SFError.MISSING_CONNECTION_PROPERTY);
-            Assert.True(exception.Message.Contains("Required property PASSWORD is not provided"));
+            Assert.Contains("Required property PASSWORD is not provided", exception.Message);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeTomlConnectionBuilderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeTomlConnectionBuilderTest.cs
@@ -336,7 +336,7 @@ token_file_path = ""{tokenFilePath}""");
 
             // Act and assert
             var exception = Assert.Throws<SnowflakeDbException>(() => reader.GetConnectionStringFromToml());
-            Assert.True(exception.Message.StartsWith("Error: Invalid parameter value /Users/testuser/token for token_file_path"));
+            Assert.StartsWith("Error: Invalid parameter value /Users/testuser/token for token_file_path", exception.Message);
         }
 
         [SFFact]


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis xUnit2009 - ""Do not use boolean check to check for substrings"

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
