### PR TITLE
SNOW-3560694 Post-CI-stabilization cleanup - fix xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
@@ -393,7 +393,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             await conn2.CloseAsync(CancellationToken.None);
         }
 
-        public static Task ConcurrentPoolingAsyncHelper(string connectionString, bool closeConnection, int tasksCount, int connectionsInTask, int abandonedConnectionsCount)
+        internal static Task ConcurrentPoolingAsyncHelper(string connectionString, bool closeConnection, int tasksCount, int connectionsInTask, int abandonedConnectionsCount)
         {
             var tasks = new Task[tasksCount + 1];
             for (int i = 0; i < tasksCount; i++)

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -830,7 +830,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        public async TaskOrValueTask DisposeAsync()
+        private async TaskOrValueTask DisposeAsync()
         {
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
@@ -857,7 +857,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
         }
 
-        public async TaskOrValueTask InitializeAsync()
+        private async TaskOrValueTask InitializeAsync()
         {
             // Base object's names on on worker thread id
             var suffix = Guid.NewGuid().ToString("N");

--- a/Snowflake.Data.Tests/PackageTests/MiniCorePackageIT.cs
+++ b/Snowflake.Data.Tests/PackageTests/MiniCorePackageIT.cs
@@ -32,7 +32,8 @@ namespace Snowflake.Data.Tests.PackageTests
         private string _tempDir;
         private string _artifactsDir;
         private string _repoRoot;
-        public void Setup()
+
+        private void Setup()
         {
             _repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
             _artifactsDir = Path.Combine(_repoRoot, "artifacts");
@@ -41,7 +42,8 @@ namespace Snowflake.Data.Tests.PackageTests
             Directory.CreateDirectory(_artifactsDir);
             Directory.CreateDirectory(_tempDir);
         }
-        public void TearDown()
+
+        private void TearDown()
         {
             try { Directory.Delete(_tempDir, true); } catch { }
         }

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -16,7 +16,7 @@
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <OutputType Condition="'$(OldXunit)' != 'True'">Exe</OutputType>
         <!-- SNOW-3560694 !-->
-        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003;xUnit2002;xUnit2008;xUnit1026;xUnit3003;xUnit1026;xUnit1025</NoWarn>
+        <NoWarn>$(NoWarn);xUnit2009;xUnit1013;xUnit2004;xUnit2000;xUnit2013;xUnit2017;xUnit1012;xUnit2003</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="wiremock\**\*.*">

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/ChallengeProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/ChallengeProviderTest.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
 
             // assert
             Assert.Equal(32, state.Length);
-            Assert.True(_onlyDigitsOrNumbers.IsMatch(state));
+            Assert.Matches(_onlyDigitsOrNumbers, state);
         }
 
         [SFFact]
@@ -29,7 +29,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
 
             // assert
             Assert.InRange(codeVerifier.Length, 43, 128);
-            Assert.True(_onlyDigitsOrNumbers.IsMatch(codeVerifier));
+            Assert.Matches(_onlyDigitsOrNumbers, codeVerifier);
         }
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Configuration/EasyLoggingConfigParserTest.cs
@@ -31,7 +31,7 @@ namespace Snowflake.Data.Tests.UnitTests.Configuration
         {
         }
 
