### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2004

### DIFF
--- a/Snowflake.Data.Tests/IcebergTests/TestIcebergTable.cs
+++ b/Snowflake.Data.Tests/IcebergTests/TestIcebergTable.cs
@@ -229,11 +229,11 @@ namespace Snowflake.Data.Tests.IcebergTests
                                     nu number(10,0),
                                     tx2 varchar(100)".Split('\n');
                 var reader = (DbDataReader)conn.ExecuteReader(sql);
-                Assert.Equal(true, reader.Read());
+                Assert.True(reader.Read());
                 AssertRowValuesEqual(reader, resultSetColumns, I32, I64, Dec, Dbl, Flt, Txt, B1, B0, _dt, _tm, _ntz, _ltz, _bi, Id1, I32, Txt1);
-                Assert.Equal(true, reader.Read());
+                Assert.True(reader.Read());
                 AssertRowValuesEqual(reader, resultSetColumns, I32, I64, Dec, Dbl, Flt, Txt, B1, B0, _dt, _tm, _ntz, _ltz, _bi, Id2, I32, Txt2);
-                Assert.Equal(false, reader.Read());
+                Assert.False(reader.Read());
             }
         }
 
@@ -255,7 +255,7 @@ namespace Snowflake.Data.Tests.IcebergTests
                 // Assert
                 Assert.Equal(1, removed.RecordsAffected);
                 var left = conn.ExecuteReader($"select count(*) from {TableNameIceberg} where nu1 <> {I32}");
-                Assert.Equal(true, left.Read());
+                Assert.True(left.Read());
                 Assert.Equal(99, left.GetInt32(0));
             }
         }
@@ -277,7 +277,7 @@ namespace Snowflake.Data.Tests.IcebergTests
                 // Assert
                 Assert.Equal(100, removed.RecordsAffected);
                 var left = conn.ExecuteReader($"select count(*) from {TableNameIceberg}");
-                Assert.Equal(true, left.Read());
+                Assert.True(left.Read());
                 Assert.Equal(0, left.GetInt32(0));
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -168,7 +168,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             connection.ConnectionString = connectionString;
             await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             await connection.BeginTransactionAsync();
-            Assert.Equal(true, connection.HasActiveExplicitTransaction());
+            Assert.True(connection.HasActiveExplicitTransaction());
 
             // act
             await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
@@ -172,7 +172,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             connection.ConnectionString = connectionString;
             await connection.OpenAsync(CancellationToken.None);
             await connection.BeginTransactionAsync();
-            Assert.Equal(true, connection.HasActiveExplicitTransaction());
+            Assert.True(connection.HasActiveExplicitTransaction());
 
             // act
             connection.Close();

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -69,7 +69,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             await Task.Delay(100).ConfigureAwait(false);
             SFStatement statement = new SFStatement(conn1.SfSession);
             SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false, false);
-            Assert.Equal(true, await resultSet.NextAsync().ConfigureAwait(false));
+            Assert.True(await resultSet.NextAsync().ConfigureAwait(false));
             Assert.Equal("1", resultSet.GetString(0));
             await conn1.CloseAsync(CancellationToken.None);
         }
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await connection.OpenAsync(CancellationToken.None);
                 firstOpenedSessionId = connection.SfSession.sessionId;
                 await connection.BeginTransactionAsync();
