### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2013

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -422,7 +422,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // assert
             Assert.Equal(2, pool.GetCurrentPoolSize()); // 1 idle session and 1 busy
             var sessionStartTimes = pool.GetIdleSessionsStartTimes();
-            Assert.Equal(1, sessionStartTimes.Count);
+            Assert.Single(sessionStartTimes);
             Assert.True(sessionStartTimes.First() > beforeSleepMillis);
             Assert.True(conn5.SfSession.GetStartTime() > beforeSleepMillis);
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -532,7 +532,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Same(p3, cmd.Parameters[0]);
 
                     cmd.Parameters.Clear();
-                    Assert.Equal(0, cmd.Parameters.Count);
+                    Assert.Empty(cmd.Parameters);
                 }
 
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1283,7 +1283,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         watchClosedFinished.Stop();
 
         // assert
-        Assert.Equal(1, restRequester.CloseRequests.Count);
+        Assert.Single(restRequester.CloseRequests);
         Assert.True(watchClose.Elapsed.Duration() < TimeSpan.FromSeconds(5)); // close executed immediately
         Assert.True(watchClosedFinished.Elapsed.Duration() >= TimeSpan.FromSeconds(10)); // while background task took more time
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
@@ -1527,8 +1527,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(ActivityKind.Client, capturedActivity3.Kind);
 
             Assert.Equal(2, capturedActivity1.Events.Count());
-            Assert.Equal(1, capturedActivity2.Events.Count());
-            Assert.Equal(1, capturedActivity3.Events.Count());
+            Assert.Single(capturedActivity2.Events);
+            Assert.Single(capturedActivity3.Events);
 
             Assert.Equal(conn.SfSession.sessionId, capturedActivity1.GetTagItem(TelemetryTags.SessionId));
             Assert.Equal(conn.SfSession.sessionId, capturedActivity2.GetTagItem(TelemetryTags.SessionId));

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredArraysIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredArraysIT.cs
@@ -180,10 +180,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var array = reader.GetArray<Dictionary<string, string>>(0);
 
                     // assert
-                    Assert.Equal(1, array.Length);
+                    Assert.Single(array);
                     var map = array[0];
                     Assert.NotNull(map);
-                    Assert.Equal(1, map.Count);
+                    Assert.Single(map);
                     Assert.Equal("b", map["a"]);
                 }
             }
@@ -411,7 +411,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var array = reader.GetArray<DateTime>(0);
 
                     // assert
-                    Assert.Equal(1, array.Length);
+                    Assert.Single(array);
                     Assert.Equal(new[] { DateTime.Parse("2024-01-01") }, array);
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredMapsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredMapsIT.cs
@@ -216,7 +216,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var map = reader.GetMap<string, string[]>(0);
 
                     // assert
-                    Assert.Equal(1, map.Count);
+                    Assert.Single(map);
                     Assert.Equal(new string[] { "a" }, map.Keys);
                     Assert.Equal(new string[] { "b", "c" }, map["a"]);
                 }
@@ -242,7 +242,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var map = reader.GetMap<string, List<string>>(0);
 
                     // assert
-                    Assert.Equal(1, map.Count);
+                    Assert.Single(map);
                     Assert.Equal(new string[] { "a" }, map.Keys);
                     Assert.Equal(new string[] { "b", "c" }, map["a"]);
                 }
@@ -268,9 +268,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var map = reader.GetMap<string, Dictionary<string, string>>(0);
 
                     // assert
-                    Assert.Equal(1, map.Count);
+                    Assert.Single(map);
                     var nestedMap = map["a"];
-                    Assert.Equal(1, nestedMap.Count);
+                    Assert.Single(nestedMap);
                     Assert.Equal("c", nestedMap["b"]);
                 }
             }
@@ -298,7 +298,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // assert
                     Assert.NotNull(map);
-                    Assert.Equal(1, map.Count);
+                    Assert.Single(map);
                     Assert.Equal(RemoveWhiteSpaces(expectedValue), RemoveWhiteSpaces(map["x"]));
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredObjectsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredObjectsIT.cs
@@ -324,9 +324,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(new[] { "c" }, objectWithStructuredTypes.ArrayValue);
                     Assert.Equal(new[] { "d", "e" }, objectWithStructuredTypes.IListValue);
                     Assert.Equal(typeof(List<string>), objectWithStructuredTypes.IListValue.GetType());
-                    Assert.Equal(1, objectWithStructuredTypes.MapValue.Count);
+                    Assert.Single(objectWithStructuredTypes.MapValue);
                     Assert.Equal(5, objectWithStructuredTypes.MapValue[3]);