-        public static void BeforeAll()
+        internal static void BeforeAll()
         {
             if (!Directory.Exists(s_workingDirectory))
             {

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileImplTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SFCredentialManagerFileImplTest.cs
@@ -36,7 +36,8 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         private static readonly string s_customLockPath = Path.Combine(CustomJsonDir, SFCredentialManagerFileStorage.CredentialCacheLockName);
 
         private const int UserId = 1;
-        public void SetUp()
+
+        private void SetUp()
         {
             t_fileOperations = new Mock<FileOperations>();
             t_directoryOperations = new Mock<DirectoryOperations>();

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -9,7 +9,7 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
 {
     public class SnowflakeCredentialManagerFactoryTest : IDisposable
     {
-        public void TearDown()
+        private void TearDown()
         {
             SnowflakeCredentialManagerFactory.UseDefaultCredentialManager();
         }

--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -209,6 +209,9 @@ namespace Snowflake.Data.Tests.UnitTests
         public void TestDefaultConnectionLimitIsChangedToDefaultWhenUnder50()
         {
             // arrange
+#if NET9_0_OR_GREATER
+            Skip.When(true, "TODO SNOW-3662960");
+#endif
             var originalLimit = ServicePointManager.DefaultConnectionLimit;
             ServicePointManager.DefaultConnectionLimit = 49;
 

--- a/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggingStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Logger/EasyLoggingStarterTest.cs
@@ -142,18 +142,19 @@ namespace Snowflake.Data.Tests.UnitTests.Session
 
 
         [SFTheory(SkipCondition.SkipOnWindows)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupExecute)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite | FileAccessPermissions.GroupExecute)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupReadWriteExecute | FileAccessPermissions.OtherRead | FileAccessPermissions.OtherExecute)]
-        [InlineData(FileAccessPermissions.AllPermissions)]
-        [InlineData(FileAccessPermissions.GroupReadWriteExecute)]
-        [InlineData(FileAccessPermissions.OtherReadWriteExecute)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead)]
-        [InlineData(FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead)]
-        public void TestThatThrowsErrorWhenLogDirectoryHasInvalidPermissions(FileAccessPermissions invalidPermissions)
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupExecute, "User RWX + Group RX")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite | FileAccessPermissions.GroupExecute, "User RWX + Group RWX")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupReadWriteExecute | FileAccessPermissions.OtherRead | FileAccessPermissions.OtherExecute, "User RWX + Group RWX + Other RX")]
+        [InlineData(FileAccessPermissions.AllPermissions, "All")]
+        [InlineData(FileAccessPermissions.GroupReadWriteExecute, "Group RWX")]
+        [InlineData(FileAccessPermissions.OtherReadWriteExecute, "Other RWX")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead, "User RWX + Other R")]
+        [InlineData(FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite, "User RW")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead, "User RWX + Group R")]
+        public void TestThatThrowsErrorWhenLogDirectoryHasInvalidPermissions(FileAccessPermissions invalidPermissions, string log)
         {
             // arrange
+            Console.WriteLine($@"Executing {nameof(TestThatThrowsErrorWhenLogDirectoryHasInvalidPermissions)} with {log}..");
             t_easyLoggingProvider
                 .Setup(provider => provider.ProvideConfig(ConfigPath))
                 .Returns(s_configWithInfoLevel);

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CrlCacheManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CrlCacheManagerTest.cs
@@ -24,7 +24,8 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
 
         const string CrlUrl1 = "http://snowflakecomputing.com/crl1.crl";
         const string CrlUrl2 = "http://snowflakecomputing.com/crl2.crl";
-        public void SetUp()
+
+        private void SetUp()
         {
             var cacheDir = GetCrlCacheDirectory();
             if (Directory.Exists(cacheDir))

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CrlRepositoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CrlRepositoryTest.cs
@@ -12,7 +12,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             SetUp();
         }
 
-        public void SetUp()
+        private void SetUp()
         {
             Environment.SetEnvironmentVariable("SF_CRL_CACHE_REMOVAL_DELAY", null);
         }

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CrlTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CrlTest.cs
@@ -158,6 +158,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.True(isRevoked);
         }
 
+#pragma warning disable xUnit1026
         [SFTheory]
         [InlineData(true)]
         [InlineData(false)]
@@ -215,6 +216,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.True(isRevoked, "Certificate should be found in the revocation list");
 #endif
         }
+#pragma warning restore xUnit1026
 
 #if NET8_0_OR_GREATER
         private static X509Certificate2 BuildSelfSignedCertificate(int runNo)

--- a/Snowflake.Data.Tests/UnitTests/Revocation/FileCrlCacheTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/FileCrlCacheTest.cs
@@ -447,11 +447,10 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
         }
 
         [SFTheory(SkipCondition.SkipOnWindows)]
-        [InlineData(1, 0, 0, 0)]
-        [InlineData(0, 1, 0, 0)]
-        [InlineData(0, 0, 1, 0)]
-        [InlineData(0, 0, 1, 1)]
-        public void TestWithMocksUnixCrlShouldNotBeSavedIfFailedToSetSecurePermissions(long changeDirOwnerResult, long changeDirPermissionsResult, long changeFileOwnerResult, long changeFilePermissionsResult)
+        [InlineData(1, 0, 0)]
+        [InlineData(0, 1, 0)]
+        [InlineData(0, 0, 1)]
+        public void TestWithMocksUnixCrlShouldNotBeSavedIfFailedToSetSecurePermissions(long changeDirOwnerResult, long changeDirPermissionsResult, long changeFileOwnerResult)
         {
             // arrange
             var crl = CreateCrl();

--- a/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDbParameterCollectionTest.cs
@@ -164,9 +164,8 @@ namespace Snowflake.Data.Tests
             Assert.Equal(PARAM_COUNT - 1, _parameterCollection.IndexOf(paramName));
         }
 