-                Assert.Equal(true, connection.HasActiveExplicitTransaction());
+                Assert.True(connection.HasActiveExplicitTransaction());
                 await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
                 {
                     using (var command = connection.CreateCommand())
@@ -148,7 +148,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await connectionWithSessionReused.OpenAsync(CancellationToken.None);
 
                 Assert.Equal(firstOpenedSessionId, connectionWithSessionReused.SfSession.sessionId);
-                Assert.Equal(false, connectionWithSessionReused.HasActiveExplicitTransaction());
+                Assert.False(connectionWithSessionReused.HasActiveExplicitTransaction());
                 using (var cmd = connectionWithSessionReused.CreateCommand())
                 {
                     cmd.CommandText = "SELECT CURRENT_TRANSACTION()";
@@ -170,7 +170,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     command.CommandText = "BEGIN"; // in general can be put as a part of a multi statement call and mixed with commit as well
                     await command.ExecuteNonQueryAsync();
-                    Assert.Equal(false, connection.HasActiveExplicitTransaction());
+                    Assert.False(connection.HasActiveExplicitTransaction());
                 }
             }
         }
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await connection1.OpenAsync(CancellationToken.None);
                 Assert.Equal(ExpectedPoolCountAfterOpen(), SnowflakeDbConnectionPool.GetCurrentPoolSize());
                 await connection1.BeginTransactionAsync();
-                Assert.Equal(true, connection1.HasActiveExplicitTransaction());
+                Assert.True(connection1.HasActiveExplicitTransaction());
                 using (var command = connection1.CreateCommand())
                 {
                     firstOpenedSessionId = connection1.SfSession.sessionId;
@@ -201,7 +201,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 await connection2.OpenAsync(CancellationToken.None);
                 Assert.Equal(ExpectedPoolCountAfterOpen(), SnowflakeDbConnectionPool.GetCurrentPoolSize());
-                Assert.Equal(false, connection2.HasActiveExplicitTransaction());
+                Assert.False(connection2.HasActiveExplicitTransaction());
                 using (var command = connection2.CreateCommand())
                 {
                     Assert.Equal(firstOpenedSessionId, connection2.SfSession.sessionId);

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
@@ -356,7 +356,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             connection.ConnectionString = _fixture.ConnectionString;
             await connection.OpenAsync(CancellationToken.None);
             connection.BeginTransaction();
-            Assert.Equal(true, connection.HasActiveExplicitTransaction());
+            Assert.True(connection.HasActiveExplicitTransaction());
             // no Rollback or Commit; during internal Rollback while closing a connection a mocked exception will be thrown
 
             // act

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
@@ -154,7 +154,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             const int PoolTimeout = 1;
 
             // reset to default settings in case it changed by other test cases
-            Assert.Equal(true, SnowflakeDbConnectionPool.GetPool(connectionString).GetPooling()); // to instantiate pool
+            Assert.True(SnowflakeDbConnectionPool.GetPool(connectionString).GetPooling()); // to instantiate pool
             SnowflakeDbConnectionPool.SetMaxPoolSize(2);
             SnowflakeDbConnectionPool.SetTimeout(PoolTimeout);
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -231,18 +231,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
                 conn.Open();
-                Assert.Equal(false, conn.HasActiveExplicitTransaction());
+                Assert.False(conn.HasActiveExplicitTransaction());
 
                 var trans = conn.BeginTransaction();
-                Assert.Equal(true, conn.HasActiveExplicitTransaction());
+                Assert.True(conn.HasActiveExplicitTransaction());
                 trans.Rollback();
-                Assert.Equal(false, conn.HasActiveExplicitTransaction());
+                Assert.False(conn.HasActiveExplicitTransaction());
 
                 conn.BeginTransaction().Rollback();
-                Assert.Equal(false, conn.HasActiveExplicitTransaction());
+                Assert.False(conn.HasActiveExplicitTransaction());
 
                 conn.BeginTransaction().Commit();
-                Assert.Equal(false, conn.HasActiveExplicitTransaction());
+                Assert.False(conn.HasActiveExplicitTransaction());
             }
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1096,18 +1096,18 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
         {
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(false, conn.HasActiveExplicitTransaction());
+            Assert.False(conn.HasActiveExplicitTransaction());
 
             var trans = await conn.BeginTransactionAsync();
-            Assert.Equal(true, conn.HasActiveExplicitTransaction());
+            Assert.True(conn.HasActiveExplicitTransaction());
             await trans.RollbackAsync();
-            Assert.Equal(false, conn.HasActiveExplicitTransaction());
+            Assert.False(conn.HasActiveExplicitTransaction());
 
             await (await conn.BeginTransactionAsync()).RollbackAsync();
-            Assert.Equal(false, conn.HasActiveExplicitTransaction());
+            Assert.False(conn.HasActiveExplicitTransaction());
 
             await (await conn.BeginTransactionAsync()).CommitAsync();
-            Assert.Equal(false, conn.HasActiveExplicitTransaction());
+            Assert.False(conn.HasActiveExplicitTransaction());
         }
     }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -103,7 +103,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             Assert.Equal(ConnectionState.Open, conn.State);
 
             // connection pooling is disabled for external browser by default