-                    Assert.Equal(1, objectWithStructuredTypes.IMapValue.Count);
+                    Assert.Single(objectWithStructuredTypes.IMapValue);
                     Assert.Equal(13, objectWithStructuredTypes.IMapValue[8]);
                     Assert.Equal(typeof(Dictionary<int, int>), objectWithStructuredTypes.IMapValue.GetType());
                 }

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggerManagerTest.cs
@@ -206,7 +206,7 @@ namespace Snowflake.Data.Tests.UnitTests.Logger
         {
             Assert.True(Directory.Exists(directoryLogPath));
             var files = Directory.GetFiles(directoryLogPath);
-            Assert.Equal(1, files.Length);
+            Assert.Single(files);
             return files.First();
         }
 

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
@@ -25,13 +25,13 @@ namespace Snowflake.Data.Tests
         [SFFact]
         public void TestDefaultDbParameterCollection()
         {
-            Assert.Equal(0, _parameterCollection.Count);
+            Assert.Empty(_parameterCollection);
         }
 
         [SFFact]
         public void TestDbParameterCollectionCount()
         {
-            Assert.Equal(0, _parameterCollection.Count);
+            Assert.Empty(_parameterCollection);
 
             SnowflakeDbParameter parameter = new SnowflakeDbParameter();
 
@@ -96,7 +96,7 @@ namespace Snowflake.Data.Tests
             Assert.Equal(PARAM_COUNT, _parameterCollection.Count);
 
             _parameterCollection.Clear();
-            Assert.Equal(0, _parameterCollection.Count);
+            Assert.Empty(_parameterCollection);
         }
 
         [SFTheory]

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -416,7 +416,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // assert
             Assert.NotNull(header);
-            Assert.Equal(1, header.Count());
+            Assert.Single(header);
             Assert.Equal(HeaderValue, header.First());
         }
 
@@ -435,7 +435,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // assert
             Assert.NotNull(header);
-            Assert.Equal(1, header.Count());
+            Assert.Single(header);
             Assert.Equal(HeaderValue, header.First());
         }
 

--- a/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFSessionTest.cs
@@ -205,7 +205,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Equal("test\"with'quotations{}", loginRequest.data.password);
 
@@ -229,7 +229,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Equal(passcode, loginRequest.data.passcode);
             Assert.Equal("passcode", loginRequest.data.extAuthnDuoMethod);
@@ -248,7 +248,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Equal(passcode, loginRequest.data.passcode);
             Assert.Equal("passcode", loginRequest.data.extAuthnDuoMethod);
@@ -266,7 +266,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Null(loginRequest.data.passcode);
             Assert.Equal("passcode", loginRequest.data.extAuthnDuoMethod);
@@ -283,7 +283,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Null(loginRequest.data.passcode);
             Assert.Equal("push", loginRequest.data.extAuthnDuoMethod);
@@ -300,7 +300,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests[0];
             Assert.Null(loginRequest.data.passcode);
             Assert.Equal("push", loginRequest.data.extAuthnDuoMethod);
@@ -317,7 +317,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests.Dequeue();
             Assert.Null(loginRequest.data.passcode);
             Assert.True(loginRequest.data.SessionParameters.TryGetValue(SFSessionParameter.CLIENT_REQUEST_MFA_TOKEN, out var value) && (bool)value);
@@ -340,7 +340,7 @@ namespace Snowflake.Data.Tests.UnitTests
             sfSession.Open();
 
             // assert
-            Assert.Equal(1, restRequester.LoginRequests.Count);
+            Assert.Single(restRequester.LoginRequests);
             var loginRequest = restRequester.LoginRequests.Dequeue();
             Assert.Equal(SecureStringHelper.Decode(sfSession._mfaToken), testToken);
             Assert.Null(loginRequest.data.passcode);

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -294,7 +294,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
-            Assert.Equal(1, cachedContext.Entries.Count);
+            Assert.Single(cachedContext.Entries);
             Assert.Equal(42, cachedContext.Entries[0].Id);
         }
 
@@ -310,7 +310,7 @@ namespace Snowflake.Data.Tests.UnitTests
                 }
             };
             session.UpdateQueryContextCache(preExistingContext);
-            Assert.Equal(1, session.GetQueryContextRequest().Entries.Count);
+            Assert.Single(session.GetQueryContextRequest().Entries);
 
             var response = new QueryExecResponse
             {
@@ -331,7 +331,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
-            Assert.Equal(1, cachedContext.Entries.Count);
+            Assert.Single(cachedContext.Entries);
             Assert.Equal(99, cachedContext.Entries[0].Id);
         }
 
@@ -347,7 +347,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
-            Assert.Equal(1, cachedContext.Entries.Count);
+            Assert.Single(cachedContext.Entries);
             Assert.Equal(42, cachedContext.Entries[0].Id);
         }
 
@@ -364,7 +364,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
-            Assert.Equal(1, cachedContext.Entries.Count);
+            Assert.Single(cachedContext.Entries);
             Assert.Equal(42, cachedContext.Entries[0].Id);
         }
 

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionOrCreationTokensTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionOrCreationTokensTest.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             // act
             var backgroundCreationTokens = sessionOrTokens.BackgroundSessionCreationTokens();
 