-        [SFTheory]
-        [MemberData(nameof(AllSFDataTypes))]
-        public void TestDbParameterCollectionIndexOfNameNotExists(SFDataType SFDataType)
+        [SFFact]
+        public void TestDbParameterCollectionIndexOfNameNotExists()
         {
             int expectedParameterIndex = -1;
             string paramName = "1";

--- a/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFFileTransferAgentTests.cs
@@ -78,7 +78,7 @@ namespace Snowflake.Data.Tests.UnitTests
             AfterEachTest();
         }
 
-        public void BeforeEachTest()
+        private void BeforeEachTest()
         {
             // Base object's names on worker thread id
             var threadSuffix = Thread.CurrentThread.ManagedThreadId.ToString()?.Replace('#', '_');
@@ -127,7 +127,8 @@ namespace Snowflake.Data.Tests.UnitTests
 
             _session = new SFSession(ConnectionStringMock, new SessionPropertiesContext());
         }
-        public void AfterEachTest()
+
+        private void AfterEachTest()
         {
             // Delete stage directory recursively
             if (Directory.Exists(t_locationStage))
@@ -665,7 +666,7 @@ namespace Snowflake.Data.Tests.UnitTests
             TestGetFilePathFromPutCommand("PUT 'file://" + s_filePathWithSpaces + "'  @TestStage", s_filePathWithSpaces);
         }
 
-        public void TestGetFilePathFromPutCommand(string query, string expectedFilePath)
+        private void TestGetFilePathFromPutCommand(string query, string expectedFilePath)
         {
             var actualFilePath = SFFileTransferAgent.getFilePathFromPutCommand(query);
             Assert.Equal(expectedFilePath, actualFilePath);

--- a/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SecretDetectorTest.cs
@@ -16,7 +16,7 @@ namespace Snowflake.Data.Tests.UnitTests
             mask = SecretDetector.MaskSecrets(null);
         }
 
-        public void BasicMasking(string text)
+        private void BasicMasking(string text)
         {
             mask = SecretDetector.MaskSecrets(text);
             Assert.False(mask.isMasked);
@@ -51,7 +51,7 @@ namespace Snowflake.Data.Tests.UnitTests
             Assert.Equal("Test exception", mask.errStr);
         }
 
-        public void BasicMasking(string text, string expectedText)
+        private void BasicMasking(string text, string expectedText)
         {
             mask = SecretDetector.MaskSecrets(text);
             Assert.True(mask.isMasked);

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -122,7 +122,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var poolIdentification = pool.PoolIdentificationBasedOnInternalId;
 
             // assert
-            Assert.True(poolIdRegex.IsMatch(poolIdentification));
+            Assert.Matches(poolIdRegex, poolIdentification);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPropertiesWithDefaultValuesExtractorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPropertiesWithDefaultValuesExtractorTest.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
         }
 
         [SFFact]
-        public void TestReturnDefaultValueWhenValueIsMissing( )
+        public void TestReturnDefaultValueWhenValueIsMissing()
         {
             // arrange
             var properties = SFSessionProperties.ParseConnectionString($"account=test;user=test;password=test", new SessionPropertiesContext());

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPropertiesWithDefaultValuesExtractorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPropertiesWithDefaultValuesExtractorTest.cs
@@ -27,11 +27,8 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             Assert.Equal(15, value);
         }
 
-        [SFTheory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestReturnDefaultValueWhenValueIsMissing(
-            bool failOnWrongValue)
+        [SFFact]
+        public void TestReturnDefaultValueWhenValueIsMissing( )
         {
             // arrange
             var properties = SFSessionProperties.ParseConnectionString($"account=test;user=test;password=test", new SessionPropertiesContext());

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ActivityStarterTest.cs
@@ -102,7 +102,6 @@ public sealed class ActivityStarterTest : IDisposable
         Assert.Equal("ERROR", _sessionIdCapturedActivitiesMap[session.sessionId].GetTagItem(TelemetryTags.StatusCode));
 
         var exceptionEvent = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "exception");
-        Assert.NotNull(exceptionEvent);
         Assert.Equal(typeof(AbandonedMutexException).FullName,
             exceptionEvent.Tags.First(t => t.Key == TelemetryTags.Exception).Value);
     }
@@ -268,7 +267,7 @@ public sealed class ActivityStarterTest : IDisposable
 
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
         var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "TestEvent");
-        Assert.NotNull(evt);
+        Assert.NotEqual(default, evt);
     }
 
     [SFFact]
@@ -285,7 +284,6 @@ public sealed class ActivityStarterTest : IDisposable
 
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
         var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "StepComplete");
-        Assert.NotNull(evt);
         Assert.Equal("validation", evt.Tags.First(t => t.Key == "step.name").Value);
         Assert.Equal(42, evt.Tags.First(t => t.Key == "step.duration_ms").Value);
     }
