### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2000

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -298,7 +298,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var nestedException = ((AggregateException)thrown.InnerException).InnerException;
             Assert.Contains("Could not obtain a connection from the pool within a given timeout", nestedException.Message);
             Assert.InRange(watch.ElapsedMilliseconds, 1000, long.MaxValue);
-            Assert.Equal(pool.GetCurrentPoolSize(), 2);
+            Assert.Equal(2, pool.GetCurrentPoolSize());
 
             // cleanup
             await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
@@ -50,7 +50,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // assert
             Assert.Contains("Unable to connect. Could not obtain a connection from the pool within a given timeout", thrown.Message);
             Assert.InRange(watch.ElapsedMilliseconds, 1000, 5000);
-            Assert.Equal(pool.GetCurrentPoolSize(), 2);
+            Assert.Equal(2, pool.GetCurrentPoolSize());
 
             // cleanup
             await conn1.CloseAsync(CancellationToken.None);

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
@@ -35,7 +35,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
                 await conn.OpenAsync(connectionCancelToken.Token).ConfigureAwait(false);
 
@@ -55,7 +55,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var invalidConnectionString = ";connection_timeout=0";
             using (var conn = new SnowflakeDbConnection(invalidConnectionString))
             {
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
                 try
                 {

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
@@ -58,7 +58,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
                 await conn.OpenAsync(connectionCancelToken.Token).ConfigureAwait(false);
 
@@ -78,7 +78,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var invalidConnectionString = ";connection_timeout=0";
             using (var conn = new SnowflakeDbConnection(invalidConnectionString))
             {
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
                 try
                 {

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 conn.ConnectionString = loginTimeOut5sec;
 
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 try
                 {
@@ -90,7 +90,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     conn.ConnectionString = loginTimeOut5sec;
 
-                    Assert.Equal(conn.State, ConnectionState.Closed);
+                    Assert.Equal(ConnectionState.Closed, conn.State);
                     Stopwatch stopwatch = Stopwatch.StartNew();
                     try
                     {
@@ -122,7 +122,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Default timeout is 300 sec
                 Assert.Equal(SFSessionHttpClientProperties.DefaultRetryTimeout.TotalSeconds, conn.ConnectionTimeout);
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
             }
         }
 
@@ -137,7 +137,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 conn.ConnectionString = invalidConnectionString;
 
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 try
                 {
                     conn.Open();
@@ -166,7 +166,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                                                  + "connection_timeout=0;account=testFailFast;user=testFailFast;password=testFailFast;disableretry=true;forceretryon404=true;certRevocationCheckMode=enabled;";
                 conn.ConnectionString = invalidConnectionString;
 
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
                 try
                 {
                     conn.Open();

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -141,7 +141,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 "unknown",
                 _fixture.testConfig.password);
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
             try
             {
                 await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -251,7 +251,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 _fixture.testConfig.warehouse,
                 _fixture.testConfig.user,
                 _fixture.testConfig.password);
-            Assert.Equal(conn1.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn1.State);
 
             await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             using (IDbCommand cmd = conn1.CreateCommand())
@@ -308,7 +308,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
@@ -323,7 +323,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
 
             conn.ConnectionString = maxRetryConnStr;
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
@@ -424,7 +424,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             conn.ConnectionString = _fixture.ConnectionString + ";invalidProperty=invalidvalue;";
 
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
@@ -436,12 +436,12 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         {
             conn.ConnectionString = _fixture.ConnectionString;
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -468,12 +468,12 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using var conn = new SnowflakeDbConnection();
         conn.ConnectionString = _fixture.ConnectionString;
 
-        Assert.Equal(conn.State, ConnectionState.Closed);
+        Assert.Equal(ConnectionState.Closed, conn.State);
 
         await conn.OpenAsync(CancellationToken);
 
         Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
-        Assert.Equal(conn.State, ConnectionState.Open);
+        Assert.Equal(ConnectionState.Open, conn.State);
 
         var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(databaseName));
         Assert.Equal(2043, ex.ErrorCode); // object does not exist
@@ -490,12 +490,12 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using var conn = new SnowflakeDbConnection();
         conn.ConnectionString = _fixture.ConnectionString;
 
-        Assert.Equal(conn.State, ConnectionState.Closed);
+        Assert.Equal(ConnectionState.Closed, conn.State);
 
         await conn.OpenAsync(CancellationToken);
 
         Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
-        Assert.Equal(conn.State, ConnectionState.Open);
+        Assert.Equal(ConnectionState.Open, conn.State);
 
         var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(invalidDatabaseName, CancellationToken));
         Assert.Equal(1003, ex.ErrorCode); // unable to parse sql
@@ -514,7 +514,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             if (string.IsNullOrEmpty(_fixture.testConfig.host))
             {
                 await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-                Assert.Equal(conn.State, ConnectionState.Open);
+                Assert.Equal(ConnectionState.Open, conn.State);
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
@@ -544,7 +544,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 _fixture.testConfig.account
             );
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             using (var command = conn.CreateCommand())
             {
@@ -842,7 +842,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
 
             conn.ConnectionString = infiniteLoginTimeOut;
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             CancellationTokenSource connectionCancelToken = new CancellationTokenSource();
             var openTask = conn.OpenAsync(connectionCancelToken.Token);
@@ -880,7 +880,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 timeoutSec);
             conn.ConnectionString = loginTimeOut5sec;
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
@@ -940,7 +940,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 conn.ConnectionString = String.Format(_fixtureHere.ConnectionString + "connection_timeout={0};retry_timeout={1};maxHttpRetries=0",
                     connectionTimeout, retryTimeout);
 
-                Assert.Equal(conn.State, ConnectionState.Closed);
+                Assert.Equal(ConnectionState.Closed, conn.State);
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 try
@@ -980,7 +980,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
 
             conn.ConnectionString = invalidConnectionString;
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
             try
             {
                 await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1010,23 +1010,23 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using (var conn = new SnowflakeDbConnection())
         {
             conn.ConnectionString = _fixture.ConnectionString;
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Close the connection. It's not opened yet, but it should not have any issue
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Open the connection
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             // Close the opened connection
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Close the connection again.
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
         }
     }
 
@@ -1041,23 +1041,23 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using (var conn = new SnowflakeDbConnection())
         {
             conn.ConnectionString = _fixture.ConnectionString;
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Close the connection. It's not opened yet, but it should not have any issue
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Open the connection
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             // Close the opened connection
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Close the connection again.
             await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
         }
     }
 #endif
@@ -1068,11 +1068,11 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using (var conn = new MockSnowflakeDbConnection(new MockCloseSessionException()))
         {
             conn.ConnectionString = _fixture.ConnectionString;
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
 
             // Open the connection
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
 
             // Close the opened connection
             var closeTask = conn.CloseAsync(CancellationToken.None);
@@ -1086,7 +1086,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 Assert.Equal(MockCloseSessionException.SESSION_CLOSE_ERROR,
                     ((SnowflakeDbException)e.InnerException).ErrorCode);
             }
-            Assert.Equal(conn.State, ConnectionState.Open);
+            Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -728,7 +728,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var command = conn.CreateCommand())
         {
             command.CommandText = $"SELECT COUNT(*) FROM DOUBLE_TABLE";
-            Assert.Equal(await command.ExecuteScalarAsync(), 46);
+            Assert.Equal(46, await command.ExecuteScalarAsync());
         }
 
         await conn.CloseAsync(CancellationToken);
@@ -755,7 +755,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var command = conn.CreateCommand())
         {
             command.CommandText = $"SELECT COUNT(*) FROM DOUBLE_TABLE";
-            Assert.Equal(await command.ExecuteScalarAsync(), 46);
+            Assert.Equal(46, await command.ExecuteScalarAsync());
         }
 
         await conn1.CloseAsync(CancellationToken);
@@ -783,7 +783,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 "",
                 "externalbrowser");
 