-            Assert.Equal(0, backgroundCreationTokens.Count);
+            Assert.Empty(backgroundCreationTokens);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -293,14 +293,14 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var contextElement = new QueryContextElement(123, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 1, "context");
             var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new(contextElement) } };
             session.UpdateQueryContextCache(context);
-            Assert.Equal(1, session.GetQueryContextRequest().Entries.Count);
+            Assert.Single(session.GetQueryContextRequest().Entries);
 
             // act
             var isSessionReturnedToPool = pool.AddSession(session, false);
 
             // assert
             Assert.True(isSessionReturnedToPool);
-            Assert.Equal(0, session.GetQueryContextRequest().Entries.Count);
+            Assert.Empty(session.GetQueryContextRequest().Entries);
         }
 
         [SFFact]
@@ -313,14 +313,14 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var contextElement = new QueryContextElement(123, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 1, "context");
             var context = new ResponseQueryContext { Entries = new List<ResponseQueryContextElement> { new(contextElement) } };
             session.UpdateQueryContextCache(context);
-            Assert.Equal(1, session.GetQueryContextRequest().Entries.Count);
+            Assert.Single(session.GetQueryContextRequest().Entries);
 
             // act
             var isSessionReturnedToPool = pool.AddSession(session, false);
 
             // assert
             Assert.True(isSessionReturnedToPool);
-            Assert.Equal(0, session.GetQueryContextRequest().Entries.Count);
+            Assert.Empty(session.GetQueryContextRequest().Entries);
         }
 
         [SFFact]
@@ -404,7 +404,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             pool.ClearIdleSessions();
 
             // assert - pool must be empty even though close() threw for each session
-            Assert.Equal(0, pool._idleSessions.Count);
+            Assert.Empty(pool._idleSessions);
         }
 
         [SFFact]
@@ -426,7 +426,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             pool.ClearIdleSessions();
 
             // assert - pool must be empty and second session's close should have been attempted
-            Assert.Equal(0, pool._idleSessions.Count);
+            Assert.Empty(pool._idleSessions);
             Assert.Null(normalSession.sessionToken);
         }
 
@@ -453,7 +453,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // assert — invalidated session must be rejected
             Assert.False(wasAdded);
-            Assert.Equal(0, pool._idleSessions.Count);
+            Assert.Empty(pool._idleSessions);
         }
 
         [SFFact]
@@ -470,7 +470,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // assert - valid session should be returned to pool
             Assert.True(wasAdded);
-            Assert.Equal(1, pool._idleSessions.Count);
+            Assert.Single(pool._idleSessions);
         }
 
         [SFFact]
@@ -486,7 +486,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // act & assert - DestroyPool should not throw even if session.close() fails
             pool.DestroyPool();
-            Assert.Equal(0, pool._idleSessions.Count);
+            Assert.Empty(pool._idleSessions);
         }
 
         [SFFact]
@@ -502,7 +502,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
             // act & assert - ClearSessions should not throw even if session.close() fails
             pool.ClearSessions();
-            Assert.Equal(0, pool._idleSessions.Count);
+            Assert.Empty(pool._idleSessions);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -328,7 +328,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
                 activity?.SetSuccess();
             }
 
-            Assert.Equal(1, customActivities.Count);
+            Assert.Single(customActivities);
             var captured = customActivities.Single();
             Assert.Equal("MultiStepOp", captured.OperationName);
             Assert.Equal(ActivityStarter.ClientDefinedTelemetrySourceName, captured.Source.Name);
@@ -379,7 +379,7 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
                 activity?.SetSuccess();
             }
 
-            Assert.Equal(1, customActivities.Count);
+            Assert.Single(customActivities);
             var captured = customActivities.Single();
             Assert.Equal("snowflake", captured.GetTagItem(TelemetryTags.DbSystem));
             Assert.Equal("telemetry-test-session", captured.GetTagItem(TelemetryTags.SessionId));

--- a/Snowflake.Data.Tests/UnitTests/Tools/OsReleaseReaderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/OsReleaseReaderTest.cs
@@ -105,7 +105,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
             // assert
             Assert.NotNull(result);
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [SFFact]
@@ -116,7 +116,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
             // assert
             Assert.NotNull(result);
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [SFFact]
@@ -170,7 +170,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var result = OsReleaseReader.ParseOsReleaseContents(contents);
 
             // assert
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.Equal("Valid", result["NAME"]);
         }
 
@@ -205,7 +205,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var result = OsReleaseReader.ParseOsReleaseContents(contents);
 
             // assert
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.Equal("", result["NAME"]);
         }
 
@@ -224,7 +224,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var result = OsReleaseReader.ParseOsReleaseContents(contents);
 
             // assert
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
@@ -330,7 +330,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             var bytes = _fixture.UnixOperations.ReadAllBytes(filePath, s => { });
 
             // assert
-            Assert.Equal(0, bytes.Length);
+            Assert.Empty(bytes);
         }
 
         [SFFact(SkipCondition.SkipOnWindows)]


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis xUnit2013 - "Do not use equality check to check for collection size."

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