-            Assert.Equal(false, SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
+            Assert.False(SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_USER()";
@@ -123,7 +123,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                   + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com;POOLINGENABLED=TRUE";
             await conn.OpenAsync(CancellationToken.None);
             Assert.Equal(ConnectionState.Open, conn.State);
-            Assert.Equal(true, SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
+            Assert.True(SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_USER()";

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -1400,7 +1400,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (var rdr = cmd.ExecuteReader())
                 {
                     // Can read the first row
-                    Assert.Equal(true, rdr.Read());
+                    Assert.True(rdr.Read());
                 }
 
                 // test rows_loaded exists
@@ -1408,14 +1408,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (var rdr = cmd.ExecuteReader())
                 {
                     // Can read the first row
-                    Assert.Equal(true, rdr.Read());
+                    Assert.True(rdr.Read());
                 }
 
                 cmd.CommandText = $"copy into {tableName}";
                 using (var rdr = cmd.ExecuteReader())
                 {
                     // Can read the first row
-                    Assert.Equal(true, rdr.Read());
+                    Assert.True(rdr.Read());
                 }
 
                 // clean up
@@ -1447,7 +1447,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     ValidateResultFormat(reader);
 
-                    Assert.Equal(true, reader.Read());
+                    Assert.True(reader.Read());
                     Assert.Equal("[\n  \"1\",\n  \"2\"\n]", reader.GetString(0));
                     Assert.Equal("[\n  \"1\",\n  \"2\"\n]", reader.GetString(1));
                     Assert.Equal("{\n  \"key\": \"value\"\n}", reader.GetString(2));
@@ -1528,20 +1528,20 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(20, row[SchemaTableColumn.NumericPrecision]);
                     Assert.Equal(4, row[SchemaTableColumn.NumericScale]);
                     Assert.Equal(SFDataType.FIXED, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
 
                     row = dataTable.Rows[1];
                     Assert.Equal("C2", row[SchemaTableColumn.ColumnName]);
                     Assert.Equal(1, row[SchemaTableColumn.ColumnOrdinal]);
                     Assert.Equal(100, row[SchemaTableColumn.ColumnSize]);
                     Assert.Equal(SFDataType.TEXT, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
 
                     row = dataTable.Rows[2];
                     Assert.Equal("C3", row[SchemaTableColumn.ColumnName]);
                     Assert.Equal(2, row[SchemaTableColumn.ColumnOrdinal]);
                     Assert.Equal(SFDataType.REAL, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
 
                     row = dataTable.Rows[3];
                     Assert.Equal("C4", row[SchemaTableColumn.ColumnName]);
@@ -1549,19 +1549,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(0, row[SchemaTableColumn.NumericPrecision]);
                     Assert.Equal(9, row[SchemaTableColumn.NumericScale]);
                     Assert.Equal(SFDataType.TIMESTAMP_NTZ, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
 
                     row = dataTable.Rows[4];
                     Assert.Equal("C5", row[SchemaTableColumn.ColumnName]);
                     Assert.Equal(4, row[SchemaTableColumn.ColumnOrdinal]);
                     Assert.Equal(SFDataType.VARIANT, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(false, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.False((bool)row[SchemaTableColumn.AllowDBNull]);
 
                     row = dataTable.Rows[5];
                     Assert.Equal("C6", row[SchemaTableColumn.ColumnName]);
                     Assert.Equal(5, row[SchemaTableColumn.ColumnOrdinal]);
                     Assert.Equal(SFDataType.BOOLEAN, (SFDataType)row[SchemaTableColumn.ProviderType]);
-                    Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+                    Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
                 }
 
                 await CloseConnectionAsync(conn);

--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -77,8 +77,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 Assert.True(reader.NextResult());
                 Assert.True(reader.Read());
-                Assert.Equal(true, reader.GetBoolean(0));
-                Assert.Equal(false, reader.GetBoolean(1));
+                Assert.True(reader.GetBoolean(0));
+                Assert.False(reader.GetBoolean(1));
                 Assert.Equal(DBNull.Value, reader.GetValue(2));
                 Assert.False(reader.IsDBNull(0));
                 Assert.False(reader.IsDBNull(1));

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -207,7 +207,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     command.CommandText = sql;
                     var reader = command.ExecuteReader();
-                    Assert.Equal(false, await reader.ReadAsync());
+                    Assert.False(await reader.ReadAsync());
                 }
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredTypesWithEmbeddedUnstructuredIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredTypesWithEmbeddedUnstructuredIT.cs
@@ -98,7 +98,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(1.23f, allUnstructuredTypesObject.FloatValue);
                     Assert.Equal(1.23d, allUnstructuredTypesObject.DoubleValue);
                     Assert.Equal(1.23m, allUnstructuredTypesObject.DecimalValue);
-                    Assert.Equal(true, allUnstructuredTypesObject.BooleanValue);
+                    Assert.True(allUnstructuredTypesObject.BooleanValue);
                     Assert.Equal(Guid.Parse("57af59a1-f010-450a-8c37-8fdc78e6ee93"), allUnstructuredTypesObject.GuidValue);
                     Assert.Equal(DateTime.Parse("2024-07-11 14:20:05"), allUnstructuredTypesObject.DateTimeValue);
                     Assert.Equal(DateTimeOffset.Parse($"2024-07-11 14:20:05 {expectedOffsetString}"), allUnstructuredTypesObject.DateTimeOffsetValue);
@@ -188,7 +188,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(1.23f, allUnstructuredTypesObject.FloatValue);
                     Assert.Equal(1.23d, allUnstructuredTypesObject.DoubleValue);
                     Assert.Equal(1.23m, allUnstructuredTypesObject.DecimalValue);
-                    Assert.Equal(true, allUnstructuredTypesObject.BooleanValue);
+                    Assert.True(allUnstructuredTypesObject.BooleanValue);
                     Assert.Equal(Guid.Parse("57af59a1-f010-450a-8c37-8fdc78e6ee93"), allUnstructuredTypesObject.GuidValue);
                     Assert.Equal(DateTime.Parse("2024-07-11 14:20:05"), allUnstructuredTypesObject.DateTimeValue);
                     Assert.Equal(DateTimeOffset.Parse($"2024-07-11 14:20:05 {expectedOffsetString}"), allUnstructuredTypesObject.DateTimeOffsetValue);

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
@@ -136,7 +136,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             arrowResultSet.Next();
 
-            Assert.Equal(true, arrowResultSet.IsDBNull(0));
+            Assert.True(arrowResultSet.IsDBNull(0));
             Assert.Equal(DBNull.Value, arrowResultSet.GetValue(0));
         }
 

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthCacheKeysTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthCacheKeysTests.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var isAvailable = cacheKeys.IsAvailable();
 
             // assert
-            Assert.Equal(false, isAvailable);
+            Assert.False(isAvailable);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
@@ -82,10 +82,10 @@ namespace Snowflake.Data.Tests
         public void TestDbParameterIsNullable(SFDataType SFDataType)
         {
             _parameter = new SnowflakeDbParameter(1, SFDataType);
-            Assert.Equal(false, _parameter.IsNullable);
+            Assert.False(_parameter.IsNullable);
 
             _parameter.IsNullable = true;
-            Assert.Equal(true, _parameter.IsNullable);
+            Assert.True(_parameter.IsNullable);
         }
 
         [SFTheory]
@@ -116,10 +116,10 @@ namespace Snowflake.Data.Tests
         public void TestDbParameterSourceColumnNullMapping(SFDataType SFDataType)
         {
             _parameter = new SnowflakeDbParameter(1, SFDataType);
-            Assert.Equal(false, _parameter.SourceColumnNullMapping);
+            Assert.False(_parameter.SourceColumnNullMapping);
 
             _parameter.SourceColumnNullMapping = true;
-            Assert.Equal(true, _parameter.SourceColumnNullMapping);
+            Assert.True(_parameter.SourceColumnNullMapping);
         }
 
         [SFTheory]

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -24,7 +24,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
             var statement = new SFStatement(sfSession);
             var resultSet = statement.Execute(0, "select 1", null, false, false);
-            Assert.Equal(true, resultSet.Next());
+            Assert.True(resultSet.Next());
             Assert.Equal("1", resultSet.GetString(0));
             Assert.Equal("new_session_token", sfSession.sessionToken);
             Assert.Equal("new_master_token", sfSession.masterToken);
@@ -39,7 +39,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
             var statement = new SFStatement(sfSession);
             var resultSet = statement.GetResultWithId("mockId");
-            Assert.Equal(true, resultSet.Next());
+            Assert.True(resultSet.Next());
             Assert.Equal("abc", resultSet.GetString(0));
             Assert.Equal("new_session_token", sfSession.sessionToken);
             Assert.Equal("new_master_token", sfSession.masterToken);
@@ -64,7 +64,7 @@ namespace Snowflake.Data.Tests.UnitTests
             await sfSession.OpenAsync(CancellationToken.None);
             var statement = new SFStatement(sfSession);
             var resultSet = await statement.GetResultWithIdAsync("mockId", CancellationToken.None);
-            Assert.Equal(true, resultSet.Next());
+            Assert.True(resultSet.Next());
             Assert.Equal("abc", resultSet.GetString(0));
             Assert.Equal("new_session_token", sfSession.sessionToken);
             Assert.Equal("new_master_token", sfSession.masterToken);
@@ -90,7 +90,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
             var statement = new SFStatement(sfSession);
             var resultSet = statement.Execute(0, "select 1", null, false, false);
-            Assert.Equal(true, resultSet.Next());
+            Assert.True(resultSet.Next());
             Assert.Equal("1", resultSet.GetString(0));
         }
 

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -275,7 +275,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var pool = SessionPool.CreateSessionCache();
 
             // assert
-            Assert.Equal(true, pool.GetPooling()); // for the old connection cache pooling is always enabled
+            Assert.True(pool.GetPooling()); // for the old connection cache pooling is always enabled
 
             // act
             var isSessionReturnedToPool = pool.AddSession(session, false);

--- a/Snowflake.Data.Tests/UnitTests/Tools/DirectoryInformationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/DirectoryInformationTest.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var result = directoryInformation.IsCreatedEarlierThanSeconds(60, utcNow);
 
             // assert
-            Assert.Equal(true, result);
+            Assert.True(result);
         }
 
         [SFTheory]
@@ -33,7 +33,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var result = directoryInformation.IsCreatedEarlierThanSeconds(60, utcNow);
 
             // assert
-            Assert.Equal(false, result);
+            Assert.False(result);
         }
 
         public static IEnumerable<object[]> OldCreatingDatesTestCases()

--- a/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
@@ -142,7 +142,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/latest/dynamic/instance-identity/document")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.Equal(true, await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -152,7 +152,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Put, "http://169.254.169.254/latest/api/token")
                 .Respond(HttpStatusCode.Forbidden);
 
-            Assert.Equal(false, await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -164,7 +164,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/latest/dynamic/instance-identity/document")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.Equal(false, await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -174,7 +174,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Put, "http://169.254.169.254/latest/api/token")
                 .Throw(new HttpRequestException("Connection refused"));
 
-            Assert.Equal(false, await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
         }
 
         // --- DetectAzureVm ---
@@ -186,7 +186,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.Equal(true, await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -196,7 +196,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.Equal(false, await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -206,7 +206,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Throw(new HttpRequestException("Connection refused"));
 
-            Assert.Equal(false, await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
         }
 
         // --- DetectAzureManagedIdentity ---
@@ -219,7 +219,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             Environment.SetEnvironmentVariable(AzureWebJobsStorage, "DefaultEndpointsProtocol=https;...");
             Environment.SetEnvironmentVariable(IdentityHeader, "some-value");
 
-            Assert.Equal(true, await PlatformDetection.DetectAzureManagedIdentityAsync());
+            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync());
         }
 
         [SFFact]
@@ -230,7 +230,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             Environment.SetEnvironmentVariable(FunctionsExtensionVersion, "~4");
             Environment.SetEnvironmentVariable(AzureWebJobsStorage, "DefaultEndpointsProtocol=https;...");
 
-            Assert.Equal(false, await PlatformDetection.DetectAzureManagedIdentityAsync());
+            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync());
         }
 
         [SFFact]
@@ -240,7 +240,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/identity/oauth2/token*")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.Equal(true, await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -250,7 +250,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/identity/oauth2/token*")
                 .Respond(HttpStatusCode.BadRequest);
 
-            Assert.Equal(false, await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
         }
 
         // --- DetectGceVm ---
@@ -267,7 +267,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
                     return response;
                 });
 