-            Assert.Equal(conn.State, ConnectionState.Closed);
+            Assert.Equal(ConnectionState.Closed, conn.State);
             await conn.OpenAsync(CancellationToken);
             await conn.CloseAsync(CancellationToken);
             Assert.Equal(ConnectionState.Closed, conn.State);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
@@ -54,14 +54,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 _adapter.Fill(ds);
                 await conn.CloseAsync(CancellationToken.None);
             }
-            Assert.Equal(ds.Tables[0].TableName, "Table");
+            Assert.Equal("Table", ds.Tables[0].TableName);
             Assert.Equal(ds.Tables[0].Rows[0].ItemArray[0], 1L);
             Assert.Equal(ds.Tables[0].Rows[0].ItemArray[1], 2L);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Assert.Equal("1", ds.Tables[0].Rows[0]["col1"].ToString());
-                Assert.Equal(ds.Tables[0].Rows[0]["col2"].ToString(), "2");
+                Assert.Equal("2", ds.Tables[0].Rows[0]["col2"].ToString());
             }
         }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
@@ -678,7 +678,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 catch (SnowflakeDbException e)
                 {
                     // 604 is error code from server meaning query has been canceled
-                    Assert.Equal(e.ErrorCode, 604);
+                    Assert.Equal(604, e.ErrorCode);
                 }
 
                 await conn.CloseAsync(CancellationToken.None);