@@ -302,7 +300,6 @@ public sealed class ActivityStarterTest : IDisposable
 
         Assert.True(_sessionIdCapturedActivitiesMap.ContainsKey(session.sessionId));
         var evt = _sessionIdCapturedActivitiesMap[session.sessionId].Events.FirstOrDefault(e => e.Name == "SimpleEvent");
-        Assert.NotNull(evt);
         Assert.False(evt.Tags.Any());
     }
 

--- a/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
@@ -14,13 +14,14 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         static readonly string s_directoryFullName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
         [SFTheory(SkipCondition.SkipOnWindows)]
-        [InlineData(FileAccessPermissions.UserWrite)]
-        [InlineData(FileAccessPermissions.UserRead)]
-        [InlineData(FileAccessPermissions.UserExecute)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute)]
-        public void TestSafeDirectory(FileAccessPermissions securePermissions)
+        [InlineData(FileAccessPermissions.UserWrite, "User W")]
+        [InlineData(FileAccessPermissions.UserRead, "User R")]
+        [InlineData(FileAccessPermissions.UserExecute, "User X")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute, "User RWX")]
+        public void TestSafeDirectory(FileAccessPermissions securePermissions, string log)
         {
             // arrange
+            Console.WriteLine($@"Executing {nameof(TestSafeDirectory)} with {log}..");
             var dirInfo = new DirectoryUnixInformation(s_directoryFullName, true, securePermissions, UserId);
 
             // act

--- a/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
@@ -60,12 +60,13 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         }
 
         [SFTheory(SkipCondition.SkipOnWindows)]
-        [InlineData(FileAccessPermissions.UserRead)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead)]
-        public void TestUnsafeExactlyPermissions(FileAccessPermissions unsecurePermissions)
+        [InlineData(FileAccessPermissions.UserRead, "User R")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead, "User RWX + Group R")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead, "User RWX + Other R")]
+        public void TestUnsafeExactlyPermissions(FileAccessPermissions unsecurePermissions, string log)
         {
             // arrange
+            Console.WriteLine($@"Executing {nameof(TestUnsafePermissions)} with {log}..");
             var dirInfo = new DirectoryUnixInformation(s_directoryFullName, true, unsecurePermissions, UserId);
 
             // act

--- a/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/DirectoryUnixInformationTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Mono.Unix;
 using Xunit;
@@ -30,11 +31,12 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         }
 
         [SFTheory(SkipCondition.SkipOnWindows)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead)]
