### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2017 and xUnit1012

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -907,7 +907,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData(ResultFormat.ARROW, SFTableType.Standard, SFDataType.TIMESTAMP_LTZ, 6, DbType.DateTimeOffset, FormatYmdHmsZ, "Europe/Warsaw")]
         [InlineData(ResultFormat.ARROW, SFTableType.Standard, SFDataType.TIMESTAMP_LTZ, 6, DbType.DateTimeOffset, FormatYmdHmsZ, "Asia/Tokyo")]
 
-        public async Task TestDateTimeBinding(ResultFormat resultFormat, SFTableType tableType, SFDataType columnType, Int32? columnPrecision, DbType bindingType, string comparisonFormat, string timeZone)
+        public async Task TestDateTimeBinding(ResultFormat resultFormat, SFTableType tableType, SFDataType columnType, Int32? columnPrecision, DbType bindingType, string comparisonFormat, string? timeZone)
         {
             // Arrange
             string[] timestamps =

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -48,7 +48,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.Equal(ConnectionString1, sessionPool.ConnectionString);
-            Assert.Equal(null, sessionPool.Password);
+            Assert.Null(sessionPool.Password);
         }
 
         [SFFact]
@@ -113,7 +113,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.Equal(ConnectionString1, sfSession.ConnectionString);
-            Assert.Equal(null, sfSession.PropertiesContext.Password);
+            Assert.Null(sfSession.PropertiesContext.Password);
         }
 
         [SFFact]
@@ -124,7 +124,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Assert
             Assert.Equal(ConnectionString1, sfSession.ConnectionString);
-            Assert.Equal(null, sfSession.PropertiesContext.Password);
+            Assert.Null(sfSession.PropertiesContext.Password);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CrlTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CrlTest.cs
@@ -37,7 +37,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.Equivalent(expectedCrlDistributionPoints, crl.IssuerDistributionPoints);
             Assert.Contains(DigiCertRevokedCertSerialNumber, crl.RevokedCertificates);
             Assert.True(crl.IsRevoked(DigiCertRevokedCertSerialNumber));
-            Assert.False(crl.RevokedCertificates.Contains(DigiCertUnrevokedCertSerialNumber));
+            Assert.DoesNotContain(DigiCertUnrevokedCertSerialNumber, crl.RevokedCertificates);
             Assert.False(crl.IsRevoked(DigiCertUnrevokedCertSerialNumber));
             Assert.False(crl.NeedsReplacement(now, TimeSpan.FromDays(1)));
         }

--- a/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbCommandBuilderTest.cs
@@ -24,7 +24,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestCommandBuilderWithoutAdapter()
         {
             builder = new SnowflakeDbCommandBuilder();
-            Assert.Equal(null, builder.DataAdapter);
+            Assert.Null(builder.DataAdapter);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterTest.cs
@@ -104,7 +104,7 @@ namespace Snowflake.Data.Tests
         public void TestDbParameterSourceColumn(SFDataType SFDataType)
         {
             _parameter = new SnowflakeDbParameter(1, SFDataType);
-            Assert.Equal(null, _parameter.SourceColumn);
+            Assert.Null(_parameter.SourceColumn);
 
             string col = "col";
             _parameter.SourceColumn = col;
@@ -127,7 +127,7 @@ namespace Snowflake.Data.Tests
         public void TestDbParameterValue(SFDataType SFDataType)
         {
             _parameter = new SnowflakeDbParameter(1, SFDataType);
-            Assert.Equal(null, _parameter.Value);
+            Assert.Null(_parameter.Value);
 
             object obj = new object();
             _parameter.Value = obj;

--- a/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFGCSClientTest.cs
@@ -340,11 +340,11 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [SFTheory]
-        [InlineData("us-central1", null, null, "https://storage.googleapis.com/mock-customer-stage/mock-id/tables/mock-key/")]
-        [InlineData("us-central1", "example.com", null, "https://example.com/mock-customer-stage/mock-id/tables/mock-key/")]
-        [InlineData("us-central1", "https://example.com", null, "https://example.com/mock-customer-stage/mock-id/tables/mock-key/")]
+        [InlineData("us-central1", null, false, "https://storage.googleapis.com/mock-customer-stage/mock-id/tables/mock-key/")]
+        [InlineData("us-central1", "example.com", false, "https://example.com/mock-customer-stage/mock-id/tables/mock-key/")]
+        [InlineData("us-central1", "https://example.com", false, "https://example.com/mock-customer-stage/mock-id/tables/mock-key/")]
         [InlineData("us-central1", null, true, "https://storage.us-central1.rep.googleapis.com/mock-customer-stage/mock-id/tables/mock-key/")]
-        [InlineData("me-central2", null, null, "https://storage.me-central2.rep.googleapis.com/mock-customer-stage/mock-id/tables/mock-key/")]
+        [InlineData("me-central2", null, false, "https://storage.me-central2.rep.googleapis.com/mock-customer-stage/mock-id/tables/mock-key/")]
         public void TestUseUriWithRegionsWhenNeeded(string region, string endPoint, bool useRegionalUrl, string expectedRequestUri)
         {
             var fileMetadata = new SFFileMetadata()

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -370,7 +370,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [SFTheory]
-        [InlineData(HttpStatusCode.NotFound, null, 0)]
+        [InlineData(HttpStatusCode.NotFound, default(HttpStatusCode), 0)]
         public async Task TestUploadOneFileAsyncThrowsForUnknownErrors(HttpStatusCode httpStatusCode, HttpStatusCode httpStatusCodeAfterRetry, int expectedResultStatus)
         {
             // Arrange

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -276,7 +276,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [SFTheory]
-        [InlineData(HttpStatusCode.OK, null, 4)]
+        [InlineData(HttpStatusCode.OK, default(HttpStatusCode), 4)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.OK, 1)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.BadRequest, 6)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.Unauthorized, 5)]
@@ -298,7 +298,7 @@ namespace Snowflake.Data.Tests.UnitTests
         }
 
         [SFTheory]
-        [InlineData(HttpStatusCode.OK, null, 4)]
+        [InlineData(HttpStatusCode.OK, default(HttpStatusCode), 4)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.OK, 1)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.BadRequest, 6)]
         [InlineData(HttpStatusCode.NotFound, HttpStatusCode.Unauthorized, 5)]