@@ -1517,7 +1517,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             // Assert
             SpinWait.SpinUntil(() => capturedActivities.Count > 3, TimeSpan.FromSeconds(30));
-            Assert.Equal(capturedActivities.Count, 4);
+            Assert.Equal(4, capturedActivities.Count);
             var capturedActivity1 = capturedActivities.Single(x => x.DisplayName == "Custom activity!");
             var capturedActivity2 = capturedActivities.Single(x => x.DisplayName == "Custom activity 2!");
             var capturedActivity3 = capturedActivities.Single(x => x.DisplayName == "Custom activity 3!");

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
@@ -126,7 +126,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Console.Write("Row %d: %s, %d", row, dataDate.ToString(), dataInt);
                 row++;
             }
-            Assert.Equal(row, 4);
+            Assert.Equal(4, row);
 
             await conn.CloseAsync(CancellationToken.None);
         }
@@ -176,7 +176,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Console.Write("Row %d: %s, %d", row, dataDate.ToString(), dataInt);
                 row++;
             }
-            Assert.Equal(row, 3);
+            Assert.Equal(3, row);
 
             await conn.CloseAsync(CancellationToken.None);
         }

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
@@ -233,7 +233,7 @@ namespace Snowflake.Data.Tests.UnitTests
             InitCacheWithData();
 
             _qcc.Update(null);
-            Assert.Equal(_qcc.GetSize(), 0);
+            Assert.Equal(0, _qcc.GetSize());
         }
 
         [SFFact]
@@ -243,7 +243,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             ResponseQueryContext rsp = JsonConvert.DeserializeObject<ResponseQueryContext>("", JsonUtils.JsonSettings);
             _qcc.Update(rsp);
-            Assert.Equal(_qcc.GetSize(), 0);
+            Assert.Equal(0, _qcc.GetSize());
         }
 
         [SFFact]
@@ -257,7 +257,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Clear _qcc
             _qcc.ClearCache();
-            Assert.Equal(_qcc.GetSize(), 0);
+            Assert.Equal(0, _qcc.GetSize());
 
             ResponseQueryContext rsp = JsonConvert.DeserializeObject<ResponseQueryContext>(json, JsonUtils.JsonSettings);
             _qcc.Update(rsp);
@@ -275,7 +275,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Clear _qcc
             _qcc.ClearCache();
-            Assert.Equal(_qcc.GetSize(), 0);
+            Assert.Equal(0, _qcc.GetSize());
 
             ResponseQueryContext rsp = JsonConvert.DeserializeObject<ResponseQueryContext>(json, JsonUtils.JsonSettings);
             _qcc.Update(rsp);

--- a/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryContextCacheTest.cs
@@ -88,7 +88,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 Assert.Equal(context, elem.Context);
                 i++;
             }
-            Assert.Equal(i, MaxCapacity);
+            Assert.Equal(MaxCapacity, i);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandTest.cs
@@ -51,7 +51,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var thrown = Assert.Throws<AggregateException>(() => commandTask.Wait());
 
             // Assert
-            Assert.Equal(thrown.InnerException.Message, "Unable to execute command due to command text not being set");
+            Assert.Equal("Unable to execute command due to command text not being set", thrown.InnerException.Message);
         }
 
         [SFFact]


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis xUnit2009 - "Constants and literals should be the expected argument"

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