-            Assert.Equal(true, await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -277,7 +277,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal")
                 .Respond(HttpStatusCode.OK);
 
-            Assert.Equal(false, await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -287,7 +287,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal")
                 .Throw(new HttpRequestException("Host not found"));
 
-            Assert.Equal(false, await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
         }
 
         // --- RunDetectionAsync (disable env var) ---
@@ -355,7 +355,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")
                 .Respond(HttpStatusCode.OK, "text/plain", "sa@project.iam.gserviceaccount.com");
 
-            Assert.Equal(true, await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
         }
 
         [SFFact]
@@ -365,7 +365,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.Equal(false, await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
         }
 
         public void Dispose()

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Tests.Util
         public static void HasHttpErrorCodeInExceptionChain(Exception exception, HttpStatusCode expected)
         {
             var exceptions = CollectExceptions(exception);
-            Assert.Equal(true, exceptions.Any(e =>
+            Assert.True(exceptions.Any(e =>
                 {
                     switch (e)
                     {
@@ -58,7 +58,7 @@ namespace Snowflake.Data.Tests.Util
         public static void HasMessageInExceptionChain(Exception exception, string expected)
         {
             var exceptions = CollectExceptions(exception);
-            Assert.Equal(true, exceptions.Any(e => e.Message.Contains(expected)));
+            Assert.True(exceptions.Any(e => e.Message.Contains(expected)));
         }
 
         private static List<Exception> CollectExceptions(Exception exception)

--- a/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
+++ b/Snowflake.Data.Tests/Util/SnowflakeDbExceptionAssert.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Tests.Util
         public static void HasHttpErrorCodeInExceptionChain(Exception exception, HttpStatusCode expected)
         {
             var exceptions = CollectExceptions(exception);
-            Assert.True(exceptions.Any(e =>
+            Assert.Contains(exceptions, e =>
                 {
                     switch (e)
                     {
@@ -52,13 +52,13 @@ namespace Snowflake.Data.Tests.Util
                         default:
                             return false;
                     }
-                }));
+                });
         }
 
         public static void HasMessageInExceptionChain(Exception exception, string expected)
         {
             var exceptions = CollectExceptions(exception);
-            Assert.True(exceptions.Any(e => e.Message.Contains(expected)));
+            Assert.Contains(exceptions, e => e.Message.Contains(expected));
         }
 
         private static List<Exception> CollectExceptions(Exception exception)


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis xUnit2009 - "Do not use equality check to test for boolean conditions"

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