@@ -355,7 +355,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
 
         [SFTheory]
-        [InlineData(HttpStatusCode.NotFound, null, 0)]
+        [InlineData(HttpStatusCode.NotFound, default(HttpStatusCode), 0)]
         public void TestUploadOneFileThrowsForUnknownErrors(HttpStatusCode httpStatusCode, HttpStatusCode httpStatusCodeAfterRetry, int expectedResultStatus)
         {
             // Arrange

--- a/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
@@ -53,13 +53,13 @@ namespace Snowflake.Data.Tests.UnitTests
             var chunk = PrepareChunkAsync(data, 3, 2).Result;
 
             chunk.Next();
-            Assert.Equal(null, chunk.ExtractCell(0).SafeToString());
+            Assert.Null(chunk.ExtractCell(0).SafeToString());
             Assert.Equal("1.234", chunk.ExtractCell(1).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(2).SafeToString());
+            Assert.Null(chunk.ExtractCell(2).SafeToString());
 
             chunk.Next();
             Assert.Equal("2", chunk.ExtractCell(0).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(1).SafeToString());
+            Assert.Null(chunk.ExtractCell(1).SafeToString());
             Assert.Equal("fghi", chunk.ExtractCell(2).SafeToString());
         }
 
@@ -70,13 +70,13 @@ namespace Snowflake.Data.Tests.UnitTests
             var chunk = PrepareChunkAsync(data, 3, 2).Result;
 
             chunk.Next();
-            Assert.Equal(null, chunk.ExtractCell(0).SafeToString());
+            Assert.Null(chunk.ExtractCell(0).SafeToString());
             Assert.Equal("2019-08-21T11:58:00", chunk.ExtractCell(1).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(2).SafeToString());
+            Assert.Null(chunk.ExtractCell(2).SafeToString());
 
             chunk.Next();
             Assert.Equal("2", chunk.ExtractCell(0).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(1).SafeToString());
+            Assert.Null(chunk.ExtractCell(1).SafeToString());
             Assert.Equal("fghi", chunk.ExtractCell(2).SafeToString());
         }
 
@@ -89,11 +89,11 @@ namespace Snowflake.Data.Tests.UnitTests
             chunk.Next();
             Assert.Equal("\\åäö\nÅÄÖ\r", chunk.ExtractCell(0).SafeToString());
             Assert.Equal("1.234", chunk.ExtractCell(1).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(2).SafeToString());
+            Assert.Null(chunk.ExtractCell(2).SafeToString());
 
             chunk.Next();
             Assert.Equal("2", chunk.ExtractCell(0).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(1).SafeToString());
+            Assert.Null(chunk.ExtractCell(1).SafeToString());
             Assert.Equal("fghi", chunk.ExtractCell(2).SafeToString());
         }
 
@@ -107,11 +107,11 @@ namespace Snowflake.Data.Tests.UnitTests
             chunk.Next();
             Assert.Equal("åäö\nÅÄÖ\r", chunk.ExtractCell(0).SafeToString());
             Assert.Equal("1.234", chunk.ExtractCell(1).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(2).SafeToString());
+            Assert.Null(chunk.ExtractCell(2).SafeToString());
 
             chunk.Next();
             Assert.Equal("2", chunk.ExtractCell(0).SafeToString());
-            Assert.Equal(null, chunk.ExtractCell(1).SafeToString());
+            Assert.Null(chunk.ExtractCell(1).SafeToString());
             Assert.Equal(longstring, chunk.ExtractCell(2).SafeToString());
         }
 
@@ -236,7 +236,7 @@ namespace Snowflake.Data.Tests.UnitTests
             chunk.Clear();
 
             Assert.Equal(0, chunk.ChunkIndex);
-            Assert.Equal(null, chunk.Url);
+            Assert.Null(chunk.Url);
             Assert.Equal(0, chunk.RowCount);
             Assert.Equal(0, chunk.UncompressedSize);
             Assert.Equal(0, chunk.data.blockCount);


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis xUnit2017 "Do not use Contains() to check if a value exists in a collection" and xUnit2012 - "Null should not be used for value type parameters"

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