-        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead)]
-        public void TestUnsafePermissions(FileAccessPermissions unsecurePermissions)
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead, "User RW + Group R")]
+        [InlineData(FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.OtherRead, "User RWX + Other R")]
+        public void TestUnsafePermissions(FileAccessPermissions unsecurePermissions, string log)
         {
             // arrange
+            Console.WriteLine($@"Executing {nameof(TestUnsafePermissions)} with {log}..");
             var dirInfo = new DirectoryUnixInformation(s_directoryFullName, true, unsecurePermissions, UserId);
 
             // act

--- a/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsUnixTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsUnixTest.cs
@@ -26,7 +26,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         private static readonly string s_workingDirectory = Path.Combine(TempUtil.GetTempPath(), s_relativeWorkingDirectory);
         private static readonly string s_content = "random text";
         private static readonly string s_fileName = "testfile";
-        public static void Before()
+
+        private static void Before()
         {
             if (!Directory.Exists(s_workingDirectory))
             {
@@ -35,7 +36,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
             s_fileOperations = new FileOperations();
         }
-        public static void After()
+
+        private static void After()
         {
             Directory.Delete(s_workingDirectory, true);
         }

--- a/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsWindowsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/FileOperationsWindowsTest.cs
@@ -20,7 +20,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         private static readonly string s_workingDirectory = Path.Combine(TempUtil.GetTempPath(), s_relativeWorkingDirectory);
         private static readonly string s_content = "random text";
         private static readonly string s_fileName = "testfile";
-        public static void Before()
+
+        private static void Before()
         {
             if (!Directory.Exists(s_workingDirectory))
             {
@@ -29,7 +30,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
             s_fileOperations = new FileOperations();
         }
-        public static void After()
+
+        private static void After()
         {
             Directory.Delete(s_workingDirectory, true);
         }

--- a/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
@@ -26,7 +26,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         private const string KConfiguration = "K_CONFIGURATION";
         private const string CloudRunJob = "CLOUD_RUN_JOB";
         private const string CloudRunExecution = "CLOUD_RUN_EXECUTION";
-        public void TearDown()
+
+        private void TearDown()
         {
             Environment.SetEnvironmentVariable(LambdaTaskRoot, null);
             Environment.SetEnvironmentVariable(GithubActions, null);

--- a/Snowflake.Data.Tests/UnitTests/Tools/SpcsTokenProviderTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/SpcsTokenProviderTest.cs
@@ -22,7 +22,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
         [ThreadStatic]
         private static SpcsTokenProvider t_provider;
-        public void Setup()
+
+        private void Setup()
         {
             t_fileOperations = new Mock<FileOperations>();
             t_environmentOperations = new Mock<EnvironmentOperations>();

--- a/Snowflake.Data.Tests/Util/SFFactAttribute.cs
+++ b/Snowflake.Data.Tests/Util/SFFactAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -21,7 +22,10 @@ public sealed class SFFactAttribute : FactAttribute
 
     public RetriesCount RetriesCount { get; set; }
 
-    public SFFactAttribute(SkipCondition skip = SkipCondition.None, bool dedicatedSessionPool = false, RetriesCount retriesCount = 0)
+    public SFFactAttribute(SkipCondition skip = SkipCondition.None, bool dedicatedSessionPool = false, RetriesCount retriesCount = 0, [CallerFilePath] string sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+#if NET8_0_OR_GREATER
+        : base(sourceFilePath, sourceLineNumber)
+#endif
     {
         RetriesCount = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JENKINS_HOME")) ? RetriesCount.Thrice : retriesCount;
         DedicatedSessionPool = dedicatedSessionPool;
@@ -43,7 +47,10 @@ public sealed class SFTheoryAttribute : TheoryAttribute
 
     public RetriesCount RetriesCount { get; set; }
 
-    public SFTheoryAttribute(SkipCondition skip = SkipCondition.None, bool dedicatedSessionPool = false, RetriesCount retriesCount = 0)
+    public SFTheoryAttribute(SkipCondition skip = SkipCondition.None, bool dedicatedSessionPool = false, RetriesCount retriesCount = 0, [CallerFilePath] string sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+#if NET8_0_OR_GREATER
+        : base(sourceFilePath, sourceLineNumber)
+#endif
     {
         DedicatedSessionPool = dedicatedSessionPool;
         RetriesCount = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JENKINS_HOME")) ? RetriesCount.Thrice : retriesCount;

--- a/Snowflake.Data/Client/SnowflakeDbException.cs
+++ b/Snowflake.Data/Client/SnowflakeDbException.cs
@@ -6,10 +6,10 @@ using Snowflake.Data.Core;
 namespace Snowflake.Data.Client
 {
     /// <summary>
-    ///     Wraps the exception. 
-    ///     If the exception is thrown in the client side, error code from 
+    ///     Wraps the exception.
+    ///     If the exception is thrown in the client side, error code from
     ///     270000 to 279999 will be used. Otherwise, server side error code
-    ///     will be used. 
+    ///     will be used.
     /// </summary>
     public sealed class SnowflakeDbException : DbException
     {
@@ -19,7 +19,9 @@ namespace Snowflake.Data.Client
         static private ResourceManager rm = new ResourceManager("Snowflake.Data.Core.ErrorMessages",
             typeof(SnowflakeDbException).Assembly);
 
+#pragma warning disable CS0108, CS0114 // TODO SNOW-3662960
         public string SqlState { get; private set; }
+#pragma warning restore CS0108, CS0114
         private int VendorCode;
 
         public string QueryId { get; set; }

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/AwsSdkWrapper.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/AwsSdkWrapper.cs
@@ -7,7 +7,9 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
         public static AwsSdkWrapper Instance = new AwsSdkWrapper();
 
         public virtual ImmutableCredentials GetAwsCredentials() =>
+#pragma warning disable CS0618 // Type or member is obsolete
             FallbackCredentialsFactory.GetCredentials()?.GetCredentials();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         public virtual string GetAwsRegion() =>
             FallbackRegionFactory.GetRegionEndpoint()?.SystemName;

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetriever.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetriever.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Xml.Linq;
 using Amazon.Runtime;
 using Newtonsoft.Json;
+using Snowflake.Data.Core.Extensions;
 using Snowflake.Data.Core.Rest;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
@@ -152,8 +153,8 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
                 {
                     request.Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }
-                request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-                request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+                request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+                request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
 
                 string responseXml;
                 using (var response = _restRequester.Get(new RestRequestWrapper(request)))

--- a/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityGcpAttestationRetriever.cs
+++ b/Snowflake.Data/Core/Authenticator/WorkflowIdentity/WorkflowIdentityGcpAttestationRetriever.cs
@@ -114,8 +114,9 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
             var uri = new Uri(url);
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Add("Metadata-Flavor", "Google");
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
 
             try
             {
@@ -159,8 +160,8 @@ namespace Snowflake.Data.Core.Authenticator.WorkflowIdentity
                 Content = new StringContent(jsonContent, Encoding.UTF8, "application/json")
             };
             request.Headers.Add("Authorization", $"Bearer {accessToken}");
-            request.Properties.Add(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
-            request.Properties.Add(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
+            request.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, HttpTimeout);
+            request.SetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY, RestTimeout);
 
             try
             {

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -917,7 +917,9 @@ namespace Snowflake.Data.Core
         /// <param name="fileMetadata">The metadata for the file to get digest.</param>
         private void getDigestAndSizeForFile(SFFileMetadata fileMetadata)
         {
+#pragma warning disable SYSLIB0021 // TODO SNOW-3662960
             using (SHA256 SHA256 = SHA256Managed.Create())
+#pragma warning restore SYSLIB0021
             {
                 if (fileMetadata.memoryStream != null)
                 {

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
@@ -133,7 +133,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 generateFileURL(fileMetadata.stageInfo, fileMetadata.RemoteFileName()) :
                 fileMetadata.presignedUrl;
 
+#pragma warning disable SYSLIB0014 // TODO SNOW-3662960
             WebRequest request = WebRequest.Create(url);
+#pragma warning restore SYSLIB0014
             request.Headers.Add("Authorization", $"Bearer {AccessToken}");
             request.Method = method;
 

--- a/Snowflake.Data/Core/HttpUtil.cs
+++ b/Snowflake.Data/Core/HttpUtil.cs
@@ -38,7 +38,7 @@ namespace Snowflake.Data.Core
             long crlDownloadMaxSize = 209715200,
             string minTlsProtocol = "TLS12",
             string maxTlsProtocol = "TLS13"
-            )
+        )
         {
             ProxyHost = proxyHost;
             ProxyPort = proxyPort;
@@ -60,7 +60,8 @@ namespace Snowflake.Data.Core
             MaxTlsProtocol = minTlsProtocol != null ? SslProtocolsExtensions.FromString(maxTlsProtocol) : SslProtocols.None;
 
             ConfKey = string.Join(";",
-                new string[] {
+                new string[]
+                {
                     proxyHost,
                     proxyPort,
                     proxyUser,
@@ -137,6 +138,7 @@ namespace Snowflake.Data.Core
 
         internal void IncreaseLowDefaultConnectionLimitOfServicePointManager()
         {
+#if !NET9_0_OR_GREATER // ServicePointManager has no effect on HttpClient from net9
             var currentLimit = ServicePointManager.DefaultConnectionLimit;
 
             // Only increase if below Snowflake's minimum requirement
@@ -152,6 +154,7 @@ namespace Snowflake.Data.Core
             {
                 logger.Debug($"Using the current ServicePointManager.DefaultConnectionLimit value of {currentLimit}");
             }
+#endif
         }
 
         internal static HttpUtil Instance { get; } = new HttpUtil();
@@ -187,7 +190,8 @@ namespace Snowflake.Data.Core
 
         internal HttpClient CreateNewHttpClient(HttpClientConfig config, DelegatingHandler customHandler = null) =>
             new HttpClient(
-                new RetryHandler(SetupCustomHttpHandler(config, customHandler), config.DisableRetry, config.ForceRetryOn404, config.MaxHttpRetries, config.IncludeRetryReason, config.ConnectionLimit))
+                new RetryHandler(SetupCustomHttpHandler(config, customHandler), config.DisableRetry, config.ForceRetryOn404, config.MaxHttpRetries,
+                    config.IncludeRetryReason, config.ConnectionLimit))
             {
                 Timeout = Timeout.InfiniteTimeSpan
             };
@@ -199,12 +203,14 @@ namespace Snowflake.Data.Core
             {
                 return _restRequesterForCrlCheck;
             }
+
             lock (_httpClientProviderLock)
             {
                 if (_restRequesterForCrlCheck != null)
                 {
                     return _restRequesterForCrlCheck;
                 }
+
                 var httpClient = new HttpClient();
                 _restRequesterForCrlCheck = new RestRequester(httpClient);
                 return _restRequesterForCrlCheck;
@@ -256,8 +262,8 @@ namespace Snowflake.Data.Core
 
                         // Replace with the valid entry syntax
                         bypassList[i] = entry;
-
                     }
+
                     proxy.BypassList = bypassList;
                 }
 
@@ -266,6 +272,7 @@ namespace Snowflake.Data.Core
                 httpHandlerWithProxy.Proxy = proxy;
                 return httpHandlerWithProxy;
             }
+
             return httpHandler;
         }
 
@@ -279,6 +286,7 @@ namespace Snowflake.Data.Core
                     customizedCrlCheck = true;
                     return CreateHttpClientHandlerWithCustomizedCrlCheck(config);
                 }
+
                 return CreateHttpClientHandlerWithDotnetCrlCheck(config);
             }
             // special logic for .NET framework 4.7.1 that
@@ -287,8 +295,10 @@ namespace Snowflake.Data.Core
             {
                 if (customizedCrlCheck)
                 {
-                    logger.Error("Could not use customized Crl revocation check. Probably you are using old .net framework 4.6.2 or 4.7.1 where revocation check is done by Windows OS");
+                    logger.Error(
+                        "Could not use customized Crl revocation check. Probably you are using old .net framework 4.6.2 or 4.7.1 where revocation check is done by Windows OS");
                 }
+
                 return new HttpClientHandler
                 {
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
@@ -371,6 +381,7 @@ namespace Snowflake.Data.Core
                     {
                         queryParams.Set(RestParams.SF_QUERY_RETRY_COUNT, retryCount.ToString());
                     }
+
                     retryCount++;
                 }
             }
@@ -411,6 +422,7 @@ namespace Snowflake.Data.Core
 
             UriBuilder uriBuilder;
             List<IRule> rules;
+
             internal UriUpdater(Uri uri, bool includeRetryReason = true)
             {
                 uriBuilder = new UriBuilder(uri);
@@ -450,6 +462,7 @@ namespace Snowflake.Data.Core
                     {
                         ((RetryReasonRule)rule).SetRetryReason(retryReason);
                     }
+
                     rule.apply(queryParams);
                 }
 
@@ -465,6 +478,7 @@ namespace Snowflake.Data.Core
                 return uriBuilder.Uri;
             }
         }
+
         private class RetryHandler : DelegatingHandler
         {
             static private SFLogger logger = SFLoggerFactory.GetLogger<RetryHandler>();
@@ -475,7 +489,8 @@ namespace Snowflake.Data.Core
             private bool includeRetryReason;
             private int connectionLimit;
 
-            internal RetryHandler(HttpMessageHandler innerHandler, bool disableRetry, bool forceRetryOn404, int maxRetryCount, bool includeRetryReason, int connectionLimit) : base(innerHandler)
+            internal RetryHandler(HttpMessageHandler innerHandler, bool disableRetry, bool forceRetryOn404, int maxRetryCount,
+                bool includeRetryReason, int connectionLimit) : base(innerHandler)
             {
                 this.disableRetry = disableRetry;
                 this.forceRetryOn404 = forceRetryOn404;
@@ -488,20 +503,22 @@ namespace Snowflake.Data.Core
                 CancellationToken cancellationToken)
             {
                 HttpResponseMessage response = null;
-                string absolutePath = requestMessage.RequestUri.AbsolutePath;
-                bool isLoginRequest = IsLoginEndpoint(absolutePath);
-                bool isOktaSSORequest = IsOktaSSORequest(requestMessage.RequestUri.Host, absolutePath);
-                int backOffInSec = s_baseBackOffTime;
-                int totalRetryTime = 0;
+                var absolutePath = requestMessage.RequestUri!.AbsolutePath;
+                var isLoginRequest = IsLoginEndpoint(absolutePath);
+                var isOktaSSORequest = IsOktaSSORequest(requestMessage.RequestUri.Host, absolutePath);
+                var backOffInSec = s_baseBackOffTime;
                 Exception lastException = null;
 
-                ServicePoint p = ServicePointManager.FindServicePoint(requestMessage.RequestUri);
+
+#pragma warning disable SYSLIB0014 // TODO SNOW-3662960
+                var p = ServicePointManager.FindServicePoint(requestMessage.RequestUri);
+#pragma warning restore SYSLIB0014
                 p.Expect100Continue = false; // Saves about 100 ms per request
                 p.UseNagleAlgorithm = false; // Saves about 200 ms per request
-                p.ConnectionLimit = connectionLimit;    // Default value is 2, we need more connections for performing multiple parallel queries
+                p.ConnectionLimit = connectionLimit; // Default value is 2, we need more connections for performing multiple parallel queries
 
-                TimeSpan httpTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY);
-                TimeSpan restTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY);
+                var httpTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY);
+                var restTimeout = (TimeSpan)requestMessage.GetOption(BaseRestRequest.REST_REQUEST_TIMEOUT_KEY);
 
                 if (logger.IsDebugEnabled())
                 {
@@ -511,10 +528,10 @@ namespace Snowflake.Data.Core
 
                 CancellationTokenSource childCts = null;
 
-                UriUpdater updater = new UriUpdater(requestMessage.RequestUri, includeRetryReason);
-                int retryCount = 0;
+                var updater = new UriUpdater(requestMessage.RequestUri, includeRetryReason);
+                var retryCount = 0;
 
-                long startTimeInMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var startTimeInMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 while (true)
                 {
                     try
@@ -529,8 +546,8 @@ namespace Snowflake.Data.Core
                             else
                                 childCts.CancelAfter(httpTimeout);
                         }
-                        response = await base.SendAsync(requestMessage, childCts == null ?
-                            cancellationToken : childCts.Token).ConfigureAwait(false);
+
+                        response = await base.SendAsync(requestMessage, childCts?.Token ?? cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {
@@ -540,13 +557,13 @@ namespace Snowflake.Data.Core
                             logger.Info("SF rest request timeout or explicit cancel called.");
                             cancellationToken.ThrowIfCancellationRequested();
                         }
-                        else if (childCts != null && childCts.Token.IsCancellationRequested)
+                        else if (childCts is { Token.IsCancellationRequested: true })
                         {
                             logger.Warn($"Http request timeout. Retry the request after max {backOffInSec} sec.");
                         }
                         else
                         {
-                            Exception innermostException = GetInnerMostException(e);
+                            var innermostException = GetInnerMostException(e);
 
                             if (innermostException is AuthenticationException)
                             {
@@ -561,14 +578,11 @@ namespace Snowflake.Data.Core
                         }
                     }
 
-                    totalRetryTime = (int)((DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTimeInMilliseconds) / 1000);
+                    var totalRetryTime = (int)((DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTimeInMilliseconds) / 1000);
 
-                    if (childCts != null)
-                    {
-                        childCts.Dispose();
-                    }
+                    childCts?.Dispose();
 
-                    int errorReason = 0;
+                    var errorReason = 0;
 
                     if (response != null)
                     {
@@ -594,6 +608,7 @@ namespace Snowflake.Data.Core
                                 return response;
                             }
                         }
+
                         errorReason = (int)response.StatusCode;
                     }
                     else
@@ -608,6 +623,7 @@ namespace Snowflake.Data.Core
                         {
                             return response;
                         }
+
                         var errorMessage = $"http request failed and connection_timeout {restTimeout.TotalSeconds} sec. reached.\n";
                         errorMessage += $"Last exception encountered: {lastException}";
                         logger.Error(errorMessage);
@@ -628,6 +644,7 @@ namespace Snowflake.Data.Core
                         {
                             return response;
                         }
+
                         var errorMessage = $"http request failed and max retry {maxRetryCount} reached.\n";
                         errorMessage += $"Last exception encountered: {lastException}";
                         logger.Error(errorMessage);
@@ -684,22 +701,22 @@ namespace Snowflake.Data.Core
             if (forceRetryOn404 && statusCode == 404)
                 return true;
             return (500 <= statusCode && statusCode < 600) ||
-            // Forbidden
-            (statusCode == 403) ||
-            // Request timeout
-            (statusCode == 408) ||
-            // Too many requests
-            (statusCode == 429) ||
-            IsRedirectHTTPCode(statusCode);
+                   // Forbidden
+                   (statusCode == 403) ||
+                   // Request timeout
+                   (statusCode == 408) ||
+                   // Too many requests
+                   (statusCode == 429) ||
+                   IsRedirectHTTPCode(statusCode);
         }
 
         static public bool IsRedirectHTTPCode(int statusCode)
         {
             return
-            // Temporary redirect
-            (statusCode == 307) ||
-            // Permanent redirect
-            (statusCode == 308);
+                // Temporary redirect
+                (statusCode == 307) ||
+                // Permanent redirect
+                (statusCode == 308);
         }
 
         /// <summary>
@@ -749,5 +766,3 @@ namespace Snowflake.Data.Core
         }
     }
 }
-
-


### PR DESCRIPTION
### Description
Changing the test runner involved a lot of changes (~50k lines changed). To reduce the scope, some minor improvements were split away from it for readability sake, even though they're simple to introduce. This PR addresses static rule analysis 
xUnit1025 - "InlineData should be unique within the Theory it belongs to"
xUnit1026 - "Theory methods should use all of their parameters"
xUnit2002 - "Do not use null check on value type"
xUnit2008 - "Do not use boolean check to match on regular expressions"
xUnit3003 - "Classes which extend FactAttribute (directly or indirectly) should provide a public constructor for source information"

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
