### PR TITLE
SNOW-3560671 Add missing .ConfigureAwait(false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.8.0
+  -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.
   -  Replaced NUnit tests with Xunit in order to modernize and stabilize existing CI/CD setup.
   -  Improved handling of certificates serial number matching and performance of CRL checkup.
   -  Switched AWS Workload Identity Federation attestation from a SigV4-presigned `GetCallerIdentity` request to STS

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -98,9 +98,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 try
                 {
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync().ConfigureAwait(false))
                         {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
@@ -167,7 +167,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connection = new TestSnowflakeDbConnection(mockDbProviderFactory.Object);
             connection.ConnectionString = connectionString;
             await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            await connection.BeginTransactionAsync();
+            await connection.BeginTransactionAsync().ConfigureAwait(false);
             Assert.True(connection.HasActiveExplicitTransaction());
 
             // act
@@ -183,7 +183,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // add test case name in connection string to make in unique for each test case
             // set short expiration timeout to cover the case that connection expired
             string connStr = _fixture.ConnectionString + ";application=TestConcurrentConnectionPoolingAsync2;ExpirationTimeout=3;poolingEnabled=true";
-            await ConnectionSinglePoolCacheAsyncIT.ConcurrentPoolingAsyncHelper(connStr, true, 5, 5, 3);
+            await ConnectionSinglePoolCacheAsyncIT.ConcurrentPoolingAsyncHelper(connStr, true, 5, 5, 3).ConfigureAwait(false);
         }
 
         [SFFact(DisplayName = "test connection pooling with concurrent connection and using async calls no close call for connection. Connection is closed when Dispose() is called by framework.")]
@@ -193,7 +193,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // set short expiration timeout to cover the case that connection expired
             string connStr = _fixture.ConnectionString +
                              ";application=TestConcurrentConnectionPoolingDisposeAsync2;ExpirationTimeout=3;poolingEnabled=true";
-            await ConnectionSinglePoolCacheAsyncIT.ConcurrentPoolingAsyncHelper(connStr, false, 5, 5, 3);
+            await ConnectionSinglePoolCacheAsyncIT.ConcurrentPoolingAsyncHelper(connStr, false, 5, 5, 3).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -201,9 +201,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var connectionString = _fixture.ConnectionString + "minPoolSize=0;maxPoolSize=1;poolingEnabled=true";
             var conn1 = new SnowflakeDbConnection(connectionString);
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
-            await conn1.CloseAsync();
+            await conn1.CloseAsync().ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -216,18 +216,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var connectionString = _fixture.ConnectionString + "minPoolSize=1;poolingEnabled=true";
             var conn1 = new SnowflakeDbConnection(connectionString);
-            await conn1.OpenAsync(CancellationToken);
+            await conn1.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
-            await conn1.CloseAsync();
+            await conn1.CloseAsync().ConfigureAwait(false);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(connectionString).GetCurrentPoolSize());
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = connectionString;
-            await conn2.OpenAsync(CancellationToken);
+            await conn2.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn2.State);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(connectionString).GetCurrentPoolSize());
 
-            await conn2.CloseAsync();
+            await conn2.CloseAsync().ConfigureAwait(false);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(connectionString).GetCurrentPoolSize());
             Assert.Equal(ConnectionState.Closed, conn1.State);
             Assert.Equal(ConnectionState.Closed, conn2.State);
@@ -241,32 +241,32 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = connectionString;
-            await conn1.OpenAsync(CancellationToken);
+            await conn1.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = connectionString;
-            await conn2.OpenAsync(CancellationToken);
+            await conn2.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn2.State);
 
             Assert.Equal(2, pool.GetCurrentPoolSize());
-            await conn1.CloseAsync();
-            await conn2.CloseAsync();
+            await conn1.CloseAsync().ConfigureAwait(false);
+            await conn2.CloseAsync().ConfigureAwait(false);
             Assert.Equal(2, pool.GetCurrentPoolSize());
 
             var conn3 = new SnowflakeDbConnection();
             conn3.ConnectionString = connectionString;
-            await conn3.OpenAsync(CancellationToken);
+            await conn3.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn3.State);
 
             var conn4 = new SnowflakeDbConnection();
             conn4.ConnectionString = connectionString;
-            await conn4.OpenAsync(CancellationToken);
+            await conn4.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn4.State);
 
-            await conn3.CloseAsync();
+            await conn3.CloseAsync().ConfigureAwait(false);
             Assert.Equal(2, pool.GetCurrentPoolSize());
-            await conn4.CloseAsync();
+            await conn4.CloseAsync().ConfigureAwait(false);
             Assert.Equal(2, pool.GetCurrentPoolSize());
 
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -283,8 +283,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                                    "application=TestWaitForMaxSize2;waitingForIdleSessionTimeout=1s;maxPoolSize=2;minPoolSize=1;poolingEnabled=true";
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(0, pool.GetCurrentPoolSize());
-            var conn1 = await OpenConnectionAsync(connectionString);
-            var conn2 = await OpenConnectionAsync(connectionString);
+            var conn1 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            var conn2 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
             var watch = new StopWatch();
 
             // act
@@ -315,13 +315,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             connection.ConnectionString = connectionString;
 
             // act
-            await connection.OpenAsync(CancellationToken);
+            await connection.OpenAsync(CancellationToken).ConfigureAwait(false);
 
             // assert
             Assert.Equal(1, pool.GetCurrentPoolSize());
 
             // act
-            await connection.CloseAsync();
+            await connection.CloseAsync().ConfigureAwait(false);
 
             // assert
             Assert.Equal(1, pool.GetCurrentPoolSize());
@@ -336,14 +336,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             conn1.ConnectionString = _fixture.ConnectionString;
 
             // act
-            await conn1.OpenAsync(CancellationToken);
+            await conn1.OpenAsync(CancellationToken).ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Open, conn1.State);
             Assert.Equal(0, pool.GetCurrentPoolSize());
 
             // act
-            await conn1.CloseAsync();
+            await conn1.CloseAsync().ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -394,16 +394,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(0, pool.GetCurrentPoolSize());
 
             // act
-            var conn1 = await OpenConnectionAsync(connectionString);
-            var conn2 = await OpenConnectionAsync(connectionString);
-            var conn3 = await OpenConnectionAsync(connectionString);
-            var conn4 = await OpenConnectionAsync(connectionString);
+            var conn1 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            var conn2 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            var conn3 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            var conn4 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
 
             // assert
             Assert.Equal(4, pool.GetCurrentPoolSize());
 
             // act
-            await WaitUntilAllSessionsCreatedOrTimeout(pool);
+            await WaitUntilAllSessionsCreatedOrTimeout(pool).ConfigureAwait(false);
             var beforeSleepMillis = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             await Task.Delay(TimeSpan.FromSeconds(ExpirationTimeoutInSeconds)).ConfigureAwait(false);
             await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -415,9 +415,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(2, pool.GetCurrentPoolSize()); // 2 idle sessions, but expired because close doesn't remove expired sessions
 
             // act
-            await WaitUntilAllSessionsCreatedOrTimeout(pool);
-            var conn5 = await OpenConnectionAsync(connectionString);
-            await WaitUntilAllSessionsCreatedOrTimeout(pool);
+            await WaitUntilAllSessionsCreatedOrTimeout(pool).ConfigureAwait(false);
+            var conn5 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            await WaitUntilAllSessionsCreatedOrTimeout(pool).ConfigureAwait(false);
 
             // assert
             Assert.Equal(2, pool.GetCurrentPoolSize()); // 1 idle session and 1 busy
@@ -430,7 +430,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         private static async Task WaitUntilAllSessionsCreatedOrTimeout(SessionPool pool)
         {
             var expectingToWaitAtMostForSessionCreations = TimeSpan.FromSeconds(15);
-            await Awaiter.WaitUntilConditionOrTimeout(() => pool.OngoingSessionCreationsCount() == 0, expectingToWaitAtMostForSessionCreations);
+            await Awaiter.WaitUntilConditionOrTimeout(() => pool.OngoingSessionCreationsCount() == 0, expectingToWaitAtMostForSessionCreations).ConfigureAwait(false);
         }
 
         private async Task<SnowflakeDbConnection> OpenConnectionAsync(string connectionString)

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsIT.cs
@@ -38,8 +38,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connectionString = _fixture.ConnectionString + "application=TestWaitForMaxSize1;waitingForIdleSessionTimeout=1s;maxPoolSize=2;minPoolSize=1;poolingEnabled=true";
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(0, pool.GetCurrentPoolSize());
-            var conn1 = await OpenConnectionAsync(connectionString);
-            var conn2 = await OpenConnectionAsync(connectionString);
+            var conn1 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
+            var conn2 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
             var watch = new StopWatch();
 
             // act
@@ -53,8 +53,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(2, pool.GetCurrentPoolSize());
 
             // cleanup
-            await conn1.CloseAsync(CancellationToken.None);
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact(RetriesCount = RetriesCount.Thrice)]
@@ -138,7 +138,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(3, pool.GetCurrentPoolSize());
 
             // cleanup
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -146,7 +146,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             // arrange
             var connectionString = _fixture.ConnectionString + "minPoolSize=0;poolingEnabled=true";
-            var connection = await OpenConnectionAsync(connectionString);
+            var connection = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(1, pool.GetCurrentPoolSize());
 
@@ -170,8 +170,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(0, pool.GetCurrentPoolSize());
             var connection = new TestSnowflakeDbConnection(mockDbProviderFactory.Object);
             connection.ConnectionString = connectionString;
-            await connection.OpenAsync(CancellationToken.None);
-            await connection.BeginTransactionAsync();
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await connection.BeginTransactionAsync().ConfigureAwait(false);
             Assert.True(connection.HasActiveExplicitTransaction());
 
             // act
@@ -200,11 +200,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 using (var connection = new SnowflakeDbConnection(connectionString))
                 {
-                    await connection.OpenAsync(cts.Token);
+                    await connection.OpenAsync(cts.Token).ConfigureAwait(false);
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = $"SELECT SYSTEM$WAIT(20)";
-                        await command.ExecuteNonQueryAsync(cts.Token);
+                        await command.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
                     }
                 }
             }, CancellationToken.None);
@@ -213,7 +213,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 var state = pool.GetCurrentState();
                 return state.IdleSessionsCount == 0 && state.BusySessionsCount == 1;
-            }, TimeSpan.FromMilliseconds(10000));
+            }, TimeSpan.FromMilliseconds(10000)).ConfigureAwait(false);
 
             // one busy session
             Assert.Equal(0, pool.GetCurrentState().IdleSessionsCount);
@@ -221,7 +221,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             if (cancelAsync)
 #if NET8_0_OR_GREATER
-                await cts.CancelAsync();
+                await cts.CancelAsync().ConfigureAwait(false);
 #else
                 cts.Cancel();
 #endif
@@ -229,7 +229,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 cts.Cancel();
 
             // operation canceled properly
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task).ConfigureAwait(false);
 
             // one idle session
             Assert.Equal(1, pool.GetCurrentState().IdleSessionsCount);

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolChangedSessionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolChangedSessionIT.cs
@@ -65,9 +65,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             connection.SfSession.UpdateSessionProperties(_queryExecResponseChangedDatabase());
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(0, pool.GetCurrentPoolSize());
         }
@@ -79,8 +79,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(1, pool.GetCurrentPoolSize());
         }
@@ -92,18 +92,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             connection.SfSession.UpdateSessionProperties(_queryExecResponseChangedWarehouse());
             var sessionId = connection.SfSession.sessionId;
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(1, pool.GetCurrentPoolSize());
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var connection2 = new SnowflakeDbConnection(connectionString);
-            await connection2.OpenAsync(CancellationToken.None);
+            await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(sessionId, connection2.SfSession.sessionId);
-            await connection2.CloseAsync(CancellationToken.None);
+            await connection2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -113,17 +113,17 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             connection.SfSession.UpdateSessionProperties(_queryExecResponseChangedRole());
             var sessionId = connection.SfSession.sessionId;
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(0, pool.GetCurrentPoolSize());
 
             var connection2 = new SnowflakeDbConnection(connectionString);
-            await connection2.OpenAsync(CancellationToken.None);
+            await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.NotEqual(sessionId, connection2.SfSession.sessionId);
-            await connection2.CloseAsync(CancellationToken.None);
+            await connection2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -132,18 +132,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connectionString = _fixture.ConnectionString + "application=DestroyRecreateSession;ChangedSession=Destroy;minPoolSize=1;maxPoolSize=3;poolingEnabled=true";
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var sessionId = connection.SfSession.sessionId;
             connection.SfSession.UpdateSessionProperties(_queryExecResponseChangedSchema);
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(1, pool.GetCurrentPoolSize());
 
             var connection2 = new SnowflakeDbConnection(connectionString);
-            await connection2.OpenAsync(CancellationToken.None);
+            await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.NotEqual(sessionId, connection2.SfSession.sessionId);
-            await connection2.CloseAsync(CancellationToken.None);
+            await connection2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -160,18 +160,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             };
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var sessionId = connection.SfSession.sessionId;
             connection.SfSession.UpdateSessionProperties(responseData);
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(1, pool.GetCurrentPoolSize());
 
             var connection2 = new SnowflakeDbConnection(connectionString);
-            await connection2.OpenAsync(CancellationToken.None);
+            await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(sessionId, connection2.SfSession.sessionId);
-            await connection2.CloseAsync(CancellationToken.None);
+            await connection2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -188,18 +188,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             };
 
             var connection = new SnowflakeDbConnection(connectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var sessionId = connection.SfSession.sessionId;
             connection.SfSession.UpdateSessionProperties(responseData);
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(1, pool.GetCurrentPoolSize());
 
             var connection2 = new SnowflakeDbConnection(connectionString);
-            await connection2.OpenAsync(CancellationToken.None);
+            await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.NotEqual(sessionId, connection2.SfSession.sessionId);
-            await connection2.CloseAsync(CancellationToken.None);
+            await connection2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -54,8 +54,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = connstr;
-            await conn1.OpenAsync(CancellationToken.None);
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             await Task.Delay(100).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Closed, conn1.State);
         }
@@ -64,14 +64,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = connstr;
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             await Task.Delay(100).ConfigureAwait(false);
             SFStatement statement = new SFStatement(conn1.SfSession);
             SFBaseResultSet resultSet = statement.Execute(0, "select 1", null, false, false);
             Assert.True(await resultSet.NextAsync().ConfigureAwait(false));
             Assert.Equal("1", resultSet.GetString(0));
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFTheory]
@@ -95,7 +95,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 Assert.Throws<SnowflakeDbException>(() => conn1.Open());
             }
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(ConnectionState.Closed, conn1.State);
             if (_connectionPoolTypeUnderTest == ConnectionPoolType.SingleConnectionCache)
@@ -129,9 +129,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             object firstOpenedSessionId;
             using (var connection = new SnowflakeDbConnection(connectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 firstOpenedSessionId = connection.SfSession.sessionId;
-                await connection.BeginTransactionAsync();
+                await connection.BeginTransactionAsync().ConfigureAwait(false);
                 Assert.True(connection.HasActiveExplicitTransaction());
                 await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
                 {
@@ -140,12 +140,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         command.CommandText = "invalid command will throw exception and leave session with an unfinished transaction";
                         await command.ExecuteNonQueryAsync();
                     }
-                });
+                }).ConfigureAwait(false);
             }
 
             using (var connectionWithSessionReused = new SnowflakeDbConnection(connectionString))
             {
-                await connectionWithSessionReused.OpenAsync(CancellationToken.None);
+                await connectionWithSessionReused.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 Assert.Equal(firstOpenedSessionId, connectionWithSessionReused.SfSession.sessionId);
                 Assert.False(connectionWithSessionReused.HasActiveExplicitTransaction());
@@ -165,11 +165,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var connectionString = SetPoolWithOneElement();
             using (var connection = new SnowflakeDbConnection(connectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText = "BEGIN"; // in general can be put as a part of a multi statement call and mixed with commit as well
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     Assert.False(connection.HasActiveExplicitTransaction());
                 }
             }
@@ -184,9 +184,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             string firstOpenedSessionId;
             using (var connection1 = new SnowflakeDbConnection(connectionString))
             {
-                await connection1.OpenAsync(CancellationToken.None);
+                await connection1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 Assert.Equal(ExpectedPoolCountAfterOpen(), SnowflakeDbConnectionPool.GetCurrentPoolSize());
-                await connection1.BeginTransactionAsync();
+                await connection1.BeginTransactionAsync().ConfigureAwait(false);
                 Assert.True(connection1.HasActiveExplicitTransaction());
                 using (var command = connection1.CreateCommand())
                 {
@@ -199,7 +199,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var connection2 = new SnowflakeDbConnection(connectionString))
             {
-                await connection2.OpenAsync(CancellationToken.None);
+                await connection2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 Assert.Equal(ExpectedPoolCountAfterOpen(), SnowflakeDbConnectionPool.GetCurrentPoolSize());
                 Assert.False(connection2.HasActiveExplicitTransaction());
                 using (var command = connection2.CreateCommand())

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionPoolCommonIT.cs
@@ -138,7 +138,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = "invalid command will throw exception and leave session with an unfinished transaction";
-                        await command.ExecuteNonQueryAsync();
+                        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
             }

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheAsyncIT.cs
@@ -101,9 +101,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 try
                 {
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync().ConfigureAwait(false))
                         {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
@@ -128,7 +128,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             string connStr = _fixture.ConnectionString + ";application=TestConcurrentConnectionPoolingAsync";
             SnowflakeDbConnectionPool.SetMaxPoolSize(3);
             SnowflakeDbConnectionPool.SetTimeout(1); // set short pooling timeout to cover the case that connection expired
-            await ConcurrentPoolingAsyncHelper(connStr, true, 5, 5, 3);
+            await ConcurrentPoolingAsyncHelper(connStr, true, 5, 5, 3).ConfigureAwait(false);
             SnowflakeDbConnectionPool.SetTimeout(3600);
         }
 
@@ -139,7 +139,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             string connStr = _fixture.ConnectionString + ";application=TestConcurrentConnectionPoolingDisposeAsync";
             SnowflakeDbConnectionPool.SetMaxPoolSize(3);
             SnowflakeDbConnectionPool.SetTimeout(1); // set short pooling timeout to cover the case that connection expired
-            await ConcurrentPoolingAsyncHelper(connStr, false, 5, 5, 3);
+            await ConcurrentPoolingAsyncHelper(connStr, false, 5, 5, 3).ConfigureAwait(false);
             SnowflakeDbConnectionPool.SetTimeout(3600);
         }
 
@@ -149,9 +149,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             SnowflakeDbConnectionPool.SetMaxPoolSize(1);
 
             var conn1 = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(ConnectionState.Closed, conn1.State);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(_fixture.ConnectionString).GetCurrentPoolSize());
@@ -161,18 +161,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestPoolContainsClosedConnections() // old name: TestConnectionPool
         {
             var conn1 = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(_fixture.ConnectionString).GetCurrentPoolSize());
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = _fixture.ConnectionString;
-            await conn2.OpenAsync(CancellationToken.None);
+            await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn2.State);
             Assert.Equal(0, SnowflakeDbConnectionPool.GetPool(_fixture.ConnectionString).GetCurrentPoolSize());
 
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetPool(_fixture.ConnectionString).GetCurrentPoolSize());
             Assert.Equal(ConnectionState.Closed, conn1.State);
             Assert.Equal(ConnectionState.Closed, conn2.State);
@@ -185,30 +185,30 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = _fixture.ConnectionString;
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = _fixture.ConnectionString + " retryCount=1";
-            await conn2.OpenAsync(CancellationToken.None);
+            await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn2.State);
             Assert.Equal(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
-            await conn1.CloseAsync(CancellationToken.None);
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(2, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             var conn3 = new SnowflakeDbConnection();
             conn3.ConnectionString = _fixture.ConnectionString + "  retryCount=2";
-            await conn3.OpenAsync(CancellationToken.None);
+            await conn3.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn3.State);
 
             var conn4 = new SnowflakeDbConnection();
             conn4.ConnectionString = _fixture.ConnectionString + "  retryCount=3";
-            await conn4.OpenAsync(CancellationToken.None);
+            await conn4.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn4.State);
 
-            await conn3.CloseAsync(CancellationToken.None);
+            await conn3.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(2, SnowflakeDbConnectionPool.GetCurrentPoolSize());
-            await conn4.CloseAsync(CancellationToken.None);
+            await conn4.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(2, SnowflakeDbConnectionPool.GetCurrentPoolSize());
 
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -227,14 +227,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             conn1.ConnectionString = _fixture.ConnectionString;
 
             // act
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Open, conn1.State);
             Assert.Equal(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
 
             // act
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -251,14 +251,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             conn1.ConnectionString = _fixture.ConnectionString;
 
             // act
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Open, conn1.State);
             Assert.Equal(0, pool.GetCurrentPoolSize());
 
             // act
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -271,25 +271,25 @@ namespace Snowflake.Data.Tests.IntegrationTests
             SnowflakeDbConnectionPool.SetMaxPoolSize(2);
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = _fixture.ConnectionString;
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn1.State);
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = _fixture.ConnectionString + " retryCount=1";
-            await conn2.OpenAsync(CancellationToken.None);
+            await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn2.State);
 
             var conn3 = new SnowflakeDbConnection();
             conn3.ConnectionString = _fixture.ConnectionString + "  retryCount=2";
-            await conn3.OpenAsync(CancellationToken.None);
+            await conn3.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn3.State);
 
-            await conn1.CloseAsync(CancellationToken.None);
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(2, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             SnowflakeDbConnectionPool.ClearAllPools();
             Assert.Equal(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
-            await conn3.CloseAsync(CancellationToken.None);
+            await conn3.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
 
             Assert.Equal(ConnectionState.Closed, conn1.State);
@@ -306,19 +306,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var conn1 = new SnowflakeDbConnection();
             conn1.ConnectionString = _fixture.ConnectionString;
 
-            await conn1.OpenAsync(CancellationToken.None);
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             SnowflakeDbConnectionPool.SetTimeout(0);
 
             var conn2 = new SnowflakeDbConnection();
             conn2.ConnectionString = _fixture.ConnectionString;
-            await conn2.OpenAsync(CancellationToken.None);
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var conn3 = new SnowflakeDbConnection();
             conn3.ConnectionString = _fixture.ConnectionString;
-            await conn3.OpenAsync(CancellationToken.None);
-            await conn3.CloseAsync(CancellationToken.None);
+            await conn3.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            await conn3.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             // The pooling timeout should apply to all connections being pooled,
             // not just the connections created after the new setting,
@@ -331,13 +331,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             // arrange
             var connection = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var pool = SnowflakeDbConnectionPool.GetPool(_fixture.ConnectionString);
             Assert.Equal(0, pool.GetCurrentPoolSize());
 
             // act
             connection.PreventPooling();
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(0, pool.GetCurrentPoolSize());
@@ -354,13 +354,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.Equal(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
             var connection = new TestSnowflakeDbConnection(mockDbProviderFactory.Object);
             connection.ConnectionString = _fixture.ConnectionString;
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             connection.BeginTransaction();
             Assert.True(connection.HasActiveExplicitTransaction());
             // no Rollback or Commit; during internal Rollback while closing a connection a mocked exception will be thrown
 
             // act
-            await connection.CloseAsync(CancellationToken.None);
+            await connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.Equal(0, SnowflakeDbConnectionPool.GetCurrentPoolSize());
@@ -374,15 +374,15 @@ namespace Snowflake.Data.Tests.IntegrationTests
             const int TimeForBackgroundSessionCloseMillis = 3000;
             SnowflakeDbConnectionPool.SetTimeout(SessionTimeoutSeconds);
             var conn1 = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn1.OpenAsync(CancellationToken.None);
+            await conn1.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var session = conn1.SfSession;
-            await conn1.CloseAsync(CancellationToken.None);
+            await conn1.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.True(session.IsEstablished());
             await Task.Delay(SessionTimeoutSeconds * 1000).ConfigureAwait(false); // wait until the session is expired
             var conn2 = new SnowflakeDbConnection(_fixture.ConnectionString);
 
             // act
-            await conn2.OpenAsync(CancellationToken.None); // it gets a session from the caching pool firstly closing session of conn1 in background
+            await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false); // it gets a session from the caching pool firstly closing session of conn1 in background
 
             await Awaiter.WaitUntilConditionOrTimeout(() => !session.IsEstablished(), TimeSpan.FromMilliseconds(TimeForBackgroundSessionCloseMillis)).ConfigureAwait(false);
 
@@ -390,7 +390,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Assert.False(session.IsEstablished());
 
             // cleanup
-            await conn2.CloseAsync(CancellationToken.None);
+            await conn2.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         internal static Task ConcurrentPoolingAsyncHelper(string connectionString, bool closeConnection, int tasksCount, int connectionsInTask, int abandonedConnectionsCount)

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionSinglePoolCacheIT.cs
@@ -124,9 +124,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 try
                 {
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync().ConfigureAwait(false))
                         {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {

--- a/Snowflake.Data.Tests/IntegrationTests/DecfloatIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/DecfloatIT.cs
@@ -30,7 +30,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         private async Task<SnowflakeDbConnection> CreateAndOpenConnectionAsync()
         {
             var conn = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             return conn;
         }
 
@@ -61,13 +61,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 123.456::DECFLOAT AS decfloat_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -93,13 +93,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 1234567890.123456789::DECFLOAT AS high_precision";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -120,13 +120,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT NULL::DECFLOAT AS null_decfloat";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -145,13 +145,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT -987.654::DECFLOAT AS negative_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -172,13 +172,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 0::DECFLOAT AS zero_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -199,13 +199,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 1.23e10::DECFLOAT AS large_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -226,13 +226,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 1.5e-3::DECFLOAT AS small_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -253,19 +253,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 var fixtureTableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-                await _fixture.CreateOrReplaceTable(conn, fixtureTableName, new[] { "col_decfloat DECFLOAT" });
+                await _fixture.CreateOrReplaceTable(conn, fixtureTableName, new[] { "col_decfloat DECFLOAT" }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = $"INSERT INTO {fixtureTableName} VALUES (123.456), (-999.999), (NULL)";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     cmd.CommandText = $"SELECT col_decfloat FROM {fixtureTableName} ORDER BY col_decfloat NULLS LAST";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -291,7 +291,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -300,7 +300,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         2.2::DECFLOAT AS col2,
                         3.3::DECFLOAT AS col3";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -327,13 +327,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await SetResultFormat(conn);
+                await SetResultFormat(conn).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT 123.456::DECFLOAT AS decfloat_value";
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         ValidateResultFormat(reader);
 
@@ -371,13 +371,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
                 {
-                    await SetResultFormat(conn);
+                    await SetResultFormat(conn).ConfigureAwait(false);
 
                     using (var cmd = conn.CreateCommand())
                     {
                         cmd.CommandText = "SELECT 123.456::DECFLOAT AS decfloat_value";
 
-                        using (var reader = await cmd.ExecuteReaderAsync())
+                        using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                         {
                             ValidateResultFormat(reader);
 

--- a/Snowflake.Data.Tests/IntegrationTests/EasyLoggingIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/EasyLoggingIT.cs
@@ -89,7 +89,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 conn.ConnectionString = _fixture.ConnectionString + $"CLIENT_CONFIG_FILE={configFilePath}";
 
                 // act
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // assert
                 Assert.True(EasyLoggerManager.HasEasyLoggingAppender());
@@ -126,7 +126,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (var conn = new SnowflakeDbConnection())
                 {
                     conn.ConnectionString = _fixture.ConnectionString + $"CLIENT_CONFIG_FILE={configFilePath}";
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                     var sfLogger = (SFLoggerImpl)SFLoggerFactory.GetSFLogger<EasyLoggingIT>();
                     var fileAppender = (SFRollingFileAppender)SFLoggerImpl.s_appenders.First();
                     var logFile = fileAppender.LogFilePath;
@@ -161,7 +161,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (var conn = new SnowflakeDbConnection())
                 {
                     conn.ConnectionString = _fixture.ConnectionString + $"CLIENT_CONFIG_FILE={configFilePath}";
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                     var sfLogger = (SFLoggerImpl)SFLoggerFactory.GetSFLogger<EasyLoggingIT>();
                     var fileAppender = (SFRollingFileAppender)SFLoggerImpl.s_appenders.First();
                     var logFile = fileAppender.LogFilePath;

--- a/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/FileUploadDownloadLargeFilesIT.cs
@@ -67,8 +67,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestThatUploadsAndDownloadsTheSameFile()
         {
             // act
-            await UploadFileAsync(_fixture2.s_fullFileName, _fixture2.s_remoteFolderName);
-            await DownloadFileAsync(_fixture2.s_remoteFolderName, _fixture2.s_downloadFolderName, FileUploadDownloadLargeFilesITFixture.FileName);
+            await UploadFileAsync(_fixture2.s_fullFileName, _fixture2.s_remoteFolderName).ConfigureAwait(false);
+            await DownloadFileAsync(_fixture2.s_remoteFolderName, _fixture2.s_downloadFolderName, FileUploadDownloadLargeFilesITFixture.FileName).ConfigureAwait(false);
 
             // assert
             Assert.Equal(
@@ -76,7 +76,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 CalcualteMD5(_fixture2.s_fullDownloadedFileName));
 
             // cleanup
-            await RemoveFilesFromServerAsync(_fixture2.s_remoteFolderName);
+            await RemoveFilesFromServerAsync(_fixture2.s_remoteFolderName).ConfigureAwait(false);
             FileUploadDownloadLargeFilesITFixture.RemoveLocalFile(_fixture2.s_fullDownloadedFileName);
         }
 
@@ -85,7 +85,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "FILE_TRANSFER_MEMORY_THRESHOLD=1048576;";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
                 command.CommandText = $"PUT file://{fullFileName} @~/{remoteFolderName} AUTO_COMPRESS=FALSE";
                 command.ExecuteNonQuery();
@@ -98,7 +98,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
                 command.CommandText = $"GET @~/{remoteFolderName} file://{downloadFolderName} PATTERN='{filePattern}'";
                 command.ExecuteNonQuery();
@@ -110,10 +110,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
                 command.CommandText = $"remove @~/{remoteFolderName};";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
         }
 

--- a/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/MaxLobSizeIT.cs
@@ -122,12 +122,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 using (var command = conn.CreateCommand())
                 {
                     // act
                     command.CommandText = $"SELECT RANDSTR({size}, 124)";
-                    string row = (string)await command.ExecuteScalarAsync(CancellationToken);
+                    string row = (string)await command.ExecuteScalarAsync(CancellationToken).ConfigureAwait(false);
 
                     // assert
                     Assert.Equal(size, row.Length);
@@ -147,17 +147,17 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
                     // act
                     command.CommandText = $"{t_insertQuery.Value} ('{c1}', '{c2}', '{c3}')";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = t_selectQuery.Value;
-                    var reader = await command.ExecuteReaderAsync();
+                    var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // assert
                     Assert.True(reader.Read());
@@ -180,8 +180,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
@@ -206,10 +206,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p3.Value = c3;
                     command.Parameters.Add(p3);
 
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = t_selectQuery.Value;
-                    var reader = await command.ExecuteReaderAsync();
+                    var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // assert
                     Assert.True(reader.Read());
@@ -233,8 +233,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
@@ -259,10 +259,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p3.Value = c3;
                     command.Parameters.Add(p3);
 
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = t_selectQuery.Value;
-                    var reader = await command.ExecuteReaderAsync();
+                    var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // assert
                     Assert.True(reader.Read());
@@ -288,12 +288,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
-                await PutFile(conn);
-                await CopyIntoTableAsync(conn);
-                await GetFileAsync(conn);
+                await PutFile(conn).ConfigureAwait(false);
+                await CopyIntoTableAsync(conn).ConfigureAwait(false);
+                await GetFileAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -375,13 +375,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 command.CommandText = $"COPY INTO {t_tableName.Value}";
 
                 // act
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                 // arrange
                 command.CommandText = $"SELECT * FROM {t_tableName.Value}";
 
                 // act
-                var reader = await command.ExecuteReaderAsync();
+                var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                 // assert
                 Assert.True(await reader.ReadAsync().ConfigureAwait(false));
@@ -430,7 +430,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Alter session result format
                 command.CommandText = $"ALTER SESSION SET DOTNET_QUERY_RESULT_FORMAT = {_resultFormat}";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                 //// Alter session max lob
                 //command.CommandText = "ALTER SESSION SET FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY = 'ENABLED'";

--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -38,7 +38,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     "cola INTEGER",
                     "colb STRING"
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -86,7 +86,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "timeData TIME",
                     "dateTimeData DATETIME",
                     "dateTimeWithTimeZone TIMESTAMP_TZ"
-                });
+                }).ConfigureAwait(false);
                 foreach (DbType type in Enum.GetValues(typeof(DbType)))
                 {
                     bool isTypeSupported = true;
@@ -229,7 +229,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "timeData TIME",
                     "dateTimeData DATETIME",
                     "dateTimeWithTimeZone TIMESTAMP_TZ"
-                });
+                }).ConfigureAwait(false);
 
                 foreach (DbType type in Enum.GetValues(typeof(DbType)))
                 {
@@ -342,7 +342,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         using (var command = dbConnection.CreateCommand())
                         {
                             command.CommandText = $"select {colName} from {fixtureTableName};";
-                            using (IDataReader reader = await command.ExecuteReaderAsync())
+                            using (IDataReader reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                             {
                                 reader.Read();
                                 Assert.True(!reader.IsDBNull(0));
@@ -392,7 +392,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         }
 
                         var fixtureTableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-                        await _fixture.CreateOrReplaceTable(dbConnection, fixtureTableName, columns);
+                        await _fixture.CreateOrReplaceTable(dbConnection, fixtureTableName, columns).ConfigureAwait(false);
 
                         using (var command = dbConnection.CreateCommand())
                         {
@@ -556,7 +556,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "cold TIME",
                     "cole TIMESTAMP_NTZ",
                     "colf TIMESTAMP_TZ"
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -662,7 +662,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     cmd.Parameters.Clear();
                     cmd.CommandText = $"SELECT * FROM {fixtureTableName}";
-                    IDataReader reader = await cmd.ExecuteReaderAsync();
+                    IDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
                 }
 
@@ -688,7 +688,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "cola REAL",
                     "colb TEXT",
                     "colc NUMBER(38,0)"
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -736,7 +736,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(total * 3, rowsCount);
 
                     cmd.CommandText = $"SELECT * FROM {fixtureTableName}";
-                    IDataReader reader = await cmd.ExecuteReaderAsync();
+                    IDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
                 }
 
@@ -756,7 +756,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await _fixture.CreateOrReplaceTable(conn, fixtureTableName, new[]
                 {
                     "cola INTEGER"
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -780,7 +780,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(70000, count);
 
                     cmd.CommandText = $"SELECT * FROM {fixtureTableName}";
-                    IDataReader reader = await cmd.ExecuteReaderAsync();
+                    IDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
                 }
                 await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
@@ -800,7 +800,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await _fixture.CreateOrReplaceTable(conn, fixtureTableName, new[]
                 {
                     "cola INTEGER",
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -833,7 +833,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await _fixture.CreateOrReplaceTable(conn, fixtureTableName, new[]
                 {
                     "cola INTEGER",
-                });
+                }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -950,7 +950,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     fixtureTableName,
                     tableType.TableDDLCreationPrefix(),
                     columns,
-                    tableType.TableDDLCreationFlags());
+                    tableType.TableDDLCreationFlags()).ConfigureAwait(false);
 
                 // Act+Assert
                 var sqlInsert = $"insert into {fixtureTableName} ({sql_columns}) values ({sql_values})";

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1103,10 +1103,10 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             await trans.RollbackAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
 
-            await (await conn.BeginTransactionAsync()).RollbackAsync().ConfigureAwait(false);
+            await (await conn.BeginTransactionAsync().ConfigureAwait(false)).RollbackAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
 
-            await (await conn.BeginTransactionAsync()).CommitAsync().ConfigureAwait(false);
+            await (await conn.BeginTransactionAsync().ConfigureAwait(false)).CommitAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -404,7 +404,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
                 try
                 {
                     conn.ConnectionString = invalidStrings[i];
-                    await conn.OpenAsync();
+                    await conn.OpenAsync().ConfigureAwait(false);
                     Assert.Fail();
                 }
                 catch (SnowflakeDbException e)
@@ -470,14 +470,14 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
 
         Assert.Equal(ConnectionState.Closed, conn.State);
 
-        await conn.OpenAsync(CancellationToken);
+        await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
 
         Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
         Assert.Equal(ConnectionState.Open, conn.State);
 
-        var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(databaseName));
+        var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(databaseName)).ConfigureAwait(false);
         Assert.Equal(2043, ex.ErrorCode); // object does not exist
-        await conn.CloseAsync(CancellationToken);
+        await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
     }
 
     [SFTheory(SkipCondition.RunOnlyOnCloudAWS)]
@@ -492,14 +492,14 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
 
         Assert.Equal(ConnectionState.Closed, conn.State);
 
-        await conn.OpenAsync(CancellationToken);
+        await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
 
         Assert.Equal(_fixture.testConfig.database.ToUpper(), conn.Database);
         Assert.Equal(ConnectionState.Open, conn.State);
 
-        var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(invalidDatabaseName, CancellationToken));
+        var ex = await Assert.ThrowsAsync<SnowflakeDbException>(() => conn.ChangeDatabaseAsync(invalidDatabaseName, CancellationToken)).ConfigureAwait(false);
         Assert.Equal(1003, ex.ErrorCode); // unable to parse sql
-        await conn.CloseAsync(CancellationToken);
+        await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
     }
 
     [SFFact]
@@ -573,12 +573,12 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
         {
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c INT" });
-            var t1 = await conn.BeginTransactionAsync();
+            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c INT" }).ConfigureAwait(false);
+            var t1 = await conn.BeginTransactionAsync().ConfigureAwait(false);
             var t1c1 = conn.CreateCommand();
             t1c1.Transaction = t1;
             t1c1.CommandText = $"insert into {tableName} values (1)";
-            await t1c1.ExecuteNonQueryAsync();
+            await t1c1.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
 
         using (var conn = new SnowflakeDbConnection())
@@ -589,7 +589,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var command = conn.CreateCommand();
             command.CommandText = $"SELECT * FROM {tableName}";
-            IDataReader reader = await command.ExecuteReaderAsync();
+            IDataReader reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
             Assert.False(reader.Read());
         }
     }
@@ -1078,7 +1078,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             var closeTask = conn.CloseAsync(CancellationToken.None);
             try
             {
-                await closeTask;
+                await closeTask.ConfigureAwait(false);
                 Assert.Fail();
             }
             catch (AggregateException e)
@@ -1098,15 +1098,15 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
 
-            var trans = await conn.BeginTransactionAsync();
+            var trans = await conn.BeginTransactionAsync().ConfigureAwait(false);
             Assert.True(conn.HasActiveExplicitTransaction());
-            await trans.RollbackAsync();
+            await trans.RollbackAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
 
-            await (await conn.BeginTransactionAsync()).RollbackAsync();
+            await (await conn.BeginTransactionAsync()).RollbackAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
 
-            await (await conn.BeginTransactionAsync()).CommitAsync();
+            await (await conn.BeginTransactionAsync()).CommitAsync().ConfigureAwait(false);
             Assert.False(conn.HasActiveExplicitTransaction());
         }
     }
@@ -1166,7 +1166,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             var command = conn.CreateCommand();
             // This query itself will be part of the history and will have the query tag
             command.CommandText = "SELECT QUERY_TAG FROM table(information_schema.query_history_by_session())";
-            var queryTag = await command.ExecuteScalarAsync();
+            var queryTag = await command.ExecuteScalarAsync().ConfigureAwait(false);
 
             Assert.Equal(expectedQueryTag, queryTag);
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -210,12 +210,12 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                     conn.ConnectionString
                         = _fixture.ConnectionStringWithoutAuth
                           + $";authenticator=externalbrowser;user=qa@snowflakecomputing.com;BROWSER_RESPONSE_TIMEOUT={waitSeconds}";
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                     Assert.Equal(ConnectionState.Open, conn.State);
                     using (var command = conn.CreateCommand())
                     {
                         command.CommandText = "SELECT CURRENT_USER()";
-                        Assert.Equal("QA", (await command.ExecuteScalarAsync()).ToString());
+                        Assert.Equal("QA", (await command.ExecuteScalarAsync().ConfigureAwait(false)).ToString());
                     }
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -36,7 +36,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         {
             conn.ConnectionString = _fixture.ConnectionStringWithoutAuth +
                                     $";authenticator={oktaUrl};user={oktaUser};password={oktaPassword};";
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -53,7 +53,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.oktaUrl,
                       _fixture.testConfig.oktaUser,
                       _fixture.testConfig.oktaPassword);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -71,7 +71,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.oktaUrl,
                       _fixture.testConfig.oktaUser,
                       _fixture.testConfig.oktaPassword);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
 
@@ -85,7 +85,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.oktaUrl,
                       _fixture.testConfig.oktaUser,
                       _fixture.testConfig.oktaPassword);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -99,7 +99,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString
                 = _fixture.ConnectionStringWithoutAuth
                   + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com";
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
 
             // connection pooling is disabled for external browser by default
@@ -107,7 +107,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_USER()";
-                Assert.Equal("QA", (await command.ExecuteScalarAsync()).ToString());
+                Assert.Equal("QA", (await command.ExecuteScalarAsync().ConfigureAwait(false)).ToString());
             }
         }
     }
@@ -121,13 +121,13 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString
                 = _fixture.ConnectionStringWithoutAuth
                   + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com;POOLINGENABLED=TRUE";
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
             Assert.True(SnowflakeDbConnectionPool.GetPool(conn.ConnectionString).GetPooling());
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_USER()";
-                Assert.Equal("QA", (await command.ExecuteScalarAsync()).ToString());
+                Assert.Equal("QA", (await command.ExecuteScalarAsync().ConfigureAwait(false)).ToString());
             }
         }
     }
@@ -164,12 +164,12 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString
                 = _fixture.ConnectionStringWithoutAuth
                   + ";authenticator=externalbrowser;user=qa@snowflakecomputing.com;disable_console_login=false;";
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = "SELECT CURRENT_USER()";
-                Assert.Equal("QA", (await command.ExecuteScalarAsync()).ToString());
+                Assert.Equal("QA", (await command.ExecuteScalarAsync().ConfigureAwait(false)).ToString());
             }
         }
     }
@@ -219,7 +219,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                     }
                 }
             }
-        );
+        ).ConfigureAwait(false);
         stopwatch.Stop();
 
         // timeout after specified number of seconds
@@ -248,7 +248,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString = externalBrowserConnectionString;
 
             // Authenticate to retrieve and store the token if doesn't exist or invalid
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
 
@@ -257,7 +257,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString = externalBrowserConnectionString;
 
             // Authenticate using the SSO token (the connector will automatically use the token and a browser should not pop-up in this step)
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -276,7 +276,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             using (var connection = new SnowflakeDbConnection(ConnectionStringForOAuthFlows(_fixture.testConfig, authenticator)))
             {
                 // act
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
         finally
@@ -292,7 +292,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var connection = new SnowflakeDbConnection(ConnectionStringForPat(_fixture.testConfig)))
         {
             // act
-            await connection.OpenAsync(CancellationToken.None);
+            await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -316,7 +316,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString = externalBrowserConnectionString;
 
             // Authenticate to retrieve and store the token if doesn't exist or invalid
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
 
@@ -325,7 +325,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             conn.ConnectionString = externalBrowserConnectionString;
 
             // Authenticate using the SSO token (the connector will automatically use the token and a browser should not pop-up in this step)
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
 
@@ -391,7 +391,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
 
             // Authenticate to retrieve and store the token if doesn't exist or invalid
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -421,7 +421,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
 
             // Open a connection which should switch to external browser after trying to connect using the wrong token
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
 
             // Switch back to the default credential manager
@@ -439,7 +439,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 conn.ConnectionString
                     = _fixture.ConnectionStringWithoutAuth
                       + ";authenticator=externalbrowser;user=wrong@snowflakecomputing.com";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -461,7 +461,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       + String.Format(
                           ";authenticator=oauth;token={0}",
                           _fixture.testConfig.expOauthToken);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -485,7 +485,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.proxyHost,
                       _fixture.testConfig.proxyPort);
 
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -503,7 +503,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.authProxyUser,
                       _fixture.testConfig.authProxyPwd);
 
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -522,7 +522,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.authProxyPwd,
                       "*.foo.com %7C" + _fixture.testConfig.host + "|localhost");
 
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -539,14 +539,14 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                                          _fixture.testConfig.authProxyPort,
                                          _fixture.testConfig.authProxyUser,
                                          _fixture.testConfig.authProxyPwd);
-            await conn1.OpenAsync(CancellationToken);
+            await conn1.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // No proxy
         using (var conn2 = new SnowflakeDbConnection())
         {
             conn2.ConnectionString = _fixture.ConnectionString;
-            await conn2.OpenAsync(CancellationToken);
+            await conn2.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // Non authenticated proxy
@@ -557,7 +557,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                                          ";useProxy=true;proxyHost={0};proxyPort={1}",
                                          _fixture.testConfig.proxyHost,
                                          _fixture.testConfig.proxyPort);
-            await conn3.OpenAsync(CancellationToken);
+            await conn3.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // Invalid proxy
@@ -567,7 +567,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 _fixture.ConnectionString + "connection_timeout=20;useProxy=true;proxyHost=Invalid;proxyPort=8080;";
             try
             {
-                await conn4.OpenAsync(CancellationToken);
+                await conn4.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
             catch
@@ -587,7 +587,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                                                                                             _fixture.testConfig.authProxyPort,
                                                                                             _fixture.testConfig.authProxyUser,
                                                                                             _fixture.testConfig.authProxyPwd));
-            await conn5.OpenAsync(CancellationToken);
+            await conn5.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // No proxy again, but crl check is disabled
@@ -595,7 +595,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var conn6 = new SnowflakeDbConnection())
         {
             conn6.ConnectionString = ConnectionStringModifier.DisableCrlRevocationCheck(_fixture.ConnectionString);
-            await conn6.OpenAsync(CancellationToken);
+            await conn6.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // Another authenticated proxy, but this will create a new httpclient because there is
@@ -612,7 +612,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.authProxyPwd,
                       "*.foo.com %7C" + _fixture.testConfig.host + "|localhost");
 
-            await conn7.OpenAsync(CancellationToken);
+            await conn7.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // No proxy again, crl check is enabled in the default connection string for tests
@@ -620,7 +620,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var conn8 = new SnowflakeDbConnection())
         {
             conn8.ConnectionString = _fixture.ConnectionString;
-            await conn8.OpenAsync(CancellationToken);
+            await conn8.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // Another authenticated proxy with bypasslist, but this will create a new httpclient because of
@@ -637,7 +637,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.authProxyPwd,
                       "*.foo.com %7C" + _fixture.testConfig.host + "|localhost");
 
-            await conn9.OpenAsync(CancellationToken);
+            await conn9.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // Another authenticated proxy with bypasslist
@@ -654,7 +654,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.authProxyPwd,
                       "*.foo.com %7C" + _fixture.testConfig.host + "|localhost");
 
-            await conn10.OpenAsync(CancellationToken);
+            await conn10.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
 
         // No proxy, but crl check disabled
@@ -662,7 +662,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var conn11 = new SnowflakeDbConnection())
         {
             conn11.ConnectionString = ConnectionStringModifier.DisableCrlRevocationCheck(_fixture.ConnectionString);
-            await conn11.OpenAsync(CancellationToken);
+            await conn11.OpenAsync(CancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -672,7 +672,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         using (var conn = new SnowflakeDbConnection())
         {
             conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false;key1=test\'password;key2=test\"password;key3=test==password";
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
 
             Assert.Equal(SFSessionHttpClientProperties.DefaultRetryTimeout.TotalSeconds, conn.ConnectionTimeout);
@@ -686,7 +686,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 Assert.Equal(3, versionElements.Length);
             }
 
-            await conn.CloseAsync(CancellationToken);
+            await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Closed, conn.State);
         }
     }
@@ -698,7 +698,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         {
             conn.ConnectionString =
                 _fixture.ConnectionString + "poolingEnabled=false;key==word=value; key1=\"test;password\"; key2=\"test=password\"";
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
 
             Assert.Equal(SFSessionHttpClientProperties.DefaultRetryTimeout.TotalSeconds, conn.ConnectionTimeout);
@@ -712,7 +712,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 Assert.Equal(3, versionElements.Length);
             }
 
-            await conn.CloseAsync(CancellationToken);
+            await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Closed, conn.State);
         }
     }
@@ -722,16 +722,16 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
     {
         var conn = new SnowflakeDbConnection();
         conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false;CLIENT_SESSION_KEEP_ALIVE=true";
-        await conn.OpenAsync(CancellationToken);
+        await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
 
         Thread.Sleep(TimeSpan.FromSeconds(14430)); // more than 4 hrs
         using (var command = conn.CreateCommand())
         {
             command.CommandText = $"SELECT COUNT(*) FROM DOUBLE_TABLE";
-            Assert.Equal(46, await command.ExecuteScalarAsync());
+            Assert.Equal(46, await command.ExecuteScalarAsync().ConfigureAwait(false));
         }
 
-        await conn.CloseAsync(CancellationToken);
+        await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
         Assert.Equal(ConnectionState.Closed, conn.State);
     }
 
@@ -742,23 +742,23 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
         var conn = new SnowflakeDbConnection();
         conn.ConnectionString = _fixture.ConnectionString + "maxPoolSize=2;minPoolSize=0;expirationTimeout=14800;CLIENT_SESSION_KEEP_ALIVE=true";
-        await conn.OpenAsync(CancellationToken);
-        await conn.CloseAsync(CancellationToken);
+        await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
+        await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
 
         Assert.Equal(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
 
         var conn1 = new SnowflakeDbConnection();
         conn1.ConnectionString = _fixture.ConnectionString + ";CLIENT_SESSION_KEEP_ALIVE=true";
-        await conn1.OpenAsync(CancellationToken);
+        await conn1.OpenAsync(CancellationToken).ConfigureAwait(false);
         Thread.Sleep(TimeSpan.FromSeconds(14430)); // more than 4 hrs
 
         using (var command = conn.CreateCommand())
         {
             command.CommandText = $"SELECT COUNT(*) FROM DOUBLE_TABLE";
-            Assert.Equal(46, await command.ExecuteScalarAsync());
+            Assert.Equal(46, await command.ExecuteScalarAsync().ConfigureAwait(false));
         }
 
-        await conn1.CloseAsync(CancellationToken);
+        await conn1.CloseAsync(CancellationToken).ConfigureAwait(false);
         Assert.Equal(ConnectionState.Closed, conn1.State);
         Assert.Equal(1, SnowflakeDbConnectionPool.GetCurrentPoolSize());
     }
@@ -784,8 +784,8 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                 "externalbrowser");
 
             Assert.Equal(ConnectionState.Closed, conn.State);
-            await conn.OpenAsync(CancellationToken);
-            await conn.CloseAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
+            await conn.CloseAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Closed, conn.State);
         }
     }
@@ -801,7 +801,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       ";authenticator=snowflake_jwt;user={0};private_key_file={1}",
                       _fixture.testConfig.jwtAuthUser,
                       _fixture.testConfig.pemFilePath);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -817,7 +817,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       ";authenticator=snowflake_jwt;user={0};private_key_file={1}",
                       _fixture.testConfig.jwtAuthUser,
                       _fixture.testConfig.p8FilePath);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -834,7 +834,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.jwtAuthUser,
                       _fixture.testConfig.pwdProtectedPrivateKeyFilePath,
                       _fixture.testConfig.privateKeyFilePwd);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -850,7 +850,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       ";authenticator=snowflake_jwt;user={0};private_key={1}",
                       _fixture.testConfig.jwtAuthUser,
                       _fixture.testConfig.privateKey);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -867,7 +867,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                       _fixture.testConfig.jwtAuthUser,
                       _fixture.testConfig.pwdProtectedPrivateKey,
                       _fixture.testConfig.privateKeyFilePwd);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -885,7 +885,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                           ";authenticator=snowflake_jwt;user={0};private_key_pwd={1}",
                           _fixture.testConfig.jwtAuthUser,
                           _fixture.testConfig.privateKeyFilePwd);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -910,7 +910,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                           ";authenticator=snowflake_jwt;user={0};private_key_file={1};private_key_pwd=Invalid",
                           _fixture.testConfig.jwtAuthUser,
                           _fixture.testConfig.pwdProtectedPrivateKeyFilePath);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -934,7 +934,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                           ";authenticator=snowflake_jwt;user={0};private_key_file={1}",
                           _fixture.testConfig.jwtAuthUser,
                           _fixture.testConfig.pwdProtectedPrivateKeyFilePath);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -958,7 +958,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                           ";authenticator=snowflake_jwt;user={0};private_key_file={1}",
                           "WrongUser",
                           _fixture.testConfig.pemFilePath);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -983,7 +983,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                           "WrongUser",
                           _fixture.testConfig.pwdProtectedPrivateKeyFilePath,
                           _fixture.testConfig.privateKeyFilePwd);
-                await conn.OpenAsync(CancellationToken);
+                await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                 Assert.Fail();
             }
         }
@@ -1004,7 +1004,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                   + String.Format(
                       ";authenticator=oauth;token={0}",
                       _fixture.testConfig.oauthToken);
-            await conn.OpenAsync(CancellationToken);
+            await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
             Assert.Equal(ConnectionState.Open, conn.State);
         }
     }
@@ -1044,7 +1044,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                     Console.WriteLine($"{conn.ConnectionString}");
                     try
                     {
-                        await conn.OpenAsync(CancellationToken);
+                        await conn.OpenAsync(CancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {
@@ -1059,7 +1059,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                         try
                         {
                             command.CommandText = "SELECT 1";
-                            await command.ExecuteScalarAsync();
+                            await command.ExecuteScalarAsync().ConfigureAwait(false);
                         }
                         catch (Exception e)
                         {

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
@@ -52,7 +52,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 using (var conn = new SnowflakeDbConnection())
                 {
-                    await conn.OpenAsync();
+                    await conn.OpenAsync().ConfigureAwait(false);
                     Assert.Equal(ConnectionState.Open, conn.State);
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbAdaptorIT.cs
@@ -48,11 +48,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 _adapter = new SnowflakeDbDataAdapter("select 1 as col1, 2 AS col2", conn);
                 _adapter.Fill(ds);
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
             Assert.Equal("Table", ds.Tables[0].TableName);
             Assert.Equal(ds.Tables[0].Rows[0].ItemArray[0], 1L);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandIT.cs
@@ -84,7 +84,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         }
                     });
 
-                    await Task.Delay(8000);
+                    await Task.Delay(8000).ConfigureAwait(false);
                     cmd.Cancel();
 
                     try
@@ -108,7 +108,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 Assert.Equal(ConnectionState.Open, conn.State);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -122,7 +122,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.NotEqual(0, queryResult);
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     });
                 }
                 Task.WaitAll(taskArray);
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -167,7 +167,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -178,7 +178,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("Invalid query id format. Expected a UUID.", thrown.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -190,7 +190,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -201,7 +201,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("Invalid query id format. Expected a UUID.", thrown.InnerException.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -213,7 +213,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -224,7 +224,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(QueryStatus.NoData, queryStatus);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -236,7 +236,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -247,7 +247,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("Max retry for no data is reached", thrown.InnerException.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -261,7 +261,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -277,7 +277,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("Max retry for no data is reached", thrown.InnerException.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
@@ -175,7 +175,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // Act
                     cancelToken.Cancel();
                     var thrown = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                        await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false));
+                        await cmd.GetResultsFromQueryIdAsync(queryId, cancelToken.Token).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("The operation was canceled", thrown.Message);
@@ -268,7 +268,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                        await cmd.GetResultsFromQueryIdAsync(queryId, CancellationToken.None).ConfigureAwait(false));
+                        await cmd.GetResultsFromQueryIdAsync(queryId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("'FAKE_TABLE' does not exist", thrown.Message);
@@ -292,7 +292,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     // Act
                     var thrown = await Assert.ThrowsAsync<Exception>(async () =>
-                        await cmd.GetQueryStatusAsync(fakeQueryId, CancellationToken.None).ConfigureAwait(false));
+                        await cmd.GetQueryStatusAsync(fakeQueryId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("Invalid query id format. Expected a UUID.", thrown.Message);
@@ -316,7 +316,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     // Act
                     var thrown = await Assert.ThrowsAsync<Exception>(async () =>
-                        await cmd.GetResultsFromQueryIdAsync(fakeQueryId, CancellationToken.None).ConfigureAwait(false));
+                        await cmd.GetResultsFromQueryIdAsync(fakeQueryId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("Invalid query id format. Expected a UUID.", thrown.Message);
@@ -363,7 +363,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     // Act
                     var thrown = await Assert.ThrowsAsync<Exception>(async () =>
-                        await cmd.GetResultsFromQueryIdAsync(unknownQueryId, CancellationToken.None).ConfigureAwait(false));
+                        await cmd.GetResultsFromQueryIdAsync(unknownQueryId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("Max retry for no data is reached", thrown.Message);
@@ -392,7 +392,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                     // Act
                     var thrown = await Assert.ThrowsAsync<Exception>(async () =>
-                        await queryResultsAwaiter.RetryUntilQueryResultIsAvailable(conn, unknownQueryId, CancellationToken.None, true).ConfigureAwait(false));
+                        await queryResultsAwaiter.RetryUntilQueryResultIsAvailable(conn, unknownQueryId, CancellationToken.None, true).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Assert
                     Assert.Contains("Max retry for no data is reached", thrown.Message);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITAsync.cs
@@ -33,7 +33,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select count(seq4()) from table(generator(timelimit => 20)) v";
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 cmd.CommandTimeout = 10;
                 try
                 {
-                    await cmd.ExecuteScalarAsync(externalCancel.Token);
+                    await cmd.ExecuteScalarAsync(externalCancel.Token).ConfigureAwait(false);
                     Assert.Fail();
                 }
                 catch
@@ -49,8 +49,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // assert that cancel is not triggered by timeout, but external cancellation
                     Assert.True(externalCancel.IsCancellationRequested);
                 }
-                await Task.Delay(2000);
-                await conn.CloseAsync();
+                await Task.Delay(2000).ConfigureAwait(false);
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -258,7 +258,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     var queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
                     while (statusRetryCount < statusMaxRetryCount && conn.IsStillRunning(queryStatus))
                     {
-                        await Task.Delay(1000);
+                        await Task.Delay(1000).ConfigureAwait(false);
                         queryStatus = await cmd.GetQueryStatusAsync(queryId, CancellationToken.None).ConfigureAwait(false);
                         statusRetryCount++;
                     }
@@ -409,7 +409,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1";
 
@@ -461,7 +461,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 object val = cmd.ExecuteScalar();
                 Assert.Equal(1L, (long)val);
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -472,14 +472,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select seq4(), uniform(1, 10, 42) from table(generator(rowcount => 200000)) v order by 1";
-                using (var reader = await cmd.ExecuteReaderAsync())
+                using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                 {
                     int counter = 0;
-                    while (await reader.ReadAsync())
+                    while (await reader.ReadAsync().ConfigureAwait(false))
                     {
                         Assert.Equal(counter.ToString(), reader.GetString(0));
                         // don't test the second column as it has random values just to increase the response size
@@ -487,7 +487,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                     Assert.Equal(200000, counter);
                 }
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -499,13 +499,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = connectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select seq4(), uniform(1, 10, 42) from table(generator(rowcount => 10000)) v order by 1";
-                var reader = await cmd.ExecuteReaderAsync();
+                var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                 int counter = 0;
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync().ConfigureAwait(false))
                 {
                     Assert.Equal(counter.ToString(), reader.GetString(0));
                     // don't test the second column as it has random values just to increase the response size
@@ -523,13 +523,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = connectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select seq4(), uniform(1, 10, 42) from table(generator(rowcount => 10000)) v order by 1";
-                var reader = await cmd.ExecuteReaderAsync();
+                var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                 int counter = 0;
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync().ConfigureAwait(false))
                 {
                     Assert.Equal(counter.ToString(), reader.GetString(0));
                     // don't test the second column as it has random values just to increase the response size
@@ -547,25 +547,25 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection(_fixture.ConnectionString + "poolingEnabled=false"))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = $"alter session set CLIENT_PREFETCH_THREADS = {prefetchThreads}";
-                await cmd.ExecuteNonQueryAsync();
+                await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                 // 10000 - value to ensure chunking occurs
                 cmd.CommandText = "select seq4(), uniform(1, 10, 42) from table(generator(rowcount => 10000)) v order by 1";
 
-                var reader = await cmd.ExecuteReaderAsync();
+                var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                 int counter = 0;
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync().ConfigureAwait(false))
                 {
                     Assert.Equal(counter.ToString(), reader.GetString(0));
                     // don't test the second column as it has random values just to increase the response size
                     counter++;
                 }
                 Assert.Equal(10000, counter);
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -576,13 +576,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select * from table_not_exists";
                 try
                 {
-                    var reader = await cmd.ExecuteReaderAsync();
+                    var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.Fail();
                 }
                 catch (SnowflakeDbException e)
@@ -591,7 +591,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.NotEqual("", e.QueryId);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -602,7 +602,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "select count(seq4()) from table(generator(timelimit => 20)) v";
@@ -623,7 +623,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 });
 
-                await Task.Delay(8000);
+                await Task.Delay(8000).ConfigureAwait(false);
                 cmd.Cancel();
 
                 try
@@ -645,7 +645,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -656,7 +656,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 // timelimit = 17min
@@ -681,7 +681,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(604, e.ErrorCode);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
         }
@@ -694,11 +694,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 try
                 {
-                    await conn.BeginTransactionAsync(IsolationLevel.ReadUncommitted);
+                    await conn.BeginTransactionAsync(IsolationLevel.ReadUncommitted).ConfigureAwait(false);
                     Assert.Fail();
                 }
                 catch (SnowflakeDbException e)
@@ -706,38 +706,38 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(270009, e.ErrorCode);
                 }
 
-                var tran = await conn.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+                var tran = await conn.BeginTransactionAsync(IsolationLevel.ReadCommitted).ConfigureAwait(false);
 
                 var command = conn.CreateCommand();
                 command.Transaction = tran;
                 command.CommandText = $"create or replace table {tableName}(cola string)";
-                await command.ExecuteNonQueryAsync();
-                await command.Transaction.CommitAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                await command.Transaction.CommitAsync().ConfigureAwait(false);
                 _fixture.AddTableToRemoveList(tableName);
 
                 command.CommandText = $"show tables like '{tableName}'";
-                var reader = await command.ExecuteReaderAsync();
-                Assert.True(await reader.ReadAsync());
-                Assert.False(await reader.ReadAsync());
+                var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                Assert.True(await reader.ReadAsync().ConfigureAwait(false));
+                Assert.False(await reader.ReadAsync().ConfigureAwait(false));
 
                 // start another transaction to test rollback
-                tran = await conn.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+                tran = await conn.BeginTransactionAsync(IsolationLevel.ReadCommitted).ConfigureAwait(false);
                 command.Transaction = tran;
                 command.CommandText = $"insert into {tableName} values('test')";
 
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 command.CommandText = $"select * from {tableName}";
-                reader = await command.ExecuteReaderAsync();
-                Assert.True(await reader.ReadAsync());
+                reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                Assert.True(await reader.ReadAsync().ConfigureAwait(false));
                 Assert.Equal("test", reader.GetString(0));
-                await command.Transaction.RollbackAsync();
+                await command.Transaction.RollbackAsync().ConfigureAwait(false);
 
                 // no value will be in table since it has been rollbacked
                 command.CommandText = $"select * from {tableName}";
-                reader = await command.ExecuteReaderAsync();
-                Assert.False(await reader.ReadAsync());
+                reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                Assert.False(await reader.ReadAsync().ConfigureAwait(false));
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -764,7 +764,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
@@ -772,7 +772,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     for (int i = 0; i < testCommands.Length; i++)
                     {
                         command.CommandText = testCommands[i];
-                        rowsAffected = await command.ExecuteNonQueryAsync();
+                        rowsAffected = await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                         Assert.Equal(expectedResult[i], rowsAffected);
                     }
@@ -786,16 +786,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
                     command.CommandText = "select 1 where 2 > 3";
-                    object val = await command.ExecuteScalarAsync();
+                    object val = await command.ExecuteScalarAsync().ConfigureAwait(false);
 
                     Assert.Equal(DBNull.Value, val);
                 }
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -808,9 +808,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 using (var command = conn.CreateCommand())
                 {
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                     command.CommandText = "select 1";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -822,30 +822,30 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (var command = conn.CreateCommand())
                 {
-                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c1 NUMBER" });
+                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c1 NUMBER" }).ConfigureAwait(false);
 
                     command.CommandText = $"insert into {tableName} values(1), (2), (3), (4), (5), (6)";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = "drop stage if exists my_unload_stage";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = "create stage if not exists my_unload_stage";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = $"copy into @my_unload_stage/unload/ from {tableName};";
-                    int affected = await command.ExecuteNonQueryAsync();
+                    int affected = await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     Assert.Equal(6, affected);
 
                     command.CommandText = "drop stage if exists my_unload_stage";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -853,7 +853,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task testPutArrayBindAsync()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            await ArrayBindTest(_fixture.ConnectionString + "poolingEnabled=false", tableName, 7500);
+            await ArrayBindTest(_fixture.ConnectionString + "poolingEnabled=false", tableName, 7500).ConfigureAwait(false);
         }
 
         private async Task ArrayBindTest(string connstr, string tableName, int size)
@@ -863,7 +863,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = connstr;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
@@ -873,7 +873,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "cold TIME",
                     "cole TIMESTAMP_NTZ",
                     "colf TIMESTAMP_TZ"
-                });
+                }).ConfigureAwait(false);
 
                 using (DbCommand cmd = conn.CreateCommand())
                 {
@@ -983,10 +983,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(total * 3, task.Result);
 
                     cmd.CommandText = "SELECT * FROM " + tableName;
-                    var reader = await cmd.ExecuteReaderAsync();
-                    Assert.True(await reader.ReadAsync(externalCancel.Token));
+                    var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
+                    Assert.True(await reader.ReadAsync(externalCancel.Token).ConfigureAwait(false));
                 }
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -1037,9 +1037,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola INTEGER" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola INTEGER" }).ConfigureAwait(false);
 
                 using (DbCommand cmd = conn.CreateCommand())
                 {
@@ -1057,14 +1057,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p1.DbType = DbType.Int16;
                     p1.Value = arrint.ToArray();
                     cmd.Parameters.Add(p1);
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     cmd.CommandText = $"SELECT COUNT(*) FROM {tableName}";
-                    var result = await cmd.ExecuteScalarAsync(externalCancel.Token);
+                    var result = await cmd.ExecuteScalarAsync(externalCancel.Token).ConfigureAwait(false);
 
                     Assert.Equal((long)total, result);
                 }
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -1074,7 +1074,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "GCS_USE_DOWNSCOPED_CREDENTIAL=true;poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 var rowCount = 100000L;
 
@@ -1083,7 +1083,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     command.CommandText = $"SELECT COUNT(*) FROM (select seq4() from table(generator(rowcount => {rowCount})))";
                     Assert.Equal(rowCount, command.ExecuteScalar());
                 }
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -1093,7 +1093,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // query id is null when no query executed
                 SnowflakeDbCommand command = (SnowflakeDbCommand)conn.CreateCommand();
@@ -1134,7 +1134,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 string queryId2 = command2.GetQueryId();
                 Assert.Null(queryId2);
                 command2.CommandText = "select 'test2'";
-                SnowflakeDbDataReader reader2 = (SnowflakeDbDataReader)await command2.ExecuteReaderAsync();
+                SnowflakeDbDataReader reader2 = (SnowflakeDbDataReader)await command2.ExecuteReaderAsync().ConfigureAwait(false);
                 queryId2 = command2.GetQueryId();
                 Assert.NotEmpty(queryId2);
                 Assert.Equal(queryId2, reader2.GetQueryId());
@@ -1150,7 +1150,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.Equal("test", reader.GetString(0));
 
                 command2.CommandText = $"select * from table(result_scan('{queryId2}'))";
-                reader2 = (SnowflakeDbDataReader)await command2.ExecuteReaderAsync();
+                reader2 = (SnowflakeDbDataReader)await command2.ExecuteReaderAsync().ConfigureAwait(false);
                 Assert.True(reader2.Read());
                 Assert.Equal("test2", reader2.GetString(0));
 
@@ -1169,7 +1169,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 queryId = command.GetQueryId();
                 Assert.NotEmpty(queryId);
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -1182,7 +1182,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -1206,7 +1206,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(QueryStatus.Success, cmd.GetQueryStatus(queryId));
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -1256,7 +1256,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 DbDataReader reader = cmd.GetResultsFromQueryId(queryId);
 
                 // Assert
-                Assert.True(await reader.ReadAsync());
+                Assert.True(await reader.ReadAsync().ConfigureAwait(false));
                 Assert.Equal($"waited {expectedWaitTime} seconds", reader.GetString(0));
                 Assert.Equal(QueryStatus.Success, cmd.GetQueryStatus(queryId));
             }
@@ -1275,7 +1275,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -1302,7 +1302,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("'FAKE_TABLE' does not exist", thrown.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -1312,7 +1312,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -1335,7 +1335,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Contains("Get and Put are not supported in async execution mode", thrown.Message);
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -1548,7 +1548,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 string connectQueryTag = "Test 123";
                 conn.ConnectionString = _fixture.ConnectionString + $";query_tag={connectQueryTag}";
 
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
                 ((SnowflakeDbCommand)command).QueryTag = expectedQueryTag;
                 // This query itself will be part of the history and will have the query tag
@@ -1564,7 +1564,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
 
                 command.CommandText = "\r\nselect '--'\r\n";
@@ -1580,7 +1580,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var command = conn.CreateCommand();
 
                 command.CommandText = "\r\nselect '--'\r\n";
@@ -1602,7 +1602,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -1617,13 +1617,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         {
                             File.WriteAllText(Path.Combine(tempFolder, $"{GetType().Name}_{i}.csv"), data);
                         }
-                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "COL1 STRING" });
+                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "COL1 STRING" }).ConfigureAwait(false);
                         cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{tableName} AUTO_COMPRESS=FALSE";
                         var reader = cmd.ExecuteReader();
 
                         // Act
                         cmd.CommandText = $"COPY INTO {tableName} FROM @%{tableName} PATTERN='.*.csv' FILE_FORMAT=(TYPE=CSV)";
-                        int actualRowCount = await cmd.ExecuteNonQueryAsync();
+                        int actualRowCount = await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                         // Assert
                         Assert.Equal(ExpectedRowCount, actualRowCount);
@@ -1647,7 +1647,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (SnowflakeDbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (SnowflakeDbCommand cmd = (SnowflakeDbCommand)conn.CreateCommand())
                 {
@@ -1662,7 +1662,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         {
                             File.WriteAllText(Path.Combine(tempFolder, $"{GetType().Name}_{i}.csv"), data);
                         }
-                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "COL1 STRING" });
+                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "COL1 STRING" }).ConfigureAwait(false);
                         cmd.CommandText = $"PUT file://{Path.Combine(tempFolder, "*.csv")} @%{tableName} AUTO_COMPRESS=FALSE";
                         var reader = cmd.ExecuteReader();
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITSlow.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbCommandITSlow.cs
@@ -27,7 +27,7 @@ public sealed class SFDbCommandITSlow : SFBaseTestAsync
         {
             conn.ConnectionString = _fixture.ConnectionString + "poolingEnabled=false";
 
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             var cmd = conn.CreateCommand();
             cmd.CommandText = "select count(seq4()) from table(generator(timelimit => 60)) v order by 1";
@@ -35,7 +35,7 @@ public sealed class SFDbCommandITSlow : SFBaseTestAsync
             // only one result is returned
             Assert.True(reader.Read());
 
-            await conn.CloseAsync(CancellationToken.None);
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
     }
@@ -57,9 +57,9 @@ public sealed class SFDbCommandITSlowB : SFBaseTestAsync
         var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
         using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString + "poolingEnabled=false"))
         {
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
-            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c1 NUMBER" });
+            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c1 NUMBER" }).ConfigureAwait(false);
 
             using (IDbCommand command = conn.CreateCommand())
             {
@@ -69,7 +69,7 @@ public sealed class SFDbCommandITSlowB : SFBaseTestAsync
                 Assert.Equal(-1, affected);
             }
 
-            await conn.CloseAsync(CancellationToken.None);
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -94,7 +94,7 @@ public sealed class SFDbCommandITSlowC : SFBaseTestAsync
             string maxRetryConnStr = _fixture.ConnectionString + "maxHttpRetries=8;poolingEnabled=false";
 
             conn.ConnectionString = maxRetryConnStr;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
@@ -145,7 +145,7 @@ public sealed class SFDbCommandITSlowD : SFBaseTestAsync
             string maxRetryConnStr = _fixture.ConnectionString + "maxHttpRetries=8;poolingEnabled=false";
 
             conn.ConnectionString = maxRetryConnStr;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
             try

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderGetEnumeratorIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderGetEnumeratorIT.cs
@@ -39,14 +39,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetEnumerator()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await CreateAndPopulateTestTableAsync(conn, tableName);
+                await CreateAndPopulateTestTableAsync(conn, tableName).ConfigureAwait(false);
 
                 string selectCommandText = $"select * from {tableName}";
                 var selectCmd = conn.CreateCommand();
                 selectCmd.CommandText = selectCommandText;
-                DbDataReader reader = await selectCmd.ExecuteReaderAsync() as DbDataReader;
+                DbDataReader reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false) as DbDataReader;
 
                 var enumerator = reader.GetEnumerator();
                 Assert.True(enumerator.MoveNext());
@@ -59,7 +59,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await DropTestTableAndCloseConnectionAsync(conn, tableName);
+                await DropTestTableAndCloseConnectionAsync(conn, tableName).ConfigureAwait(false);
             }
         }
 
@@ -67,21 +67,21 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetEnumeratorShouldBeEmptyWhenNotRowsReturned()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await CreateAndPopulateTestTableAsync(conn, tableName);
+                await CreateAndPopulateTestTableAsync(conn, tableName).ConfigureAwait(false);
 
                 string selectCommandText = $"select * from {tableName} WHERE cola > 10";
                 var selectCmd = conn.CreateCommand();
                 selectCmd.CommandText = selectCommandText;
-                DbDataReader reader = await selectCmd.ExecuteReaderAsync() as DbDataReader;
+                DbDataReader reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false) as DbDataReader;
 
                 var enumerator = reader.GetEnumerator();
                 Assert.False(enumerator.MoveNext());
                 Assert.Null(enumerator.Current);
 
                 reader.Close();
-                await DropTestTableAndCloseConnectionAsync(conn, tableName);
+                await DropTestTableAndCloseConnectionAsync(conn, tableName).ConfigureAwait(false);
             }
         }
 
@@ -89,21 +89,21 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetEnumeratorWithCastMethod()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await CreateAndPopulateTestTableAsync(conn, tableName);
+                await CreateAndPopulateTestTableAsync(conn, tableName).ConfigureAwait(false);
 
                 string selectCommandText = $"select * from {tableName}";
                 var selectCmd = conn.CreateCommand();
                 selectCmd.CommandText = selectCommandText;
-                DbDataReader reader = await selectCmd.ExecuteReaderAsync() as DbDataReader;
+                DbDataReader reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false) as DbDataReader;
 
                 var dataRecords = reader.Cast<DbDataRecord>().ToList();
                 Assert.Equal(3, dataRecords.Count);
 
                 reader.Close();
 
-                await DropTestTableAndCloseConnectionAsync(conn, tableName);
+                await DropTestTableAndCloseConnectionAsync(conn, tableName).ConfigureAwait(false);
             }
         }
 
@@ -111,22 +111,22 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetEnumeratorForEachShouldNotEnterWhenResultsIsEmpty()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await CreateAndPopulateTestTableAsync(conn, tableName);
+                await CreateAndPopulateTestTableAsync(conn, tableName).ConfigureAwait(false);
 
                 string selectCommandText = $"select * from {tableName} WHERE cola > 10";
                 var selectCmd = conn.CreateCommand();
                 selectCmd.CommandText = selectCommandText;
-                DbDataReader reader = await selectCmd.ExecuteReaderAsync();
+                DbDataReader reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false);
 
                 foreach (var record in reader)
                 {
                     Assert.Fail("Should not enter when results is empty");
                 }
 
-                await reader.CloseAsync();
-                await DropTestTableAndCloseConnectionAsync(conn, tableName);
+                await reader.CloseAsync().ConfigureAwait(false);
+                await DropTestTableAndCloseConnectionAsync(conn, tableName).ConfigureAwait(false);
             }
         }
 
@@ -134,14 +134,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetEnumeratorShouldThrowNonSupportedExceptionWhenReset()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await CreateAndPopulateTestTableAsync(conn, tableName);
+                await CreateAndPopulateTestTableAsync(conn, tableName).ConfigureAwait(false);
 
                 string selectCommandText = $"select * from {tableName}";
                 var selectCmd = conn.CreateCommand();
                 selectCmd.CommandText = selectCommandText;
-                DbDataReader reader = await selectCmd.ExecuteReaderAsync() as DbDataReader;
+                DbDataReader reader = await selectCmd.ExecuteReaderAsync().ConfigureAwait(false) as DbDataReader;
 
                 var enumerator = reader.GetEnumerator();
                 Assert.True(enumerator.MoveNext());
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await DropTestTableAndCloseConnectionAsync(conn, tableName);
+                await DropTestTableAndCloseConnectionAsync(conn, tableName).ConfigureAwait(false);
             }
         }
 
@@ -158,27 +158,27 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var cmd = conn.CreateCommand();
             cmd.CommandText = $"drop table if exists {tableName}";
-            var count = await cmd.ExecuteNonQueryAsync();
+            var count = await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
             Assert.Equal(0, count);
 
-            await CloseConnectionAsync(conn);
+            await CloseConnectionAsync(conn).ConfigureAwait(false);
         }
 
         private async Task CreateAndPopulateTestTableAsync(SnowflakeDbConnection conn, string tableName)
         {
-            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" });
+            await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" }).ConfigureAwait(false);
 
             var cmd = conn.CreateCommand();
 
             string insertCommand = $"insert into {tableName} values (3),(5),(8)";
             cmd.CommandText = insertCommand;
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
 
         private async Task<SnowflakeDbConnection> CreateAndOpenConnectionAsync()
         {
             var conn = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
             return conn;
         }
@@ -186,7 +186,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         private async Task CloseConnectionAsync(DbConnection conn)
         {
             SessionParameterAlterer.RestoreResultFormat(conn);
-            await conn.CloseAsync();
+            await conn.CloseAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -43,9 +43,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestRecordsAffected()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -63,7 +63,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.Equal(0, count);
 
                 // Reader's RecordsAffected should be available even if the connection is closed
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
                 Assert.Equal(3, reader.RecordsAffected);
             }
         }
@@ -72,9 +72,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetNumber()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola NUMBER" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -123,7 +123,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(reader.Read());
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
 
         }
@@ -136,9 +136,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetNumberWithHighScale(string columnType)
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { $"cola {columnType}" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { $"cola {columnType}" }).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = $"INSERT INTO {tableName} SELECT 1.23";
@@ -158,14 +158,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.False(reader.Read());
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
         [SFFact]
         public async Task TestGetDecfloatWithHighPrecision()
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "SELECT 12345678901234567890.123456789::DECFLOAT";
@@ -182,7 +182,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.False(reader.Read());
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -190,9 +190,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetDouble()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola DOUBLE" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola DOUBLE" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -233,7 +233,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(reader.Read());
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -246,7 +246,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("1900-09-03 00:00:00.0000000")]
         public async Task TestGetDate(string inputTimeStr)
         {
-            await TestGetDateAndOrTimeAsync(inputTimeStr, null, SFDataType.DATE);
+            await TestGetDateAndOrTimeAsync(inputTimeStr, null, SFDataType.DATE).ConfigureAwait(false);
         }
 
         [SFFact]
@@ -255,7 +255,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 IDbCommand cmd = conn.CreateCommand();
 
                 try
@@ -278,7 +278,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     cmd.ExecuteNonQuery();
                 }
 
-                await conn.CloseAsync(CancellationToken.None);
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -295,7 +295,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("1900-09-03 12:12:12.1212121", 1)]
         public async Task TestGetTime(string inputTimeStr, int? precision)
         {
-            await TestGetDateAndOrTimeAsync(inputTimeStr, precision, SFDataType.TIME);
+            await TestGetDateAndOrTimeAsync(inputTimeStr, precision, SFDataType.TIME).ConfigureAwait(false);
         }
 
         [SFTheory]
@@ -316,7 +316,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetTimeSpan(string inputTimeStr)
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 // Insert data
                 int fractionalPartIndex = inputTimeStr.IndexOf('.');
@@ -324,7 +324,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     $"cola TIME{ (precision > 0 ? string.Empty : $"({precision})")}"
-                });
+                }).ConfigureAwait(false);
                 IDbCommand cmd = conn.CreateCommand();
 
                 string insertCommand = $"insert into {tableName} values ('{inputTimeStr}')";
@@ -353,7 +353,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.Equal(dateTimeTime.Second, timeSpanTime.Seconds);
                 Assert.Equal(dateTimeTime.Millisecond, timeSpanTime.Milliseconds);
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -362,7 +362,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             // Only Time data can be retrieved using GetTimeSpan, other type will fail
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
@@ -380,7 +380,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "C12 ARRAY",
                     "C13 VARCHAR(1)",
                     "C14 TIME"
-                });
+                }).ConfigureAwait(false);
 
                 // Insert data
                 IDbCommand cmd = conn.CreateCommand();
@@ -441,7 +441,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -459,12 +459,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 inputTime = DateTime.ParseExact(inputTimeStr, "yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
             }
 
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     $"cola {dataType}{ (precision == null ? string.Empty : $"({precision})" )}"
-                });
+                }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
                 string insertCommand = $"insert into {tableName} values (?)";
@@ -532,7 +532,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -553,7 +553,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("1900-09-03 12:12:12.0000000", 1)]
         public async Task TestGetTimestampNTZ(string inputTimeStr, int? precision)
         {
-            await TestGetDateAndOrTimeAsync(inputTimeStr, precision, SFDataType.TIMESTAMP_NTZ);
+            await TestGetDateAndOrTimeAsync(inputTimeStr, precision, SFDataType.TIMESTAMP_NTZ).ConfigureAwait(false);
         }
 
 
@@ -566,9 +566,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetTimestampTZ(int timezoneOffsetInHours)
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola TIMESTAMP_TZ" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola TIMESTAMP_TZ" }).ConfigureAwait(false);
 
                 DateTimeOffset now = DateTimeOffset.Now.ToOffset(TimeSpan.FromHours(timezoneOffsetInHours));
 
@@ -598,7 +598,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.Equal(now, dtOffset);
                 Assert.Equal(now.Offset, dtOffset.Offset);
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
 
         }
@@ -607,13 +607,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetTimestampLTZ()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync())
+            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync().ConfigureAwait(false))
             {
                 var setTimezoneCmd = conn.CreateCommand();
                 setTimezoneCmd.CommandText = "ALTER SESSION SET TIMEZONE = 'America/Los_Angeles'";
-                await setTimezoneCmd.ExecuteNonQueryAsync();
+                await setTimezoneCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola TIMESTAMP_LTZ" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola TIMESTAMP_LTZ" }).ConfigureAwait(false);
 
                 DateTimeOffset insertValue = new DateTimeOffset(2024, 1, 15, 18, 30, 45, 123, TimeSpan.Zero);
 
@@ -643,7 +643,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 Assert.Equal(insertValue.UtcDateTime, dtOffset.UtcDateTime);
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -653,9 +653,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetBoolean(bool value)
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola BOOLEAN" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola BOOLEAN" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -680,7 +680,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.Equal(value, reader.GetBoolean(0));
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -692,12 +692,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Arrange
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 NUMBER(3)",
-                });
+                }).ConfigureAwait(false);
 
                 short[] testBytes = { 0, 10, 150, 200, 255 };
 
@@ -730,14 +730,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetBinary()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 BINARY",
                     "col2 VARCHAR(50)",
                     "col3 DOUBLE"
-                });
+                }).ConfigureAwait(false);
 
                 byte[] testBytes = Encoding.UTF8.GetBytes("TEST_GET_BINARAY");
                 string testChars = "TEST_GET_CHARS";
@@ -865,7 +865,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -877,12 +877,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Arrange
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 VARCHAR(50)",
-                });
+                }).ConfigureAwait(false);
 
                 char testChar = 'T';
 
@@ -905,14 +905,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetChars()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 VARCHAR(50)",
                     "col2 BINARY",
                     "col3 DOUBLE"
-                });
+                }).ConfigureAwait(false);
 
                 string testChars = "TEST_GET_CHARS";
                 byte[] testBytes = Encoding.UTF8.GetBytes("TEST_GET_BINARY");
@@ -1042,7 +1042,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1054,14 +1054,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Arrange
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 VARCHAR(50)",
                     "col2 BINARY",
                     "col3 DOUBLE"
-                });
+                }).ConfigureAwait(false);
 
                 string testChars = "TEST_GET_CHARS";
                 byte[] testBytes = Encoding.UTF8.GetBytes("TEST_GET_BINARY");
@@ -1095,14 +1095,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetStream()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "col1 VARCHAR(50)",
                     "col2 BINARY",
                     "col3 DOUBLE"
-                });
+                }).ConfigureAwait(false);
 
                 string testChars = "TEST_GET_CHARS";
                 byte[] testBytes = Encoding.UTF8.GetBytes("TEST_GET_BINARY");
@@ -1164,7 +1164,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1172,7 +1172,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [SFFact]
         public async Task TestGetValueIndexOutOfBound()
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 IDbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1";
@@ -1203,14 +1203,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 }
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
         [SFFact]
         public async Task TestBasicDataReader()
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 using (IDbCommand cmd = conn.CreateCommand())
                 {
@@ -1264,7 +1264,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1272,13 +1272,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestReadOutNullVal()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
                     "a INTEGER",
                     "b STRING"
-                });
+                }).ConfigureAwait(false);
 
                 using (IDbCommand cmd = conn.CreateCommand())
                 {
@@ -1301,7 +1301,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1309,9 +1309,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetGuid()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
                 string insertCommand = $"insert into {tableName} values (?)";
@@ -1346,7 +1346,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1355,9 +1355,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
             var stageName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = $"create or replace stage {stageName}";
@@ -1379,7 +1379,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 cmd.CommandText = $"drop stage {stageName}";
                 cmd.ExecuteNonQuery();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1388,9 +1388,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
             var stageName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola STRING" }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = $"create or replace stage {stageName}";
@@ -1422,7 +1422,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 cmd.CommandText = $"drop stage {stageName}";
                 cmd.ExecuteNonQuery();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1430,7 +1430,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestRetrieveSemiStructuredData()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                     {
@@ -1438,7 +1438,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         "colb ARRAY",
                         "colc OBJECT"
                     },
-                    "as select '[\"1\", \"2\"]', '[\"1\", \"2\"]', '{\"key\": \"value\"}'");
+                    "as select '[\"1\", \"2\"]', '[\"1\", \"2\"]', '{\"key\": \"value\"}'").ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -1453,7 +1453,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal("{\n  \"key\": \"value\"\n}", reader.GetString(2));
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1461,9 +1461,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestGetVariant()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola VARIANT" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "cola VARIANT" }).ConfigureAwait(false);
 
                 var cmd = conn.CreateCommand();
                 var insertCommand = $"insert into {tableName} (cola) select parse_json( (?) )";
@@ -1491,7 +1491,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 reader.Close();
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1499,7 +1499,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestResultSetMetadata()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 await _fixture.CreateOrReplaceTable(conn, tableName, new[]
                 {
@@ -1509,7 +1509,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     "c4 TIMESTAMP_NTZ",
                     "c5 VARIANT not null",
                     "c6 BOOLEAN"
-                });
+                }).ConfigureAwait(false);
 
                 IDbCommand cmd = conn.CreateCommand();
 
@@ -1564,14 +1564,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.True((bool)row[SchemaTableColumn.AllowDBNull]);
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
         [SFFact]
         public async Task TestHasRows()
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1 where 1=2";
@@ -1582,14 +1582,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 Assert.False(reader.HasRows);
                 reader.Close();
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
         [SFFact]
         public async Task TestHasRowsMultiStatement()
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1;" +
@@ -1629,7 +1629,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(reader.HasRows);
 
                 reader.Close();
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1646,7 +1646,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("9999999999999999999999999.99")] // Decimal + scale
         public async Task TestNumericValues(string testValue)
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select " + testValue;
@@ -1680,7 +1680,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                                 Assert.Throws<OverflowException>(() => reader.GetByte(0));
                         }
                     }
-                    await CloseConnectionAsync(conn);
+                    await CloseConnectionAsync(conn).ConfigureAwait(false);
                 }
             }
         }
@@ -1694,7 +1694,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("9999-12-31 23:59:59.9999999 +0000", 9)]
         public async Task TestTimestampTz(string testValue, int scale)
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
 
@@ -1710,7 +1710,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(expectedValue, reader.GetValue(0));
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1723,7 +1723,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("2019-01-01 12:12:12.1234567", 7, "2019-01-01 12:12:12.1234567 -08:00")]
         public async Task TestTimestampLtz(string testValue, int scale, string expectedValue)
         {
-            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync())
+            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
 
@@ -1742,7 +1742,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(expected, reader.GetValue(0));
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1752,7 +1752,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         [InlineData("9999-12-31 23:59:59.9999999", 9)]
         public async Task TestTimestampNtz(string testValue, int scale)
         {
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 DbCommand cmd = conn.CreateCommand();
 
@@ -1768,7 +1768,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(expectedValue, reader.GetValue(0));
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1779,11 +1779,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestDataTableLoadOnSemiStructuredColumn(string type)
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
                 var colName = "c1";
                 var expectedVal = "id:1";
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { $"{colName} {type}" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { $"{colName} {type}" }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -1809,9 +1809,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestTimestampLtzHonorsSessionTimezone()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync())
+            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -1855,7 +1855,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1863,9 +1863,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestTimestampLtzWithMultipleSessionTimezones()
         {
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync())
+            using (var conn = await CreateAndOpenConnectionWithHonorSessionTimezoneAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -1904,7 +1904,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -1914,9 +1914,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Verifies that without HonorSessionTimezone, TIMESTAMP_LTZ uses the local machine
             // timezone regardless of what the session timezone is set to.
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
-            using (var conn = await CreateAndOpenConnectionAsync())
+            using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "val TIMESTAMP_LTZ" }).ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -1950,14 +1950,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
                 }
 
-                await CloseConnectionAsync(conn);
+                await CloseConnectionAsync(conn).ConfigureAwait(false);
             }
         }
 
         private async Task<SnowflakeDbConnection> CreateAndOpenConnectionAsync()
         {
             var conn = new SnowflakeDbConnection(_fixture.ConnectionString);
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
             return conn;
         }
@@ -1965,7 +1965,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         private async Task<SnowflakeDbConnection> CreateAndOpenConnectionWithHonorSessionTimezoneAsync()
         {
             var conn = new SnowflakeDbConnection(_fixture.ConnectionString + "HonorSessionTimezone=true;");
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
             return conn;
         }
@@ -1973,7 +1973,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         private async Task CloseConnectionAsync(DbConnection conn)
         {
             SessionParameterAlterer.RestoreResultFormat(conn);
-            await conn.CloseAsync();
+            await conn.CloseAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbFactoryIT.cs
@@ -37,7 +37,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             _command.Connection = _connection;
             _command.CommandText = "select 1";
 
-            object res = await _command.ExecuteScalarAsync();
+            object res = await _command.ExecuteScalarAsync().ConfigureAwait(false);
 
             Assert.Equal(1L, res);
         }
@@ -57,7 +57,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             _command.Connection = _connection;
             _command.CommandText = "select ?";
 
-            var result = await _command.ExecuteScalarAsync();
+            var result = await _command.ExecuteScalarAsync().ConfigureAwait(false);
 
             Assert.Equal((long)expectedIntValue, result);
         }
@@ -69,13 +69,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             builder.ConnectionString = _fixture.ConnectionString;
 
             _connection.ConnectionString = builder.ConnectionString;
-            await _connection.OpenAsync(CancellationToken.None);
+            await _connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // set command's connection object
             _command.Connection = _connection;
             _command.CommandText = "select 1";
 
-            var result = await _command.ExecuteScalarAsync();
+            var result = await _command.ExecuteScalarAsync().ConfigureAwait(false);
 
             Assert.Equal(1L, result);
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbTransactionIT.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Arrange
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // Act
                 using (IDbTransaction t1 = conn.BeginTransaction())
@@ -40,7 +40,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 // Arrange
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // Act
                 using (IDbTransaction t1 = conn.BeginTransaction())
@@ -59,11 +59,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
-                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c INT" });
+                await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "c INT" }).ConfigureAwait(false);
 
-                using (IDbTransaction t1 = await conn.BeginTransactionAsync())
+                using (IDbTransaction t1 = await conn.BeginTransactionAsync().ConfigureAwait(false))
                 {
                     IDbCommand t1c1 = conn.CreateCommand();
                     t1c1.Transaction = t1;
@@ -86,15 +86,15 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
             var conn = new SnowflakeDbConnection();
             conn.ConnectionString = _fixture.ConnectionString;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             await _fixture.CreateOrReplaceTable(conn, tableName, new[]
             {
                 "x TIMESTAMP_NTZ",
                 "a INTEGER"
-            });
+            }).ConfigureAwait(false);
 
-            using (DbTransaction transaction = await conn.BeginTransactionAsync())
+            using (DbTransaction transaction = await conn.BeginTransactionAsync().ConfigureAwait(false))
             {
                 IDbCommand t1c1 = conn.CreateCommand();
                 t1c1.Transaction = transaction;
@@ -128,7 +128,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
             Assert.Equal(4, row);
 
-            await conn.CloseAsync(CancellationToken.None);
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact(RetriesCount = RetriesCount.Once)]
@@ -138,13 +138,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             var tableName = _fixture.TableNameBaseName + Guid.NewGuid().ToString("N");
             var conn = new SnowflakeDbConnection();
             conn.ConnectionString = _fixture.ConnectionString;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             await _fixture.CreateOrReplaceTable(conn, tableName, new[]
             {
                 "x TIMESTAMP_NTZ",
                 "a INTEGER"
-            });
+            }).ConfigureAwait(false);
 
             using (DbTransaction transaction = conn.BeginTransaction())
             {
@@ -155,7 +155,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 t1c1.Transaction.Commit();
             }
 
-            using (DbTransaction transaction2 = await conn.BeginTransactionAsync())
+            using (DbTransaction transaction2 = await conn.BeginTransactionAsync().ConfigureAwait(false))
             {
                 IDbCommand t2c2 = conn.CreateCommand();
                 t2c2.Transaction = transaction2;
@@ -178,7 +178,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             }
             Assert.Equal(3, row);
 
-            await conn.CloseAsync(CancellationToken.None);
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/IntegrationTests/SFMaxLobSizeSwitchIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMaxLobSizeSwitchIT.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString + "poolingEnabled=false"))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 IDbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "alter session set ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT=false";
                 cmd.ExecuteNonQuery();

--- a/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFMultiStatementsIT.cs
@@ -39,7 +39,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 IDbCommand cmd = conn.CreateCommand();
@@ -96,7 +96,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(reader.Read());
 
                 reader.Close();
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -106,7 +106,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 DbCommand cmd = conn.CreateCommand();
@@ -137,8 +137,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(await reader.NextResultAsync().ConfigureAwait(false));
                 Assert.False(await reader.ReadAsync().ConfigureAwait(false));
 
-                await reader.CloseAsync();
-                await conn.CloseAsync();
+                await reader.CloseAsync().ConfigureAwait(false);
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -148,7 +148,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 IDbCommand cmd = conn.CreateCommand();
@@ -191,7 +191,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(reader.NextResult());
 
                 reader.Close();
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -202,7 +202,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -257,7 +257,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p6.Value = "str3";
                     cmd.Parameters.Add(p6);
 
-                    DbDataReader reader = await cmd.ExecuteReaderAsync();
+                    DbDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // result of create
                     Assert.True(reader.HasRows);
@@ -297,7 +297,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     reader.Close();
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -308,7 +308,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync();
+                await conn.OpenAsync().ConfigureAwait(false);
 
                 using (var cmd = conn.CreateCommand())
                 {
@@ -417,7 +417,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -472,11 +472,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p6.Value = "str3";
                     cmd.Parameters.Add(p6);
 
-                    int count = await cmd.ExecuteNonQueryAsync();
+                    int count = await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                     Assert.Equal(3, count);
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -487,7 +487,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -511,19 +511,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     stmtCountParam.Value = 11;
                     cmd.Parameters.Add(stmtCountParam);
 
-                    DbDataReader reader = await cmd.ExecuteReaderAsync();
+                    DbDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // result of select
                     Assert.True(reader.HasRows);
                     Assert.Equal(-1, reader.RecordsAffected);
 
                     // result of create
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of explain
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     // server used to return query type of explain as select
                     // but now it could be a specific type of explain
@@ -531,37 +531,37 @@ namespace Snowflake.Data.Tests.IntegrationTests
                                   (reader.RecordsAffected == -1));
 
                     // result of show
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of insert
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(1, reader.RecordsAffected);
 
                     // result of describe
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of list
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.False(reader.HasRows); // no files staged for table t1
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of remove
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.False(reader.HasRows); // no files staged for table t1
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of create
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(0, reader.RecordsAffected);
 
                     // result of call
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     // The server behaivor is inconsistant for now, some of
                     // them returns procedure call as select while some of
@@ -570,15 +570,15 @@ namespace Snowflake.Data.Tests.IntegrationTests
                                   (reader.RecordsAffected == -1));
 
                     // result of use
-                    Assert.True(await reader.NextResultAsync());
+                    Assert.True(await reader.NextResultAsync().ConfigureAwait(false));
                     Assert.True(reader.HasRows);
                     Assert.Equal(0, reader.RecordsAffected);
 
-                    Assert.False(await reader.NextResultAsync());
-                    await reader.CloseAsync();
+                    Assert.False(await reader.NextResultAsync().ConfigureAwait(false));
+                    await reader.CloseAsync().ConfigureAwait(false);
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -588,7 +588,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -596,12 +596,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // MULTI_STATEMENT_COUNT=1
                     // multiple statements execution is disabled
                     cmd.CommandText = "alter session set MULTI_STATEMENT_COUNT=1";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     cmd.CommandText = "select 1; select 2; select 3";
                     try
                     {
-                        await cmd.ExecuteNonQueryAsync();
+                        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                         Assert.Fail();
                     }
                     catch
@@ -613,10 +613,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // MULTI_STATEMENT_COUNT=0
                     // multiple statements execution is enabled
                     cmd.CommandText = "alter session set MULTI_STATEMENT_COUNT=0";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     cmd.CommandText = "select 1; select 2; select 3";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     // Set MULTI_STATEMENT_COUNT per query (not match)
                     var stmtCountParam = cmd.CreateParameter();
@@ -628,7 +628,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     cmd.CommandText = "select 1; select 2; select 3";
                     try
                     {
-                        await cmd.ExecuteNonQueryAsync();
+                        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                         Assert.Fail();
                     }
                     catch
@@ -646,7 +646,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     cmd.Parameters.Add(stmtCountParam);
 
                     cmd.CommandText = "select 1; select 2; select 3";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     // No matter how session paramter is set
                     // parameter per query always works
@@ -654,7 +654,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     // multiple statements execution is enabled
                     cmd.Parameters.Clear();
                     cmd.CommandText = "alter session set MULTI_STATEMENT_COUNT=1";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     stmtCountParam = cmd.CreateParameter();
                     stmtCountParam.ParameterName = "MULTI_STATEMENT_COUNT";
@@ -663,10 +663,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     cmd.Parameters.Add(stmtCountParam);
 
                     cmd.CommandText = "select 1; select 2; select 3";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -677,7 +677,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 SessionParameterAlterer.SetResultFormat(conn, _resultFormat);
 
                 using (DbCommand cmd = conn.CreateCommand())
@@ -708,7 +708,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     stmtCountParam.Value = stmtCount;
                     cmd.Parameters.Add(stmtCountParam);
 
-                    DbDataReader reader = await cmd.ExecuteReaderAsync();
+                    DbDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
 
                     // at least one row in the first result set
                     Assert.True(reader.HasRows);
@@ -726,7 +726,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     reader.Close();
                 }
 
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -185,7 +185,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
                 // await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false); // intentionally closed
-                var snowflakeDbException = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await ProcessFileAsync(command, conn)).ConfigureAwait(false);
+                var snowflakeDbException = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await ProcessFileAsync(command, conn).ConfigureAwait(false)).ConfigureAwait(false);
                 Assert.NotNull(snowflakeDbException);
                 Assert.Null(snowflakeDbException.QueryId);
                 SnowflakeDbExceptionAssert.HasErrorCode(snowflakeDbException, SFError.EXECUTE_COMMAND_ON_CLOSED_CONNECTION);

--- a/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFPutGetTest.cs
@@ -100,7 +100,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -125,7 +125,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -150,7 +150,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -167,7 +167,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, new List<string> { t_inputFilePath }, t_internalStagePath);
             }
@@ -184,8 +184,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                // await conn.OpenAsync(CancellationToken.None); // intentionally closed
-                var snowflakeDbException = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await ProcessFileAsync(command, conn));
+                // await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false); // intentionally closed
+                var snowflakeDbException = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await ProcessFileAsync(command, conn)).ConfigureAwait(false);
                 Assert.NotNull(snowflakeDbException);
                 Assert.Null(snowflakeDbException.QueryId);
                 SnowflakeDbExceptionAssert.HasErrorCode(snowflakeDbException, SFError.EXECUTE_COMMAND_ON_CLOSED_CONNECTION);
@@ -201,13 +201,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var sql = $"GET {t_internalStagePath}/{t_fileName} file://{s_outputDirectory}";
                 using (var command = conn.CreateCommand())
                 {
                     command.CommandText = sql;
                     var reader = command.ExecuteReader();
-                    Assert.False(await reader.ReadAsync());
+                    Assert.False(await reader.ReadAsync().ConfigureAwait(false));
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var snowflakeDbException = Assert.Throws<SnowflakeDbException>(() => PutFile(conn));
                 Assert.NotNull(snowflakeDbException);
                 Assert.NotNull(snowflakeDbException.QueryId);
@@ -240,7 +240,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var snowflakeDbException = Assert.Throws<SnowflakeDbException>(() => PutFile(conn));
                 var queryId = snowflakeDbException.QueryId;
 
@@ -262,7 +262,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var snowflakeDbException = Assert.Throws<SnowflakeDbException>(() => PutFile(conn));
                 var queryId = snowflakeDbException.QueryId;
 
@@ -286,7 +286,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // Act
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 var queryId = PutFile(conn);
 
                 // Assert
@@ -311,7 +311,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, new List<string> { t_inputFilePath }, t_internalStagePath);
             }
@@ -334,7 +334,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -353,7 +353,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn, expectedStatus: ResultStatus.UPLOADED);
                 VerifyFilesAreUploaded(conn, new List<string> { t_inputFilePath }, t_internalStagePath);
                 PutFile(conn, expectedStatus: ResultStatus.SKIPPED);
@@ -373,7 +373,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn, overwriteAttribute, expectedStatus: ResultStatus.UPLOADED);
                 VerifyFilesAreUploaded(conn, new List<string> { t_inputFilePath }, t_internalStagePath);
                 PutFile(conn, overwriteAttribute, expectedStatus: ResultStatus.UPLOADED);
@@ -402,7 +402,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -430,7 +430,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -458,7 +458,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
                 VerifyFilesAreUploaded(conn, files, t_internalStagePath);
             }
@@ -475,10 +475,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
-                await CopyIntoTableAsync(conn);
-                await GetFileAsync(conn);
+                await CopyIntoTableAsync(conn).ConfigureAwait(false);
+                await GetFileAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -492,10 +492,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn);
-                await CopyIntoTableAsync(conn);
-                await GetFileAsync(conn);
+                await CopyIntoTableAsync(conn).ConfigureAwait(false);
+                await GetFileAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -509,11 +509,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString + ";GCS_USE_DOWNSCOPED_CREDENTIAL=true"))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 PutFile(conn);
-                await CopyIntoTableAsync(conn);
-                await GetFileAsync(conn);
+                await CopyIntoTableAsync(conn).ConfigureAwait(false);
+                await GetFileAsync(conn).ConfigureAwait(false);
             }
         }
 
@@ -525,10 +525,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             PrepareTest(null, stageType, stagePath, false, true, true);
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 PutFile(conn, "", ResultStatus.UPLOADED, true);
-                await CopyIntoTableAsync(conn, true);
-                await GetFileAsync(conn, true);
+                await CopyIntoTableAsync(conn, true).ConfigureAwait(false);
+                await GetFileAsync(conn, true).ConfigureAwait(false);
             }
         }
 
@@ -702,11 +702,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         break;
                 }
 
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                 // Check contents are correct
                 command.CommandText = $"SELECT * FROM {t_schemaName}.{t_tableName}";
-                var reader = await command.ExecuteReaderAsync();
+                var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
                 while (reader.Read())
                 {
                     for (var i = 0; i < s_colData.Length; i++)
@@ -717,7 +717,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 // Check row count is correct
                 command.CommandText = $"SELECT COUNT(*) FROM {t_schemaName}.{t_tableName}";
-                Assert.Equal(NumberOfRows, (long)await command.ExecuteScalarAsync());
+                Assert.Equal(NumberOfRows, (long)await command.ExecuteScalarAsync().ConfigureAwait(false));
             }
         }
 
@@ -759,7 +759,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             switch (command)
             {
                 case "GET":
-                    await GetFileAsync(connection);
+                    await GetFileAsync(connection).ConfigureAwait(false);
                     break;
                 case "PUT":
                     PutFile(connection);
@@ -834,16 +834,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = conn.CreateCommand())
                 {
                     // Drop temp stage
                     command.CommandText = $"DROP STAGE IF EXISTS {t_schemaName}.{t_stageName}";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     // Drop temp table
                     command.CommandText = $"DROP TABLE IF EXISTS {t_schemaName}.{t_tableName}";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
 
@@ -870,21 +870,21 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             using (var conn = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = conn.CreateCommand())
                 {
                     // Create temp table
                     var columnNamesWithTypes = string.Join(",", s_colName.Select(col => col + " STRING"));
                     command.CommandText = $"CREATE OR REPLACE TABLE {t_schemaName}.{t_tableName} ({columnNamesWithTypes})";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     // Create temp stage
                     command.CommandText = $"CREATE OR REPLACE STAGE {t_schemaName}.{t_stageName}";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     // Create temp stage without client side encryption
                     command.CommandText = $"CREATE OR REPLACE STAGE {t_schemaName}.{t_stageNameSse} ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFReusableChunkTest.cs
@@ -30,12 +30,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 try
                 {
                     SessionParameterAlterer.SetResultFormat(conn, ResultFormat.JSON);
-                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" });
+                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" }).ConfigureAwait(false);
 
                     IDbCommand cmd = conn.CreateCommand();
                     var rowCount = 0;
@@ -70,7 +70,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 finally
                 {
                     SessionParameterAlterer.RestoreResultFormat(conn);
-                    await conn.CloseAsync(CancellationToken.None);
+                    await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
             }
         }
@@ -88,10 +88,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 using (var conn = new SnowflakeDbConnection())
                 {
                     conn.ConnectionString = _fixture.ConnectionString;
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                     SessionParameterAlterer.SetResultFormat(conn, ResultFormat.JSON);
-                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "src VARIANT" });
+                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "src VARIANT" }).ConfigureAwait(false);
 
                     var cmd = conn.CreateCommand();
                     var rowCount = 0;
@@ -116,7 +116,7 @@ select parse_json('{{
 )
 ";
                     cmd.CommandText = insertCommand;
-                    IDataReader insertReader = await cmd.ExecuteReaderAsync();
+                    IDataReader insertReader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.Equal(500, insertReader.RecordsAffected);
 
                     var selectCommand = $"select * from {tableName}";
@@ -124,9 +124,9 @@ select parse_json('{{
                     cmd.CommandType = System.Data.CommandType.Text;
 
                     rowCount = 0;
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync().ConfigureAwait(false))
                         {
                             Newtonsoft.Json.JsonConvert.DeserializeObject(reader[0].ToString());
                             rowCount++;
@@ -135,7 +135,7 @@ select parse_json('{{
                     Assert.Equal(500, rowCount);
 
                     SessionParameterAlterer.RestoreResultFormat(conn);
-                    await conn.CloseAsync(CancellationToken.None);
+                    await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
             }
             finally
@@ -157,29 +157,29 @@ select parse_json('{{
             using (var conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 try
                 {
                     ChunkParserFactory.Instance = testFactory;
                     SessionParameterAlterer.SetResultFormat(conn, ResultFormat.JSON);
-                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" });
+                    await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" }).ConfigureAwait(false);
 
                     var cmd = conn.CreateCommand();
                     var rowCount = 0;
 
                     var insertCommand = $"insert into {tableName}(select hex_decode_string(hex_encode('snow') || '7F' || hex_encode('FLAKE')) from table(generator(rowcount => {TestRowCount})))";
                     cmd.CommandText = insertCommand;
-                    IDataReader insertReader = await cmd.ExecuteReaderAsync();
+                    IDataReader insertReader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.Equal(TestRowCount, insertReader.RecordsAffected);
 
                     var selectCommand = $"select * from {tableName}";
                     cmd.CommandText = selectCommand;
 
                     rowCount = 0;
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync().ConfigureAwait(false))
                         {
                             var obj = new object[reader.FieldCount];
                             reader.GetValues(obj);
@@ -199,7 +199,7 @@ select parse_json('{{
                 {
                     ChunkParserFactory.Instance = previous;
                     SessionParameterAlterer.RestoreResultFormat(conn);
-                    await conn.CloseAsync(CancellationToken.None);
+                    await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
             }
         }
@@ -220,19 +220,19 @@ select parse_json('{{
                 using (var conn = new SnowflakeDbConnection())
                 {
                     conn.ConnectionString = _fixture.ConnectionString;
-                    await conn.OpenAsync(CancellationToken.None);
+                    await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                     try
                     {
                         SessionParameterAlterer.SetResultFormat(conn, ResultFormat.JSON);
-                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" });
+                        await _fixture.CreateOrReplaceTable(conn, tableName, new[] { "col STRING" }).ConfigureAwait(false);
 
                         var cmd = conn.CreateCommand();
                         var rowCount = 0;
 
                         var insertCommand = $"insert into {tableName}(select hex_decode_string(hex_encode('snow') || '7F' || hex_encode('FLAKE')) from table(generator(rowcount => {TestRowCount})))";
                         cmd.CommandText = insertCommand;
-                        IDataReader insertReader = await cmd.ExecuteReaderAsync();
+                        IDataReader insertReader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
                         Assert.Equal(TestRowCount, insertReader.RecordsAffected);
 
                         var selectCommand = $"select * from {tableName}";
@@ -260,7 +260,7 @@ select parse_json('{{
                     finally
                     {
                         SessionParameterAlterer.RestoreResultFormat(conn);
-                        await conn.CloseAsync(CancellationToken.None);
+                        await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                     }
                 }
             }

--- a/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFStatementTypeTest.cs
@@ -19,14 +19,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     try
                     {
                         command.CommandText = "ALTER SESSION SET USE_STATEMENT_TYPE_CALL_FOR_STORED_PROC_CALLS=true";
-                        await command.ExecuteNonQueryAsync();
+                        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     }
                     catch (SnowflakeDbException ex)
                     {
@@ -41,7 +41,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         + "res.next();\n"
                         + "return res.getColumnValueAsString(1) + ' ' + res.getColumnValueAsString(2) + ' ' + IN2;\n"
                         + "$$;";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = "call TEST_SP_CALL_STMT_ENABLED(?, to_variant(?))";
 
@@ -57,7 +57,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     p2.Value = "[2,3]";
                     command.Parameters.Add(p2);
 
-                    DbDataReader reader = await command.ExecuteReaderAsync();
+                    DbDataReader reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     string result = "1 \"[2,3]\" [2,3]";
                     while (reader.Read())
@@ -66,9 +66,9 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     }
 
                     command.CommandText = "drop procedure if exists TEST_SP_CALL_STMT_ENABLED(float, variant)";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
-                await conn.CloseAsync();
+                await conn.CloseAsync().ConfigureAwait(false);
             }
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredArraysIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredArraysIT.cs
@@ -24,10 +24,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var expectedValueA = 'a';
                     var expectedValueB = 'b';
                     var expectedValueC = 'c';
@@ -36,7 +36,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     command.CommandText = $"SELECT {arraySFString} AS {colName}";
 
                     // act
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         var dt = new DataTable();
                         dt.Load(reader);
@@ -80,13 +80,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arraySFString = "ARRAY_CONSTRUCT('a','b','c')::ARRAY(TEXT)";
                     command.CommandText = $"SELECT {arraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -99,8 +99,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     if (_nativeArrow)
                     {
                         var arrowString = reader.GetString(0);
-                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON);
-                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON).ConfigureAwait(false);
+                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                         Assert.True(reader.Read());
                         var jsonString = reader.GetString(0);
 
@@ -116,14 +116,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfObjects =
                         "ARRAY_CONSTRUCT(OBJECT_CONSTRUCT('name', 'Alex'), OBJECT_CONSTRUCT('name', 'Brian'))::ARRAY(OBJECT(name VARCHAR))";
                     command.CommandText = $"SELECT {arrayOfObjects}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -142,13 +142,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
                 // arrange
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfArrays = "ARRAY_CONSTRUCT(ARRAY_CONSTRUCT('a', 'b'), ARRAY_CONSTRUCT('c', 'd'))::ARRAY(ARRAY(TEXT))";
                     command.CommandText = $"SELECT {arrayOfArrays}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -167,13 +167,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfMap = "ARRAY_CONSTRUCT(OBJECT_CONSTRUCT('a', 'b'))::ARRAY(MAP(VARCHAR,VARCHAR))";
                     command.CommandText = $"SELECT {arrayOfMap}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -198,12 +198,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     command.CommandText = $"SELECT {valueSfString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -222,13 +222,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfIntegers = "ARRAY_CONSTRUCT(3, 5, 8)::ARRAY(INTEGER)";
                     command.CommandText = $"SELECT {arrayOfIntegers}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -247,13 +247,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfLongs = "ARRAY_CONSTRUCT(3, 5, 8)::ARRAY(BIGINT)";
                     command.CommandText = $"SELECT {arrayOfLongs}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -272,13 +272,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfFloats = "ARRAY_CONSTRUCT(3.1, 5.2, 8.11)::ARRAY(FLOAT)";
                     command.CommandText = $"SELECT {arrayOfFloats}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -297,13 +297,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfDoubles = "ARRAY_CONSTRUCT(3.1, 5.2, 8.11)::ARRAY(DOUBLE)";
                     command.CommandText = $"SELECT {arrayOfDoubles}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -322,13 +322,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfDoubles = "ARRAY_CONSTRUCT(1.0e100, 1.0e-100)::ARRAY(DOUBLE)";
                     command.CommandText = $"SELECT {arrayOfDoubles}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -347,13 +347,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfBooleans = "ARRAY_CONSTRUCT(true, false)::ARRAY(BOOLEAN)";
                     command.CommandText = $"SELECT {arrayOfBooleans}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -372,13 +372,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfBinaries = "ARRAY_CONSTRUCT(TO_BINARY('AB', 'UTF-8'), TO_BINARY('BC', 'UTF-8'))::ARRAY(BINARY)";
                     command.CommandText = $"SELECT {arrayOfBinaries}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -398,13 +398,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfDates = "ARRAY_CONSTRUCT('2024-01-01'::DATE)::ARRAY(DATE)";
                     command.CommandText = $"SELECT {arrayOfDates}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -423,13 +423,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arraySFString = "ARRAY_CONSTRUCT('a',NULL,'b')::ARRAY(TEXT)";
                     command.CommandText = $"SELECT {arraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -448,13 +448,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arrayOfNumberSFString = "ARRAY_CONSTRUCT(3,NULL,5)::ARRAY(INTEGER)";
                     command.CommandText = $"SELECT {arrayOfNumberSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -473,13 +473,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var nullArraySFString = "NULL::ARRAY(TEXT)";
                     command.CommandText = $"SELECT {nullArraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -497,13 +497,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arraySFString = "ARRAY_CONSTRUCT('x', 'y')::ARRAY";
                     command.CommandText = $"SELECT {arraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -523,13 +523,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arraySFString = "ARRAY_CONSTRUCT('a76dacad-0e35-497b-bf9b-7cd49262b68b', 'z76dacad-0e35-497b-bf9b-7cd49262b68b')::ARRAY(TEXT)";
                     command.CommandText = $"SELECT {arraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -552,15 +552,15 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var arraySFString = @"ARRAY_CONSTRUCT(
                         OBJECT_CONSTRUCT('x', 'a', 'y', 'b')
                     )::ARRAY(OBJECT(x VARCHAR, y VARCHAR))";
                     command.CommandText = $"SELECT {arraySFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredMapsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredMapsIT.cs
@@ -49,10 +49,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var key = "city";
                     var value = "San Mateo";
                     var addressAsSFString = $"OBJECT_CONSTRUCT('{key}','{value}')::MAP(VARCHAR, VARCHAR)";
@@ -60,7 +60,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     command.CommandText = $"SELECT {addressAsSFString} AS {colName}";
 
                     // act
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         var dt = new DataTable();
                         dt.Load(reader);
@@ -78,13 +78,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var addressAsSFString = "OBJECT_CONSTRUCT('city','San Mateo', 'state', 'CA', 'zip', '01-234')::MAP(VARCHAR, VARCHAR)";
                     command.CommandText = $"SELECT {addressAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -100,8 +100,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     if (_nativeArrow)
                     {
                         var arrowString = reader.GetString(0);
-                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON);
-                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON).ConfigureAwait(false);
+                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                         Assert.True(reader.Read());
                         var jsonString = reader.GetString(0);
 
@@ -117,13 +117,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapSfString = "OBJECT_CONSTRUCT('5','San Mateo', '8', 'CA', '13', '01-234')::MAP(INTEGER, VARCHAR)";
                     command.CommandText = $"SELECT {mapSfString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -145,13 +145,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapSfString = "OBJECT_CONSTRUCT('5','San Mateo', '8', 'CA', '13', '01-234')::MAP(INTEGER, VARCHAR)";
                     command.CommandText = $"SELECT {mapSfString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -173,16 +173,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapWitObjectValueSFString = @"OBJECT_CONSTRUCT(
                         'Warsaw', OBJECT_CONSTRUCT('prefix', '01', 'postfix', '234'),
                         'San Mateo', OBJECT_CONSTRUCT('prefix', '02', 'postfix', '567')
                     )::MAP(VARCHAR, OBJECT(prefix VARCHAR, postfix VARCHAR))";
                     command.CommandText = $"SELECT {mapWitObjectValueSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -203,13 +203,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapWithArrayValueSFString = "OBJECT_CONSTRUCT('a', ARRAY_CONSTRUCT('b', 'c'))::MAP(VARCHAR, ARRAY(TEXT))";
                     command.CommandText = $"SELECT {mapWithArrayValueSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -229,13 +229,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapWithArrayValueSFString = "OBJECT_CONSTRUCT('a', ARRAY_CONSTRUCT('b', 'c'))::MAP(VARCHAR, ARRAY(TEXT))";
                     command.CommandText = $"SELECT {mapWithArrayValueSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -255,13 +255,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var mapAsSFString = "OBJECT_CONSTRUCT('a', OBJECT_CONSTRUCT('b', 'c'))::MAP(TEXT, MAP(TEXT, TEXT))";
                     command.CommandText = $"SELECT {mapAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -285,12 +285,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     command.CommandText = $"SELECT {valueSfString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -310,13 +310,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var nullMapSFString = "NULL::MAP(TEXT,TEXT)";
                     command.CommandText = $"SELECT {nullMapSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -334,13 +334,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var invalidMapSFString = "OBJECT_CONSTRUCT('x', 'y')::OBJECT";
                     command.CommandText = $"SELECT {invalidMapSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -360,16 +360,16 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var invalidMapSFString = @"OBJECT_CONSTRUCT(
                         'x', 'a76dacad-0e35-497b-bf9b-7cd49262b68b',
                         'y', 'z76dacad-0e35-497b-bf9b-7cd49262b68b'
                     )::MAP(TEXT,TEXT)";
                     command.CommandText = $"SELECT {invalidMapSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredObjectsIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredObjectsIT.cs
@@ -48,10 +48,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var key = "city";
                     var value = "San Mateo";
                     var addressAsSFString = $"OBJECT_CONSTRUCT('{key}','{value}')::OBJECT(city VARCHAR)";
@@ -59,7 +59,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     command.CommandText = $"SELECT {addressAsSFString} AS {colName}";
 
                     // act
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                     {
                         var dt = new DataTable();
                         dt.Load(reader);
@@ -77,13 +77,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var addressAsSFString = "OBJECT_CONSTRUCT('city','San Mateo', 'state', 'CA')::OBJECT(city VARCHAR, state VARCHAR)";
                     command.CommandText = $"SELECT {addressAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -97,8 +97,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     if (_nativeArrow)
                     {
                         var arrowString = reader.GetString(0);
-                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON);
-                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                        await EnableStructuredTypesAsync(connection, ResultFormat.JSON).ConfigureAwait(false);
+                        reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                         Assert.True(reader.Read());
                         var jsonString = reader.GetString(0);
 
@@ -114,14 +114,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var addressAsSFString =
                         "OBJECT_CONSTRUCT('city','San Mateo', 'state', 'CA', 'zip', OBJECT_CONSTRUCT('prefix', '00', 'postfix', '11'))::OBJECT(city VARCHAR, state VARCHAR, zip OBJECT(prefix VARCHAR, postfix VARCHAR))";
                     command.CommandText = $"SELECT {addressAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -143,13 +143,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectWithMap = "OBJECT_CONSTRUCT('names', OBJECT_CONSTRUCT('Excellent', '6', 'Poor', '1'))::OBJECT(names MAP(VARCHAR,VARCHAR))";
                     command.CommandText = $"SELECT {objectWithMap}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -170,13 +170,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectWithArray = "OBJECT_CONSTRUCT('names', ARRAY_CONSTRUCT('Excellent', 'Poor'))::OBJECT(names ARRAY(TEXT))";
                     command.CommandText = $"SELECT {objectWithArray}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -195,13 +195,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectWithArray = "OBJECT_CONSTRUCT('names', ARRAY_CONSTRUCT('Excellent', 'Poor'))::OBJECT(names ARRAY(TEXT))";
                     command.CommandText = $"SELECT {objectWithArray}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -223,12 +223,12 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     command.CommandText = $"SELECT {valueSfString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -247,10 +247,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = @"OBJECT_CONSTRUCT_KEEP_NULL(
                         'ObjectValue', NULL,
                         'ListValue', NULL,
@@ -267,7 +267,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         IMapValue MAP(INTEGER, INTEGER)
                     )";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -291,10 +291,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = @"OBJECT_CONSTRUCT_KEEP_NULL(
                         'ObjectValue', OBJECT_CONSTRUCT('Name', 'John'),
                         'ListValue', ARRAY_CONSTRUCT('a', 'b'),
@@ -311,7 +311,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         IMapValue MAP(INTEGER, INTEGER)
                     )";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -339,10 +339,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = @"OBJECT_CONSTRUCT(
                         'IntegerValue', '8',
                         'x', 'abc'
@@ -351,7 +351,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         x TEXT
                     )";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -372,10 +372,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = @"OBJECT_CONSTRUCT(
                         'x', 'abc',
                         'IntegerValue', '8'
@@ -384,7 +384,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         IntegerValue INTEGER
                     )";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -405,10 +405,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = @"OBJECT_CONSTRUCT(
                         'x', 'abc',
                         'IntegerValue', '8'
@@ -417,7 +417,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         IntegerValue INTEGER
                     )";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -438,13 +438,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var nullObjectSFString = "NULL::OBJECT(Name TEXT)";
                     command.CommandText = $"SELECT {nullObjectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -462,13 +462,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = "OBJECT_CONSTRUCT('x', 'y')::OBJECT";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -488,13 +488,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow);
+                    await EnableStructuredTypesAsync(connection, _resultFormat, _nativeArrow).ConfigureAwait(false);
                     var objectSFString = "OBJECT_CONSTRUCT('x', 'a', 'y', 'b')::OBJECT(x VARCHAR, y VARCHAR)";
                     command.CommandText = $"SELECT {objectSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredTypesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredTypesIT.cs
@@ -14,17 +14,17 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "alter session set ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE = true";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 command.CommandText = "alter session set IGNORE_CLIENT_VESRION_IN_STRUCTURED_TYPES_RESPONSE = true";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 command.CommandText = $"ALTER SESSION SET DOTNET_QUERY_RESULT_FORMAT = {resultFormat}";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 if (resultFormat == ResultFormat.ARROW)
                 {
                     command.CommandText = $"ALTER SESSION SET ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT = {nativeArrow}";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"ALTER SESSION SET FORCE_ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT  = {nativeArrow}";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/Snowflake.Data.Tests/IntegrationTests/StructuredTypesWithEmbeddedUnstructuredIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/StructuredTypesWithEmbeddedUnstructuredIT.cs
@@ -25,11 +25,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection);
-                    var timeZone = await GetTimeZoneAsync(connection);
+                    await EnableStructuredTypesAsync(connection).ConfigureAwait(false);
+                    var timeZone = await GetTimeZoneAsync(connection).ConfigureAwait(false);
                     var expectedOffset = timeZone.GetUtcOffset(DateTime.Parse("2024-07-11 14:20:05"));
                     var expectedOffsetString = ToOffsetString(expectedOffset);
                     var allTypesObjectAsSFString = @"OBJECT_CONSTRUCT(
@@ -77,7 +77,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     ), '2024-07-11 14:20:05'::TIMESTAMP_LTZ";
                     var bytesForBinary = Encoding.UTF8.GetBytes("this is binary data");
                     command.CommandText = $"SELECT {allTypesObjectAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -115,11 +115,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection);
-                    var timeZone = await GetTimeZoneAsync(connection);
+                    await EnableStructuredTypesAsync(connection).ConfigureAwait(false);
+                    var timeZone = await GetTimeZoneAsync(connection).ConfigureAwait(false);
                     var expectedOffset = timeZone.GetUtcOffset(DateTime.Parse("2024-07-11 14:20:05"));
                     var expectedOffsetString = ToOffsetString(expectedOffset);
                     var allTypesObjectAsSFString = @"OBJECT_CONSTRUCT(
@@ -167,7 +167,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     )";
                     var bytesForBinary = Encoding.UTF8.GetBytes("this is binary data");
                     command.CommandText = $"SELECT {allTypesObjectAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -205,10 +205,10 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(_fixture.ConnectionString))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
-                    await EnableStructuredTypesAsync(connection);
+                    await EnableStructuredTypesAsync(connection).ConfigureAwait(false);
                     var allTypesObjectAsSFString = @"OBJECT_CONSTRUCT_KEEP_NULL(
                         'StringValue', NULL,
                         'CharValue', NULL,
@@ -253,7 +253,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                         SemiStructuredValue OBJECT
                     )";
                     command.CommandText = $"SELECT {allTypesObjectAsSFString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act
@@ -292,18 +292,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(ConnectionStringWithHonorSessionTimezone))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText = "ALTER SESSION SET TIMEZONE = 'America/Los_Angeles'";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
-                    await EnableStructuredTypesAsync(connection);
-                    await SetTimePrecisionAsync(connection, 9);
+                    await EnableStructuredTypesAsync(connection).ConfigureAwait(false);
+                    await SetTimePrecisionAsync(connection, 9).ConfigureAwait(false);
                     var rawValueString = $"'{dbValue}'::{dbType}";
                     var objectValueString = $"OBJECT_CONSTRUCT('Value', {rawValueString})::OBJECT(Value {dbType})";
                     command.CommandText = $"SELECT {rawValueString}, {objectValueString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act/assert
@@ -423,18 +423,18 @@ namespace Snowflake.Data.Tests.IntegrationTests
             // arrange
             using (var connection = new SnowflakeDbConnection(ConnectionStringWithHonorSessionTimezone))
             {
-                await connection.OpenAsync(CancellationToken.None);
+                await connection.OpenAsync(CancellationToken.None).ConfigureAwait(false);
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText = "ALTER SESSION SET TIMEZONE = 'America/Los_Angeles'";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
-                    await EnableStructuredTypesAsync(connection);
-                    await SetTimePrecisionAsync(connection, 9);
+                    await EnableStructuredTypesAsync(connection).ConfigureAwait(false);
+                    await SetTimePrecisionAsync(connection, 9).ConfigureAwait(false);
                     var rawValueString = $"'{dbValue}'::{dbType}";
                     var objectValueString = $"OBJECT_CONSTRUCT('Value', {rawValueString})::OBJECT(Value {dbType})";
                     command.CommandText = $"SELECT {rawValueString}, {objectValueString}";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
 
                     // act/assert
@@ -550,7 +550,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "show parameters like 'timezone'";
-                var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                 Assert.True(reader.Read());
                 var timeZoneString = reader.GetString(1);
                 return TimeZoneInfoConverter.FindSystemTimeZoneById(timeZoneString);

--- a/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
@@ -204,7 +204,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     command.CommandText = "SELECT [1.1]::VECTOR(INT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
                     AssertExtensions.AnySucceeds(
                         () => Assert.Contains("Array-like value being cast to a vector has incorrect dimension", thrown.Message),
@@ -226,7 +226,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     command.CommandText = "SELECT [A, B, C]::VECTOR(INT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
                     Assert.Contains("invalid identifier", thrown.Message);
                 }
@@ -349,7 +349,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 {
                     command.CommandText = "SELECT [A, B, C]::VECTOR(FLOAT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
                     Assert.Contains("invalid identifier", thrown.Message);
                 }

--- a/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/VectorTypesIT.cs
@@ -37,27 +37,27 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = $"CREATE OR REPLACE TABLE {tableName} (a VECTOR(INT, 3));";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [1,2,3]::VECTOR(INT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [4,5,6]::VECTOR(INT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [7,8,9]::VECTOR(INT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = $"SELECT COUNT(*) FROM {tableName};";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
                     Assert.Equal(3, reader.GetInt16(0));
 
                     command.CommandText = $"SELECT * FROM {tableName};";
-                    reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1,2,3]", reader.GetString(0));
@@ -81,7 +81,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(9, arr[2]);
 
                     command.CommandText = $"DROP TABLE IF EXISTS {tableName};";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -93,27 +93,27 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = $"CREATE OR REPLACE TABLE {tableName} (a VECTOR(FLOAT, 3));";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [1.1,2.2,3.3]::VECTOR(FLOAT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [4.4,5.5,6.6]::VECTOR(FLOAT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     command.CommandText = $"INSERT INTO {tableName} SELECT [7.7,8.8,9.9]::VECTOR(FLOAT,3);";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                     command.CommandText = $"SELECT COUNT(*) FROM {tableName};";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
                     Assert.True(reader.Read());
                     Assert.Equal(3, reader.GetInt16(0));
 
                     command.CommandText = $"SELECT * FROM {tableName};";
-                    reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1.100000,2.200000,3.300000]", reader.GetString(0));
@@ -137,7 +137,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                     Assert.Equal(9.9f, arr[2]);
 
                     command.CommandText = $"DROP TABLE IF EXISTS {tableName};";
-                    await command.ExecuteNonQueryAsync();
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -148,13 +148,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [1, 2, 3]::VECTOR(INT, 3) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1,2,3]", reader.GetString(0));
@@ -173,13 +173,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = $"SELECT [{Int32.MinValue}, {Int32.MaxValue}]::VECTOR(INT, 2) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal($"[{Int32.MinValue},{Int32.MaxValue}]", reader.GetString(0));
@@ -197,14 +197,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [1.1]::VECTOR(INT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync());
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
 
                     AssertExtensions.AnySucceeds(
                         () => Assert.Contains("Array-like value being cast to a vector has incorrect dimension", thrown.Message),
@@ -219,14 +219,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [A, B, C]::VECTOR(INT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync());
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
 
                     Assert.Contains("invalid identifier", thrown.Message);
                 }
@@ -239,13 +239,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [1.1,2.22,3.333]::VECTOR(FLOAT, 3) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1.100000,2.220000,3.333000]", reader.GetString(0));
@@ -264,13 +264,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = $"SELECT [{float.MinValue}, {float.MaxValue}]::VECTOR(FLOAT, 2) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
 
@@ -292,13 +292,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [1,2,3]::VECTOR(FLOAT, 3) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1.000000,2.000000,3.000000]", reader.GetString(0));
@@ -317,13 +317,13 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [1.123456789,2.123456789,3.123456789]::VECTOR(FLOAT, 3) as vec;";
-                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync();
+                    var reader = (SnowflakeDbDataReader)await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     Assert.True(reader.Read());
                     Assert.Equal("[1.123457,2.123457,3.123457]", reader.GetString(0));
@@ -342,14 +342,14 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (DbConnection conn = new SnowflakeDbConnection())
             {
                 conn.ConnectionString = _fixture.ConnectionString;
-                await conn.OpenAsync(CancellationToken.None);
-                await AlterSessionSettingsAsync(conn);
+                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+                await AlterSessionSettingsAsync(conn).ConfigureAwait(false);
 
                 using (DbCommand command = conn.CreateCommand())
                 {
                     command.CommandText = "SELECT [A, B, C]::VECTOR(FLOAT, 3) as vec;";
 
-                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync());
+                    var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await command.ExecuteReaderAsync()).ConfigureAwait(false);
 
                     Assert.Contains("invalid identifier", thrown.Message);
                 }
@@ -361,7 +361,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             using (var command = conn.CreateCommand())
             {
                 command.CommandText = $"ALTER SESSION SET DOTNET_QUERY_RESULT_FORMAT = {_resultFormat}";
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
         }
     }

--- a/Snowflake.Data.Tests/MiniCoreTest.cs
+++ b/Snowflake.Data.Tests/MiniCoreTest.cs
@@ -27,13 +27,13 @@ namespace Snowflake.Data.Tests
         {
             SfMiniCore.StartLoading();
             for (int i = 0; i < 100 && !SfMiniCore.IsLoaded; i++)
-                await Task.Delay(10);
+                await Task.Delay(10).ConfigureAwait(false);
         }
 
         [SFFact]
         public async Task TestMinicoreLoadsAndTelemetryIsCorrect()
         {
-            await WaitForMiniCoreToLoad();
+            await WaitForMiniCoreToLoad().ConfigureAwait(false);
 
             var clientEnv = SFEnvironment.ClientEnv.CloneForSession();
             var loadError = SfMiniCore.GetLoadError();

--- a/Snowflake.Data.Tests/Mock/MockCloseHangingRestRequester.cs
+++ b/Snowflake.Data.Tests/Mock/MockCloseHangingRestRequester.cs
@@ -66,7 +66,7 @@ namespace Snowflake.Data.Tests.Mock
                     message = "Session no longer exists. New login required to access the service",
                     success = false
                 };
-                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
                 CloseRequests.Add(sfRequest);
                 return (T)(object)closeResponse;
             }

--- a/Snowflake.Data.Tests/Mock/MockCloseSessionException.cs
+++ b/Snowflake.Data.Tests/Mock/MockCloseSessionException.cs
@@ -14,7 +14,7 @@ namespace Snowflake.Data.Tests.Mock
 
         public T Get<T>(IRestRequest request)
         {
-            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
+            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None).ConfigureAwait(false)).Result;
         }
 
         public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)
@@ -34,7 +34,7 @@ namespace Snowflake.Data.Tests.Mock
 
         public T Post<T>(IRestRequest postRequest)
         {
-            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
+            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None).ConfigureAwait(false)).Result;
         }
 
         public Task<T> PostAsync<T>(IRestRequest postRequest, CancellationToken cancellationToken)

--- a/Snowflake.Data.Tests/Mock/MockRestRequesterForQueryCancellation.cs
+++ b/Snowflake.Data.Tests/Mock/MockRestRequesterForQueryCancellation.cs
@@ -90,12 +90,12 @@ namespace Snowflake.Data.Tests.Mock
 
         public T Post<T>(IRestRequest postRequest)
         {
-            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None)).Result;
+            return Task.Run(async () => await PostAsync<T>(postRequest, CancellationToken.None).ConfigureAwait(false)).Result;
         }
 
         public T Get<T>(IRestRequest request)
         {
-            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None)).Result;
+            return Task.Run(async () => await GetAsync<T>(request, CancellationToken.None).ConfigureAwait(false)).Result;
         }
 
         public Task<T> GetAsync<T>(IRestRequest request, CancellationToken cancellationToken)

--- a/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
+++ b/Snowflake.Data.Tests/Mock/MockRetryUntilRestTimeout.cs
@@ -32,7 +32,7 @@ namespace Snowflake.Data.Tests.Mock
                 message.SetOption(BaseRestRequest.HTTP_REQUEST_TIMEOUT_KEY, TimeSpan.FromTicks(0));
             }
 
-            return await (base.SendAsync(message, restTimeout, externalCancellationToken).ConfigureAwait(false));
+            return await base.SendAsync(message, restTimeout, externalCancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Data.Tests/PackageTests/MiniCoreVerificationAppSource.cs
+++ b/Snowflake.Data.Tests/PackageTests/MiniCoreVerificationAppSource.cs
@@ -42,12 +42,12 @@ namespace MinicoreVerifyApp
             try
             {
                 var openTask = conn.OpenAsync(CancellationToken.None);
-                var completed = await Task.WhenAny(openTask, Task.Delay(TimeSpan.FromSeconds(6)));
+                var completed = await Task.WhenAny(openTask, Task.Delay(TimeSpan.FromSeconds(6))).ConfigureAwait(false);
 
                 if (completed == openTask)
                 {
                     // Re-throw any exception from the open attempt to keep the same behavior.
-                    await openTask;
+                    await openTask.ConfigureAwait(false);
                 }
                 else
                 {

--- a/Snowflake.Data.Tests/UnitTests/ArchitectureInvariantsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArchitectureInvariantsTest.cs
@@ -16,7 +16,6 @@ namespace Snowflake.Data.Tests.UnitTests;
 public sealed class ArchitectureInvariantsTest
 {
     private static readonly string s_solutionRoot = FindSolutionRoot();
-    private static readonly string s_productionSourceDir = Path.Combine(s_solutionRoot, "Snowflake.Data");
 
     private static readonly Assembly s_testAssembly = typeof(ArchitectureInvariantsTest).Assembly;
 
@@ -54,15 +53,18 @@ public sealed class ArchitectureInvariantsTest
         AssertOnViolations(expectedViolations, violations);
     }
 
-    [SFFact]
-    public void TestConfigureAwaitFalse_AllAwaitsInProductionCodeMustHaveConfigureAwaitFalse()
+    [SFTheory]
+    [InlineData("Snowflake.Data")]
+    [InlineData("Snowflake.Data.Tests")]
+    public void TestConfigureAwaitFalse_AllAwaitsInProductionCodeMustHaveConfigureAwaitFalse(string assemblyName)
     {
         var violations = new ConcurrentBag<string>();
-        var csFiles = Directory.GetFiles(s_productionSourceDir, "*.cs", SearchOption.AllDirectories);
+        var path = GetPath(assemblyName);
+        var csFiles = Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories);
 
         Parallel.ForEach(csFiles, file =>
         {
-            var relativePath = file.Substring(s_solutionRoot.Length + "Snowflake.Data".Length + 1);
+            var relativePath = file.Substring(s_solutionRoot.Length + assemblyName.Length + 1);
             var source = File.ReadAllText(file);
             var tree = CSharpSyntaxTree.ParseText(source, path: file);
             var root = tree.GetRoot();
@@ -96,29 +98,7 @@ public sealed class ArchitectureInvariantsTest
             }
         });
 
-        // TODO SNOW-3560671
-        var expectedViolations = new[]
-        {
-            "/Core/SFResultSet.cs: Task.FromResult(false)",
-            "/Core/ArrowResultSet.cs: Task.FromResult(false)",
-            "/Core/SFMultiStatementsResultSet.cs: NextResultAsync(CancellationToken.None)",
-            "/Core/SFMultiStatementsResultSet.cs: curResultSet.NextAsync()",
-            "/Core/SFMultiStatementsResultSet.cs: sfStatement.GetResultWithIdAsync(                                        resultIds[curResultIndex],                                        cancellationToken)",
-            "/Core/SFMultiStatementsResultSet.cs: Task.FromResult(curResultSet != null)",
-            "/Core/ReusableChunkParser.cs: Task.Run(...);",
-            "/Client/SnowflakeDbDataReader.cs: resultSet.NextAsync()",
-            "/Client/SnowflakeDbCommand.cs: _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken)",
-            "/Client/SnowflakeDbCommand.cs: _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true)",
-            "/Core/Authenticator/BasicAuthenticator.cs: base.LoginAsync(cancellationToken)",
-            "/Core/SFStatement.cs: RenewSessionIfNeededAsync(response, cancellationToken)",
-            "/Core/QueryResultsAwaiter.cs: GetQueryStatusAsync(connection, queryId, cancellationToken)",
-            "/Client/SnowflakeDbConnection.cs: taskCompletionSource.Task",
-            "/Core/Authenticator/MFACacheAuthenticator.cs: base.LoginAsync(cancellationToken)",
-            "/Core/SFBlockingChunkDownloaderV3.cs: chunk",
-            "/Core/SFBlockingChunkDownloaderV3.cs: Task.FromResult<BaseResultChunk>(null)",
-            "/Core/SFBlockingChunkDownloaderV3.cs: parser.ParseChunk(resultChunk)"
-        }.Select(x => x.Replace('/', Path.DirectorySeparatorChar)).ToArray();
-        AssertOnViolations(expectedViolations, violations);
+        AssertOnViolations([], violations);
     }
 
     [Fact]
@@ -164,4 +144,6 @@ public sealed class ArchitectureInvariantsTest
 
         throw new InvalidOperationException("Cannot find solution root directory");
     }
+
+    private static string GetPath(string assemblyName) => Path.Combine(s_solutionRoot, assemblyName);
 }

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultSetTest.cs
@@ -63,9 +63,9 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             for (var i = 0; i < RowCount; ++i)
             {
-                Assert.True(await _arrowResultSet.NextAsync());
+                Assert.True(await _arrowResultSet.NextAsync().ConfigureAwait(false));
             }
-            Assert.False(await _arrowResultSet.NextAsync());
+            Assert.False(await _arrowResultSet.NextAsync().ConfigureAwait(false));
         }
 
         [SFFact]
@@ -77,7 +77,7 @@ namespace Snowflake.Data.Tests.UnitTests
         [SFFact]
         public async Task TestNextResultAsyncReturnsFalse()
         {
-            Assert.False(await _arrowResultSet.NextResultAsync(CancellationToken.None));
+            Assert.False(await _arrowResultSet.NextResultAsync(CancellationToken.None).ConfigureAwait(false));
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthAuthorizationCodeFlowTest.cs
@@ -127,7 +127,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var authenticator = (OAuthAuthorizationCodeAuthenticator)session.GetAuthenticator();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.NotNull(authenticator.AccessToken);
@@ -198,7 +198,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var authenticator = (OAuthAuthorizationCodeAuthenticator)session.GetAuthenticator();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.NotNull(authenticator.AccessToken);
@@ -257,7 +257,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var authenticator = (OAuthAuthorizationCodeAuthenticator)session.GetAuthenticator();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.NotNull(authenticator.AccessToken);
@@ -295,7 +295,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var authenticator = (OAuthAuthorizationCodeAuthenticator)session.GetAuthenticator();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.NotNull(authenticator.AccessToken);
@@ -413,7 +413,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Equal(SFError.BROWSER_RESPONSE_ERROR.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
@@ -447,7 +447,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Equal(SFError.BROWSER_RESPONSE_ERROR.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
@@ -481,7 +481,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Equal(SFError.OAUTH_TOKEN_REQUEST_ERROR.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthClientCredentialFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthClientCredentialFlowTest.cs
@@ -79,7 +79,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             AssertAccessTokenSetInAuthenticator(session);
@@ -111,7 +111,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             AssertAccessTokenSetInAuthenticator(session);
@@ -157,7 +157,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Equal(SFError.OAUTH_TOKEN_REQUEST_ERROR.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/ProgrammaticAccessTokenAuthenticationTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/ProgrammaticAccessTokenAuthenticationTest.cs
@@ -74,7 +74,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
             AssertSessionSuccessfullyCreated(session);
@@ -102,7 +102,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession();
 
             // act
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Contains("Programmatic access token is invalid.", thrown.Message);

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetrieverTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/WorkflowIdentity/WorkflowIdentityAwsAttestationRetrieverTest.cs
@@ -70,7 +70,7 @@ public sealed class WorkflowIdentityAwsAttestationRetrieverTest
 
         // act
         var credentials = new ImmutableCredentials("akid", "secret", "session-token");
-        var jwt = await retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None);
+        var jwt = await retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None).ConfigureAwait(false);
 
         // assert
         Assert.Equal("fake.jwt.token", jwt);
@@ -85,7 +85,7 @@ public sealed class WorkflowIdentityAwsAttestationRetrieverTest
 
         // act/assert
         var credentials = new ImmutableCredentials("akid", "secret", "session-token");
-        var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None)).ConfigureAwait(false);
         Assert.Contains("GetWebIdentityToken returned an empty token", exception.Message);
     }
 
@@ -101,7 +101,7 @@ public sealed class WorkflowIdentityAwsAttestationRetrieverTest
 
         // act/assert
         var credentials = new ImmutableCredentials("akid", "secret", "session-token");
-        var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => retriever.GetWebIdentityTokenAsync("us-east-1", credentials, CancellationToken.None)).ConfigureAwait(false);
         Assert.Contains("Failed to call AWS STS GetWebIdentityToken", exception.Message);
         Assert.Contains("connection refused", exception.Message);
     }

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorTest.cs
@@ -65,7 +65,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
             var session = PrepareSession(AttestationProvider.AWS, null, NoEnvironmentSetup, SetupSystemTime, SetupAwsSdkDisabled);
 
             // act
-            var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None));
+            var exception = await Assert.ThrowsAsync<SnowflakeDbException>(() => session.OpenAsync(CancellationToken.None)).ConfigureAwait(false);
 
             // assert
             Assert.Contains("Retrieving attestation for AWS failed. Not available", exception?.Message);

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerMFATest.cs
@@ -64,7 +64,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var session = SnowflakeDbConnectionPool.ConnectionManager.GetSession(ConnectionStringMFACache, new SessionPropertiesContext());
 
             // Assert
-            await Awaiter.WaitUntilConditionOrTimeout(() => RestRequester.LoginRequests.Count == 2, TimeSpan.FromSeconds(15));
+            await Awaiter.WaitUntilConditionOrTimeout(() => RestRequester.LoginRequests.Count == 2, TimeSpan.FromSeconds(15)).ConfigureAwait(false);
             Assert.Equal(2, RestRequester.LoginRequests.Count);
             var loginRequest1 = RestRequester.LoginRequests.Dequeue();
             Assert.Equal(string.Empty, loginRequest1.data.Token);

--- a/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ConnectionPoolManagerTest.cs
@@ -120,7 +120,7 @@ namespace Snowflake.Data.Tests.UnitTests
         public async Task TestGetSessionAsyncWorksForSpecifiedConnectionString()
         {
             // Act
-            var sfSession = await SnowflakeDbConnectionPool.ConnectionManager.GetSessionAsync(ConnectionString1, new SessionPropertiesContext(), CancellationToken.None);
+            var sfSession = await SnowflakeDbConnectionPool.ConnectionManager.GetSessionAsync(ConnectionString1, new SessionPropertiesContext(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(ConnectionString1, sfSession.ConnectionString);

--- a/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/HttpUtilTest.cs
@@ -69,7 +69,7 @@ namespace Snowflake.Data.Tests.UnitTests
             mockHttp.When("https://test.snowflakecomputing.com")
             .Respond(statusCode);
             var client = mockHttp.ToHttpClient();
-            var response = await client.GetAsync("https://test.snowflakecomputing.com");
+            var response = await client.GetAsync("https://test.snowflakecomputing.com").ConfigureAwait(false);
 
             bool actualIsRetryable = HttpUtil.isRetryableHTTPCode((int)response.StatusCode, forceRetryOn404);
 

--- a/Snowflake.Data.Tests/UnitTests/QueryResultsAwaiterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryResultsAwaiterTest.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true));
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true)).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -44,7 +44,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var mockRequester = new MockRestRequesterForQueryCancellation();
             var conn = new MockSnowflakeDbConnection(mockRequester);
             conn.ConnectionString = ConnectionString;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             var awaiter = new QueryResultsAwaiter(new QueryResultsRetryConfig(1, new[] { 1 }));
             var cts = new CancellationTokenSource();
@@ -56,7 +56,7 @@ namespace Snowflake.Data.Tests.UnitTests
             // Act
             try
             {
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true);
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true).ConfigureAwait(false);
                 Assert.Fail("Expected an OperationCanceledException to be thrown");
             }
             catch (OperationCanceledException)
@@ -85,7 +85,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -109,7 +109,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true));
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true)).ConfigureAwait(false);
             Assert.False(mockRequester.CancelRequestSent,
                 "Cancel request should not have succeeded since the mock was configured to throw");
         }
@@ -152,7 +152,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act & Assert
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
             Assert.False(mockRequester.CancelRequestSent,
                 "Cancel request should not have succeeded since the mock was configured to throw");
         }
@@ -164,11 +164,11 @@ namespace Snowflake.Data.Tests.UnitTests
             mockRequester.EnqueueStatus("RUNNING", "RUNNING", "SUCCESS");
             var conn = new MockSnowflakeDbConnection(mockRequester);
             conn.ConnectionString = ConnectionString;
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             var awaiter = new QueryResultsAwaiter(new QueryResultsRetryConfig(1, new[] { 0, 0, 0 }));
 
-            await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, CancellationToken.None, true);
+            await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, CancellationToken.None, true).ConfigureAwait(false);
 
             Assert.False(mockRequester.CancelRequestSent,
                 "No cancel request should be sent when query completes normally");
@@ -186,7 +186,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var awaiter = new QueryResultsAwaiter(new QueryResultsRetryConfig(1, new[] { 0, 0, 0 }));
 
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, CancellationToken.None, false);
-            await task;
+            await task.ConfigureAwait(false);
 
             Assert.False(mockRequester.CancelRequestSent,
                 "No cancel request should be sent when query completes normally");
@@ -221,7 +221,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act - cancellation triggers AbortQuery which validates the query ID
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, invalidQueryId, cts.Token, true));
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, invalidQueryId, cts.Token, true)).ConfigureAwait(false);
 
             // Assert - no SQL command should have been sent
             Assert.False(mockRequester.CancelRequestSent,

--- a/Snowflake.Data.Tests/UnitTests/QueryResultsAwaiterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/QueryResultsAwaiterTest.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true)).ConfigureAwait(false);
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -85,7 +85,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task.ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -109,7 +109,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task.ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.True(mockRequester.CancelRequestSent,
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true)).ConfigureAwait(false);
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, true).ConfigureAwait(false)).ConfigureAwait(false);
             Assert.False(mockRequester.CancelRequestSent,
                 "Cancel request should not have succeeded since the mock was configured to throw");
         }
@@ -152,7 +152,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act & Assert
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, ValidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task).ConfigureAwait(false);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task.ConfigureAwait(false)).ConfigureAwait(false);
             Assert.False(mockRequester.CancelRequestSent,
                 "Cancel request should not have succeeded since the mock was configured to throw");
         }
@@ -221,7 +221,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act - cancellation triggers AbortQuery which validates the query ID
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await awaiter.RetryUntilQueryResultIsAvailable(conn, invalidQueryId, cts.Token, true)).ConfigureAwait(false);
+                await awaiter.RetryUntilQueryResultIsAvailable(conn, invalidQueryId, cts.Token, true).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert - no SQL command should have been sent
             Assert.False(mockRequester.CancelRequestSent,
@@ -246,7 +246,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act
             var task = awaiter.RetryUntilQueryResultIsAvailable(conn, invalidQueryId, cts.Token, false);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task.ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.False(mockRequester.CancelRequestSent,

--- a/Snowflake.Data.Tests/UnitTests/RedirectUnitTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RedirectUnitTest.cs
@@ -50,10 +50,10 @@ namespace Snowflake.Data.Tests.UnitTests
             var request = CreateQueryRequest();
 
             //act
-            var response = await httpClient.SendAsync(request);
+            var response = await httpClient.SendAsync(request).ConfigureAwait(false);
 
             // assert
-            await AssertResponseId(response, expectedQueryId);
+            await AssertResponseId(response, expectedQueryId).ConfigureAwait(false);
         }
 
         [SFFact(SkipCondition.SkipOnJenkins)]
@@ -66,10 +66,10 @@ namespace Snowflake.Data.Tests.UnitTests
             var request = CreateQueryRequest();
 
             //act
-            var response = await httpClient.SendAsync(request);
+            var response = await httpClient.SendAsync(request).ConfigureAwait(false);
 
             // assert
-            await AssertResponseId(response, expectedQueryId);
+            await AssertResponseId(response, expectedQueryId).ConfigureAwait(false);
         }
 
         private HttpClient CreateHttpClientForRetry()
@@ -94,7 +94,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
         private async Task AssertResponseId(HttpResponseMessage response, string expectedQueryId)
         {
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonConvert.DeserializeObject<QueryExecResponse>(json, JsonUtils.JsonSettings);
 
             // assert
@@ -111,7 +111,7 @@ namespace Snowflake.Data.Tests.UnitTests
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
     }

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterTest.cs
@@ -124,7 +124,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var request = CreateMockRestRequest(HttpMethod.Post);
 
             // act
-            var result = await restRequester.PostAsync<NullDataResponse>(request, CancellationToken.None);
+            var result = await restRequester.PostAsync<NullDataResponse>(request, CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.True(result.success);
@@ -144,7 +144,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var request = CreateMockRestRequest(HttpMethod.Get);
 
             // act
-            var result = await restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None);
+            var result = await restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None).ConfigureAwait(false);
 
             // assert
             Assert.True(result.success);
@@ -164,7 +164,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // act & assert
             await Assert.ThrowsAsync<JsonReaderException>(
-                () => restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None));
+                () => restRequester.GetAsync<NullDataResponse>(request, CancellationToken.None)).ConfigureAwait(false);
         }
 
         private static HttpClient CreateHttpClientWithSequentialResponses(params HttpResponseMessage[] responses)

--- a/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/RestRequesterWiremockTest.cs
@@ -56,16 +56,16 @@ namespace Snowflake.Data.Tests.UnitTests
 
             using var conn = new SnowflakeDbConnection();
             conn.ConnectionString = BuildConnectionString();
-            await conn.OpenAsync(CancellationToken.None);
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
             using var cmd = conn.CreateCommand();
             cmd.CommandText = "SELECT 1";
 
             // act
-            using var reader = await cmd.ExecuteReaderAsync(CancellationToken.None);
+            using var reader = await cmd.ExecuteReaderAsync(CancellationToken.None).ConfigureAwait(false);
 
             // assert
-            Assert.True(await reader.ReadAsync());
+            Assert.True(await reader.ReadAsync().ConfigureAwait(false));
             Assert.Equal("1", reader.GetString(0));
         }
 
@@ -85,7 +85,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // act & assert
             await Assert.ThrowsAsync<JsonReaderException>(
-                () => cmd.ExecuteReaderAsync(CancellationToken.None));
+                () => cmd.ExecuteReaderAsync(CancellationToken.None)).ConfigureAwait(false);
         }
 
         private string BuildConnectionString()

--- a/Snowflake.Data.Tests/UnitTests/Revocation/CrlCacheManagerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Revocation/CrlCacheManagerTest.cs
@@ -129,7 +129,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.NotNull(manager.Get(CrlUrl2));
 
             // act
-            await Task.Delay(1500);
+            await Task.Delay(1500).ConfigureAwait(false);
 
             // assert
             Assert.Null(manager.Get(CrlUrl1));
@@ -168,7 +168,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.NotNull(manager.Get(CrlUrl2));
 
             // act
-            await Task.Delay(1500);
+            await Task.Delay(1500).ConfigureAwait(false);
 
             // assert
             Assert.Null(manager.Get(CrlUrl1));
@@ -198,7 +198,7 @@ namespace Snowflake.Data.Tests.UnitTests.Revocation
             Assert.NotNull(manager.Get(CrlUrl1));
 
             // act
-            await Task.Delay(1500);
+            await Task.Delay(1500).ConfigureAwait(false);
 
             // assert
             Assert.NotNull(manager.Get(CrlUrl1));

--- a/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
@@ -234,7 +234,7 @@ namespace Snowflake.Data.Tests.UnitTests
                     await Task.Delay(1000).ContinueWith(_ =>
                     {
                         s_httpClient.GetAsync(uri.ToString());
-                    });
+                    }).ConfigureAwait(false);
                 });
 
             var restRequester = new Mock.MockExternalBrowserRestRequester()

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -424,7 +424,7 @@ namespace Snowflake.Data.Tests.UnitTests
             // Assert
             if (expectedResultStatus == ResultStatus.DOWNLOADED)
             {
-                string text = await ReadDownloadFileAsync();
+                string text = await ReadDownloadFileAsync().ConfigureAwait(false);
                 Assert.Equal(MockRemoteStorageClient.FileContent, text);
             }
             Assert.Equal(expectedResultStatus.ToString(), _fileMetadata.resultStatus);
@@ -445,7 +445,7 @@ namespace Snowflake.Data.Tests.UnitTests
             // Assert
             if (expectedResultStatus == ResultStatus.DOWNLOADED)
             {
-                var text = await ReadDownloadFileAsync();
+                var text = await ReadDownloadFileAsync().ConfigureAwait(false);
                 Assert.Equal(MockRemoteStorageClient.FileContent, text);
             }
             Assert.Equal(expectedResultStatus.ToString(), _fileMetadata.resultStatus);
@@ -547,7 +547,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SFRemoteStorageUtil.DownloadOneFile(_fileMetadata);
 
             // Assert
-            string text = await ReadDownloadFileAsync();
+            string text = await ReadDownloadFileAsync().ConfigureAwait(false);
             Assert.Equal(MockRemoteStorageClient.FileContent, text);
             Assert.Equal(((ResultStatus)expectedResultStatus).ToString(), _fileMetadata.resultStatus);
         }
@@ -564,7 +564,7 @@ namespace Snowflake.Data.Tests.UnitTests
             await SFRemoteStorageUtil.DownloadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false);
 
             // Assert
-            string text = await ReadDownloadFileAsync();
+            string text = await ReadDownloadFileAsync().ConfigureAwait(false);
             Assert.Equal(MockRemoteStorageClient.FileContent, text);
             Assert.Equal(((ResultStatus)expectedResultStatus).ToString(), _fileMetadata.resultStatus);
         }
@@ -575,7 +575,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var result = File.ReadAllText(t_downloadFileName);
             return result;
 #else
-            var text = await File.ReadAllTextAsync(t_downloadFileName, _cancellationToken);
+            var text = await File.ReadAllTextAsync(t_downloadFileName, _cancellationToken).ConfigureAwait(false);
             return text;
 #endif
         }

--- a/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFRemoteStorageClientTest.cs
@@ -346,7 +346,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SetUpMockClientForUpload(httpStatusCode, httpStatusCodeAfterRetry, IsAsync);
 
             // Act
-            Exception ex = await Assert.ThrowsAsync<WebException>(async () => await SFRemoteStorageUtil.UploadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false));
+            Exception ex = await Assert.ThrowsAsync<WebException>(async () => await SFRemoteStorageUtil.UploadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.Matches(MockRemoteStorageClient.ErrorMessage, ex.Message);
@@ -377,7 +377,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SetUpMockClientForUpload(httpStatusCode, httpStatusCodeAfterRetry, IsAsync);
 
             // Act
-            Exception ex = await Assert.ThrowsAsync<Exception>(async () => await SFRemoteStorageUtil.UploadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false));
+            Exception ex = await Assert.ThrowsAsync<Exception>(async () => await SFRemoteStorageUtil.UploadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.Matches($"Unknown Error in uploading a file: .*", ex.Message);
@@ -479,7 +479,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SetUpMockClientForDownload(httpStatusCode, IsAsync);
 
             // Act
-            Exception ex = await Assert.ThrowsAsync<WebException>(async () => await SFRemoteStorageUtil.DownloadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false));
+            Exception ex = await Assert.ThrowsAsync<WebException>(async () => await SFRemoteStorageUtil.DownloadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.Matches(MockRemoteStorageClient.ErrorMessage, ex.Message);
@@ -509,7 +509,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SetUpMockClientForDownload(httpStatusCode, IsAsync);
 
             // Act
-            Exception ex = await Assert.ThrowsAsync<Exception>(async () => await SFRemoteStorageUtil.DownloadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false));
+            Exception ex = await Assert.ThrowsAsync<Exception>(async () => await SFRemoteStorageUtil.DownloadOneFileAsync(_fileMetadata, _cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // Assert
             Assert.Matches($"Unknown Error in downloading a file: .*", ex.Message);

--- a/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFReusableChunkTest.cs
@@ -123,7 +123,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             try
             {
-                await PrepareChunkAsync(data, 1, 1);
+                await PrepareChunkAsync(data, 1, 1).ConfigureAwait(false);
                 Assert.Fail();
             }
             catch (SnowflakeDbException e)
@@ -140,7 +140,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             try
             {
-                await PrepareChunkAsync(data, 1, 1);
+                await PrepareChunkAsync(data, 1, 1).ConfigureAwait(false);
                 Assert.Fail();
             }
             catch (SnowflakeDbException e)
@@ -259,7 +259,7 @@ namespace Snowflake.Data.Tests.UnitTests
             SFReusableChunk chunk = new SFReusableChunk(colCount);
             chunk.Reset(chunkInfo, 0);
 
-            await parser.ParseChunk(chunk);
+            await parser.ParseChunk(chunk).ConfigureAwait(false);
             return chunk;
         }
     }

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -77,7 +77,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
             await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await statement.GetResultWithIdAsync("retryId", CancellationToken.None)).ConfigureAwait(false);
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await statement.GetResultWithIdAsync("retryId", CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
             Assert.Equal(thrown.ErrorCode, Mock.MockRestSessionExpired.SESSION_EXPIRED_CODE);
         }
 
@@ -360,7 +360,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var statement = new SFStatement(session);
 
             await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None)).ConfigureAwait(false);
+                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
@@ -390,7 +390,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None)).ConfigureAwait(false);
+                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
             Assert.True(sfSession.IsInvalidatedForPooling());
         }
@@ -416,7 +416,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.GetResultWithIdAsync("mockId", CancellationToken.None)).ConfigureAwait(false);
+                await statement.GetResultWithIdAsync("mockId", CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
         }
 
@@ -441,7 +441,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.GetQueryStatusAsync("mockQueryId", CancellationToken.None)).ConfigureAwait(false);
+                await statement.GetQueryStatusAsync("mockQueryId", CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
         }
     }

--- a/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFStatementTest.cs
@@ -61,9 +61,9 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockRestSessionExpired();
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await sfSession.OpenAsync(CancellationToken.None);
+            await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
-            var resultSet = await statement.GetResultWithIdAsync("mockId", CancellationToken.None);
+            var resultSet = await statement.GetResultWithIdAsync("mockId", CancellationToken.None).ConfigureAwait(false);
             Assert.True(resultSet.Next());
             Assert.Equal("abc", resultSet.GetString(0));
             Assert.Equal("new_session_token", sfSession.sessionToken);
@@ -75,9 +75,9 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockRestSessionExpired();
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await sfSession.OpenAsync(CancellationToken.None);
+            await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
-            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await statement.GetResultWithIdAsync("retryId", CancellationToken.None));
+            var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () => await statement.GetResultWithIdAsync("retryId", CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(thrown.ErrorCode, Mock.MockRestSessionExpired.SESSION_EXPIRED_CODE);
         }
 
@@ -356,11 +356,11 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockRestRequesterWithQccOnError();
             var session = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await session.OpenAsync(CancellationToken.None);
+            await session.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(session);
 
             await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None));
+                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None)).ConfigureAwait(false);
 
             var cachedContext = session.GetQueryContextRequest();
             Assert.NotNull(cachedContext);
@@ -386,11 +386,11 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockSessionGone();
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await sfSession.OpenAsync(CancellationToken.None);
+            await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None));
+                await statement.ExecuteAsync(0, "select 1", null, false, false, CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
             Assert.True(sfSession.IsInvalidatedForPooling());
         }
@@ -412,11 +412,11 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockSessionGone();
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await sfSession.OpenAsync(CancellationToken.None);
+            await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.GetResultWithIdAsync("mockId", CancellationToken.None));
+                await statement.GetResultWithIdAsync("mockId", CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
         }
 
@@ -437,11 +437,11 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var restRequester = new Mock.MockSessionGone();
             var sfSession = new SFSession("account=test;user=test;password=test", new SessionPropertiesContext(), restRequester);
-            await sfSession.OpenAsync(CancellationToken.None);
+            await sfSession.OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var statement = new SFStatement(sfSession);
 
             var thrown = await Assert.ThrowsAsync<SnowflakeDbException>(async () =>
-                await statement.GetQueryStatusAsync("mockQueryId", CancellationToken.None));
+                await statement.GetQueryStatusAsync("mockQueryId", CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(SFError.SESSION_GONE.GetAttribute<SFErrorAttr>().errorCode, thrown.ErrorCode);
         }
     }

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionCreationTokenCounterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionCreationTokenCounterTest.cs
@@ -77,7 +77,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             tokens.NewToken(); // this token will be cleaned because of expiration
             Assert.Equal(2, tokens.Count());
             const int EpsilonMillis = 5;
-            await Task.Delay((int)s_shortTime.TotalMilliseconds + EpsilonMillis);
+            await Task.Delay((int)s_shortTime.TotalMilliseconds + EpsilonMillis).ConfigureAwait(false);
 
             // act
             tokens.RemoveToken(token);

--- a/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/SessionPoolTest.cs
@@ -518,7 +518,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             {
                 try
                 {
-                    await pool.GetSessionAsync(connectionString, new SessionPropertiesContext(), cancelledToken);
+                    await pool.GetSessionAsync(connectionString, new SessionPropertiesContext(), cancelledToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
@@ -109,7 +109,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
                 syncThreadsSemaphore.Release();
                 return queue.Wait(10000, CancellationToken.None);
             });
-            await syncThreadsSemaphore.WaitAsync(10000); // make sure scheduled thread execution has started
+            await syncThreadsSemaphore.WaitAsync(10000).ConfigureAwait(false); // make sure scheduled thread execution has started
             await Task.Delay(50).ConfigureAwait(false);
 
             // act

--- a/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Session/WaitingQueueTest.cs
@@ -127,7 +127,7 @@ namespace Snowflake.Data.Tests.UnitTests.Session
             var watch = new Stopwatch();
             Task.Run(async () =>
             {
-                await Task.Delay(50);
+                await Task.Delay(50).ConfigureAwait(false);
                 queue.Reset();
             });
 

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/ClientTelemetryWiremockTest.cs
@@ -102,19 +102,19 @@ namespace Snowflake.Data.Tests.UnitTests.Telemetry
         public async Task TestAsyncCommandSendsTelemetryToServer(string method)
         {
             using var conn = new SnowflakeDbConnection(s_connectionString);
-            await conn.OpenAsync();
+            await conn.OpenAsync().ConfigureAwait(false);
 
             using var cmd = (SnowflakeDbCommand)conn.CreateCommand();
             cmd.CommandText = "SELECT 1";
 
             switch (method)
             {
-                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync(); break;
-                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync(); break;
-                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync()).Dispose(); break;
+                case "ExecuteNonQueryAsync": await cmd.ExecuteNonQueryAsync().ConfigureAwait(false); break;
+                case "ExecuteScalarAsync": await cmd.ExecuteScalarAsync().ConfigureAwait(false); break;
+                case "ExecuteReaderAsync": (await cmd.ExecuteReaderAsync().ConfigureAwait(false)).Dispose(); break;
             }
 
-            await conn.CloseAsync(CancellationToken.None);
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 
             var logs = GetTelemetryLogs();
             var matching = logs.Where(l => l.Source == ActivityStarter.ActivitySourceName && l.StatusCode == "OK").ToList();

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SessionTelemetryModuleTest.cs
@@ -87,7 +87,7 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity);
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -126,7 +126,7 @@ public sealed class SessionTelemetryModuleTest
         }
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -164,7 +164,7 @@ public sealed class SessionTelemetryModuleTest
         }
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -197,7 +197,7 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity);
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -224,13 +224,13 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity1);
 
         // Act — first flush triggers the failure
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Buffer more data and flush again — should be a no-op
         var activity2 = new Activity("SecondOp");
         activity2.Start();
         module.OnActivityStoppedImpl(activity2);
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert — Post was attempted only once
         _mockRestRequester.Verify(
@@ -252,7 +252,7 @@ public sealed class SessionTelemetryModuleTest
         activity.Start();
         module.OnActivityStoppedImpl(activity);
 
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
         var expectedToken1 = "test-token";
         _mockRestRequester.Verify(x => x.PostAsync<NullDataResponse>(It.Is<IRestRequest>(y => ((SFRestRequest)y).authorizationToken == $"Snowflake Token=\"{expectedToken1}\""), It.IsAny<CancellationToken>()), Times.Once);
 
@@ -261,7 +261,7 @@ public sealed class SessionTelemetryModuleTest
         var activity2 = new Activity("whatever 2");
         activity2.Start();
         module.OnActivityStoppedImpl(activity2);
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
         _mockRestRequester.Verify(x => x.PostAsync<NullDataResponse>(It.Is<IRestRequest>(y => ((SFRestRequest)y).authorizationToken == $"Snowflake Token=\"{newToken}\""), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -327,7 +327,7 @@ public sealed class SessionTelemetryModuleTest
         var module = new SessionTelemetryModule(session);
 
         // Act - no data added
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         _mockRestRequester.Verify(
@@ -489,7 +489,7 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity);
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -520,7 +520,7 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity);
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);
@@ -553,7 +553,7 @@ public sealed class SessionTelemetryModuleTest
         module.OnActivityStoppedImpl(activity);
 
         // Act
-        await module.FlushAsync(CancellationToken.None);
+        await module.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(capturedBody);

--- a/Snowflake.Data.Tests/UnitTests/Telemetry/SnowflakeTelemetryModuleTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Telemetry/SnowflakeTelemetryModuleTest.cs
@@ -120,18 +120,18 @@ public sealed class SnowflakeTelemetryModuleTest : IDisposable
 
         // Act
         Assert.Equal(1, sessionModule.CurrentBufferSize);
-        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None);
+        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None).ConfigureAwait(false);
         Assert.True(sessionModule.IsDisposed);
         Assert.Equal(0, sessionModule.CurrentBufferSize);
 
         // Assert - calling again should be no-op
-        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None);
+        await SnowflakeTelemetryModule.UnregisterAsync(sessionId, CancellationToken.None).ConfigureAwait(false);
     }
 
     [SFFact]
     public async Task TestUnregisterAsyncForNonExistentSessionDoesNotThrow()
     {
-        await SnowflakeTelemetryModule.UnregisterAsync("non-existent-async", CancellationToken.None);
+        await SnowflakeTelemetryModule.UnregisterAsync("non-existent-async", CancellationToken.None).ConfigureAwait(false);
     }
 
     [SFTheory]

--- a/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/PlatformDetectionTest.cs
@@ -143,7 +143,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/latest/dynamic/instance-identity/document")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.True(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -153,7 +153,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Put, "http://169.254.169.254/latest/api/token")
                 .Respond(HttpStatusCode.Forbidden);
 
-            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -165,7 +165,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/latest/dynamic/instance-identity/document")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -175,7 +175,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Put, "http://169.254.169.254/latest/api/token")
                 .Throw(new HttpRequestException("Connection refused"));
 
-            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectEc2InstanceAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         // --- DetectAzureVm ---
@@ -187,7 +187,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.True(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -197,7 +197,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -207,7 +207,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/instance?api-version=2021-02-01")
                 .Throw(new HttpRequestException("Connection refused"));
 
-            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         // --- DetectAzureManagedIdentity ---
@@ -220,7 +220,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             Environment.SetEnvironmentVariable(AzureWebJobsStorage, "DefaultEndpointsProtocol=https;...");
             Environment.SetEnvironmentVariable(IdentityHeader, "some-value");
 
-            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync());
+            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync().ConfigureAwait(false));
         }
 
         [SFFact]
@@ -231,7 +231,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             Environment.SetEnvironmentVariable(FunctionsExtensionVersion, "~4");
             Environment.SetEnvironmentVariable(AzureWebJobsStorage, "DefaultEndpointsProtocol=https;...");
 
-            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync());
+            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync().ConfigureAwait(false));
         }
 
         [SFFact]
@@ -241,7 +241,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/identity/oauth2/token*")
                 .Respond(HttpStatusCode.OK, "application/json", "{}");
 
-            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -251,7 +251,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://169.254.169.254/metadata/identity/oauth2/token*")
                 .Respond(HttpStatusCode.BadRequest);
 
-            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectAzureManagedIdentityAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         // --- DetectGceVm ---
@@ -268,7 +268,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
                     return response;
                 });
 
-            Assert.True(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -278,7 +278,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal")
                 .Respond(HttpStatusCode.OK);
 
-            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -288,7 +288,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal")
                 .Throw(new HttpRequestException("Host not found"));
 
-            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGceVmAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         // --- RunDetectionAsync (disable env var) ---
@@ -297,7 +297,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         public async Task TestRunDetectionAsyncReturnsDisabledWhenEnvVarSetToTrue()
         {
             Environment.SetEnvironmentVariable(PlatformDetection.DisableEnvVar, "true");
-            var result = await PlatformDetection.RunDetectionAsync();
+            var result = await PlatformDetection.RunDetectionAsync().ConfigureAwait(false);
             Assert.Equal(new[] { "disabled" }, result);
         }
 
@@ -305,7 +305,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         public async Task TestRunDetectionAsyncReturnsDisabledWhenEnvVarSetCaseInsensitive()
         {
             Environment.SetEnvironmentVariable(PlatformDetection.DisableEnvVar, "TRUE");
-            var result = await PlatformDetection.RunDetectionAsync();
+            var result = await PlatformDetection.RunDetectionAsync().ConfigureAwait(false);
             Assert.Equal(new[] { "disabled" }, result);
         }
 
@@ -356,7 +356,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")
                 .Respond(HttpStatusCode.OK, "text/plain", "sa@project.iam.gserviceaccount.com");
 
-            Assert.True(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.True(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         [SFFact]
@@ -366,7 +366,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             mockHttp.When(HttpMethod.Get, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")
                 .Respond(HttpStatusCode.NotFound);
 
-            Assert.False(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()));
+            Assert.False(await PlatformDetection.DetectGcpIdentityAsync(mockHttp.ToHttpClient()).ConfigureAwait(false));
         }
 
         public void Dispose()

--- a/Snowflake.Data.Tests/UnitTests/Tools/WiremockRunnerTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/WiremockRunnerTest.cs
@@ -52,7 +52,7 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
             _runner.AddMappings("wiremock/test_mapping.json");
 
             //act
-            var response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test")).Result;
+            var response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test").ConfigureAwait(false)).Result;
 
             // assert
             Assert.True(response.IsSuccessStatusCode);
@@ -63,16 +63,16 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         {
             // arrange
             _runner.AddMappings("wiremock/test_mapping.json");
-            var response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test")).Result;
+            var response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpsUrl + "/test").ConfigureAwait(false)).Result;
             Assert.True(response.IsSuccessStatusCode);
 
             // act
             _runner.ResetMapping();
-            response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpUrl + "/__admin/mappings")).Result;
+            response = Task.Run(async () => await _httpClient.GetAsync(_runner.WiremockBaseHttpUrl + "/__admin/mappings").ConfigureAwait(false)).Result;
 
             // assert
             Assert.True(response.IsSuccessStatusCode);
-            dynamic jsonObject = JsonConvert.DeserializeObject(Task.Run(async () => await response.Content.ReadAsStringAsync()).Result);
+            dynamic jsonObject = JsonConvert.DeserializeObject(Task.Run(async () => await response.Content.ReadAsStringAsync().ConfigureAwait(false)).Result);
             Assert.Equal("0", jsonObject?.meta.total.ToString());
         }
     }

--- a/Snowflake.Data.Tests/Util/Awaiter.cs
+++ b/Snowflake.Data.Tests/Util/Awaiter.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Data.Tests.Util
             var breakTime = TimeoutHelper.IsInfinite(timeout) ? long.MaxValue : startTime + timeout.TotalMilliseconds;
             while (!condition() && DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() < breakTime)
             {
-                await Task.Delay(delay);
+                await Task.Delay(delay).ConfigureAwait(false);
             }
         }
     }

--- a/Snowflake.Data.Tests/Util/AwaiterTest.cs
+++ b/Snowflake.Data.Tests/Util/AwaiterTest.cs
@@ -12,7 +12,7 @@ namespace Snowflake.Data.Tests.Util
         public async Task TestReturnsImmediatelyWhenConditionIsMet()
         {
             // act
-            var millis = await MillisecondsOfWaiting(() => true, TimeSpan.FromHours(1));
+            var millis = await MillisecondsOfWaiting(() => true, TimeSpan.FromHours(1)).ConfigureAwait(false);
 
             // assert
             Assert.InRange(millis, long.MinValue, _maxDurationRegardedAsImmediately.TotalMilliseconds);
@@ -22,7 +22,7 @@ namespace Snowflake.Data.Tests.Util
         public async Task TestReturnsImmediatelyOnZeroTimeout()
         {
             // act
-            var millis = await MillisecondsOfWaiting(() => false, TimeSpan.FromMilliseconds(0));
+            var millis = await MillisecondsOfWaiting(() => false, TimeSpan.FromMilliseconds(0)).ConfigureAwait(false);
 
             // assert
             Assert.True(millis <= _maxDurationRegardedAsImmediately.TotalMilliseconds);
@@ -35,7 +35,7 @@ namespace Snowflake.Data.Tests.Util
             var timeout = TimeSpan.FromSeconds(2);
 
             // act
-            var millis = await MillisecondsOfWaiting(() => false, TimeSpan.FromSeconds(2));
+            var millis = await MillisecondsOfWaiting(() => false, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
 
             // assert
             Assert.True(millis >= timeout.TotalMilliseconds);
@@ -45,7 +45,7 @@ namespace Snowflake.Data.Tests.Util
         {
             var watch = new StopWatch();
             watch.Start();
-            await Awaiter.WaitUntilConditionOrTimeout(condition, timeout);
+            await Awaiter.WaitUntilConditionOrTimeout(condition, timeout).ConfigureAwait(false);
             watch.Stop();
             return watch.ElapsedMilliseconds;
         }

--- a/Snowflake.Data.Tests/Util/IntegrationTestSetup.cs
+++ b/Snowflake.Data.Tests/Util/IntegrationTestSetup.cs
@@ -46,13 +46,13 @@ public static class IntegrationTestEnvironment
 
     public static async Task StartIntegrationTest()
     {
-        await s_semaphoreSlim.WaitAsync();
+        await s_semaphoreSlim.WaitAsync().ConfigureAwait(false);
 
         try
         {
             if (s_integrationTestsRunning++ == 0)
             {
-                await ModifySchemaAsync(TestConfigSingleton.TestConfig.schema, SchemaAction.Create);
+                await ModifySchemaAsync(TestConfigSingleton.TestConfig.schema, SchemaAction.Create).ConfigureAwait(false);
             }
         }
         finally
@@ -63,14 +63,14 @@ public static class IntegrationTestEnvironment
 
     public static async Task EndIntegrationTest()
     {
-        await s_semaphoreSlim.WaitAsync();
+        await s_semaphoreSlim.WaitAsync().ConfigureAwait(false);
 
         try
         {
             if (--s_integrationTestsRunning == 0)
             {
                 // cleanup
-                await ModifySchemaAsync(TestConfigSingleton.TestConfig.schema, SchemaAction.Drop);
+                await ModifySchemaAsync(TestConfigSingleton.TestConfig.schema, SchemaAction.Drop).ConfigureAwait(false);
             }
         }
         finally
@@ -90,7 +90,7 @@ public static class IntegrationTestEnvironment
         using (IDbConnection conn = new SnowflakeDbConnection())
         {
             conn.ConnectionString = BuildConnectionString(TestConfigSingleton.TestConfig);
-            await ((SnowflakeDbConnection)conn).OpenAsync(CancellationToken.None);
+            await ((SnowflakeDbConnection)conn).OpenAsync(CancellationToken.None).ConfigureAwait(false);
             var dbCommand = conn.CreateCommand();
 
             switch (schemaAction)

--- a/Snowflake.Data.Tests/Util/SFBaseTestAsync.cs
+++ b/Snowflake.Data.Tests/Util/SFBaseTestAsync.cs
@@ -65,7 +65,7 @@ namespace Snowflake.Data.Tests
 
         public virtual async TaskOrValueTask InitializeAsync()
         {
-            await IntegrationTestEnvironment.StartIntegrationTest();
+            await IntegrationTestEnvironment.StartIntegrationTest().ConfigureAwait(false);
             _anyTestStarted = true;
             testConfig = TestConfigSingleton.TestConfig;
             _stopwatch = new Stopwatch();
@@ -80,8 +80,8 @@ namespace Snowflake.Data.Tests
 
             // TODO
             //_envFixture.RecordTestPerformance(testName, _stopwatch.Elapsed);
-            await RemoveTables();
-            await IntegrationTestEnvironment.EndIntegrationTest();
+            await RemoveTables().ConfigureAwait(false);
+            await IntegrationTestEnvironment.EndIntegrationTest().ConfigureAwait(false);
         }
 
         private async Task RemoveTables()
@@ -98,7 +98,7 @@ namespace Snowflake.Data.Tests
                 foreach (var table in _tablesToRemove)
                 {
                     cmd.CommandText = $"DROP TABLE IF EXISTS {table}";
-                    await cmd.ExecuteNonQueryAsync();
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -115,7 +115,7 @@ namespace Snowflake.Data.Tests
             var cmd = conn.CreateCommand();
             cmd.CommandText = $"CREATE OR REPLACE {tableType} TABLE {tableName}({columnsStr}) {additionalQueryStr}";
             s_logger.Debug(cmd.CommandText);
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
             _tablesToRemove.Push(tableName);
         }

--- a/Snowflake.Data.Tests/Util/SFTestCaseRunner.cs
+++ b/Snowflake.Data.Tests/Util/SFTestCaseRunner.cs
@@ -25,7 +25,7 @@ public class SFTestCaseRunner : XunitTestCaseRunnerBase<SFCaseRunnerContext, IXu
         ExplicitOption explicitOption,
         object[] constructorArguments)
     {
-        var tests = await aggregator.RunAsync(testCase.CreateTests, []);
+        var tests = await aggregator.RunAsync(testCase.CreateTests, []).ConfigureAwait(false);
 
         if (aggregator.ToException() is { } ex)
         {
@@ -49,9 +49,9 @@ public class SFTestCaseRunner : XunitTestCaseRunnerBase<SFCaseRunnerContext, IXu
 
         await using var ctxt = new SFCaseRunnerContext(maxRetries, testCase, tests, messageBus, aggregator, cancellationTokenSource,
             displayName, skipReason, explicitOption, constructorArguments);
-        await ctxt.InitializeAsync();
+        await ctxt.InitializeAsync().ConfigureAwait(false);
 
-        return await Run(ctxt);
+        return await Run(ctxt).ConfigureAwait(false);
     }
 
     protected override async ValueTask<RunSummary> RunTest(
@@ -79,7 +79,7 @@ public class SFTestCaseRunner : XunitTestCaseRunnerBase<SFCaseRunnerContext, IXu
                 aggregator,
                 ctxt.CancellationTokenSource,
                 ctxt.BeforeAfterTestAttributes
-            );
+            ).ConfigureAwait(false);
 
             if (!(aggregator.HasExceptions || result.Failed != 0) || ++runCount >= maxRetries)
             {

--- a/Snowflake.Data.Tests/Util/TestPerformanceRecorder.cs
+++ b/Snowflake.Data.Tests/Util/TestPerformanceRecorder.cs
@@ -81,7 +81,7 @@ public sealed class TestPerformanceRecorder : IDisposable
         sw.Close();
         return;
 #else
-        await File.AppendAllTextAsync(s_filePath, entyStr);
+        await File.AppendAllTextAsync(s_filePath, entyStr).ConfigureAwait(false);
 #endif
     }
 

--- a/Snowflake.Data.Tests/Util/WiremockRunner.cs
+++ b/Snowflake.Data.Tests/Util/WiremockRunner.cs
@@ -108,7 +108,7 @@ namespace Snowflake.Data.Tests.Util
             s_logger.Debug($"Checking if Wiremock responds on: {wiremockUri}");
             try
             {
-                var response = Task.Run(async () => await s_httpClient.GetAsync(wiremockUri, CancellationToken.None)).Result;
+                var response = Task.Run(async () => await s_httpClient.GetAsync(wiremockUri, CancellationToken.None).ConfigureAwait(false)).Result;
                 s_logger.Debug($"Wiremock responded with status code: {response.StatusCode}");
 
                 return response.IsSuccessStatusCode;
@@ -171,7 +171,7 @@ namespace Snowflake.Data.Tests.Util
 
         public void ResetMapping()
         {
-            var response = Task.Run(async () => await s_httpClient.PostAsync(WiremockBaseHttpUrl + "/__admin/reset", null)).Result;
+            var response = Task.Run(async () => await s_httpClient.PostAsync(WiremockBaseHttpUrl + "/__admin/reset", null).ConfigureAwait(false)).Result;
             if (!response.IsSuccessStatusCode)
             {
                 throw new Exception($"Unable to reset Wiremock mappings. Response status code: {response.StatusCode}");
@@ -222,7 +222,7 @@ namespace Snowflake.Data.Tests.Util
                     s_logger.Debug($"Wiremock v{WiremockVersion} not found. Starting download.");
                     Directory.CreateDirectory(s_wiremockPath);
                     var response = s_httpClient.GetAsync($"{s_wiremockUrl}");
-                    Task.Run(async () => await response.Result.Content.CopyToAsync(new FileStream(s_wiremockJarPath, FileMode.CreateNew))).Wait();
+                    Task.Run(async () => await response.Result.Content.CopyToAsync(new FileStream(s_wiremockJarPath, FileMode.CreateNew)).ConfigureAwait(false)).Wait();
                     s_logger.Debug($"Wiremock v{WiremockVersion} has been downloaded into {s_wiremockPath}.");
                 }
                 catch (Exception)

--- a/Snowflake.Data.Tests/Util/WiremockRunner.cs
+++ b/Snowflake.Data.Tests/Util/WiremockRunner.cs
@@ -188,7 +188,7 @@ namespace Snowflake.Data.Tests.Util
             var payload = new StringContent(transformedContent, Encoding.UTF8, "application/json");
             var response = Task.Run(async () => await s_httpClient.PostAsync(
                 WiremockBaseHttpUrl + "/__admin/mappings/import",
-                payload)
+                payload).ConfigureAwait(false)
             ).Result;
 
             if (!response.IsSuccessStatusCode)

--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -429,7 +429,7 @@ namespace Snowflake.Data.Client
             using var activity = connection?.SfSession?.StartActivity(TelemetryActivities.GetQueryStatusAsync);
             try
             {
-                var status = await _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken);
+                var status = await _queryResultsAwaiter.GetQueryStatusAsync(connection, queryId, cancellationToken).ConfigureAwait(false);
                 activity?.SetSuccess();
                 return status;
             }
@@ -480,7 +480,7 @@ namespace Snowflake.Data.Client
 
             try
             {
-                await _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true);
+                await _queryResultsAwaiter.RetryUntilQueryResultIsAvailable(connection, queryId, cancellationToken, true).ConfigureAwait(false);
 
                 SFBaseResultSet resultSet = await sfStatement.GetResultWithIdAsync(queryId, cancellationToken).ConfigureAwait(false);
 

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -267,7 +267,7 @@ namespace Snowflake.Data.Client
                     taskCompletionSource.SetResult(null);
                 }
             }
-            await taskCompletionSource.Task;
+            await taskCompletionSource.Task.ConfigureAwait(false);
         }
 
         protected virtual bool CanReuseSession(TransactionRollbackStatus transactionRollbackStatus)

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -392,7 +392,7 @@ namespace Snowflake.Data.Client
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await resultSet.NextAsync();
+            return await resultSet.NextAsync().ConfigureAwait(false);
         }
 
         public override void Close()

--- a/Snowflake.Data/Core/ArrowResultSet.cs
+++ b/Snowflake.Data/Core/ArrowResultSet.cs
@@ -118,9 +118,9 @@ namespace Snowflake.Data.Core
             return false;
         }
 
-        internal override async Task<bool> NextResultAsync(CancellationToken cancellationToken)
+        internal override Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {
-            return await Task.FromResult(false);
+            return Task.FromResult(false);
         }
 
         internal override bool HasRows()

--- a/Snowflake.Data/Core/Authenticator/BasicAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/BasicAuthenticator.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Data.Core.Authenticator
         /// <see cref="IAuthenticator.AuthenticateAsync"/>
         async Task IAuthenticator.AuthenticateAsync(CancellationToken cancellationToken)
         {
-            await base.LoginAsync(cancellationToken);
+            await base.LoginAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <see cref="IAuthenticator.Authenticate"/>

--- a/Snowflake.Data/Core/Authenticator/MFACacheAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/MFACacheAuthenticator.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Data.Core.Authenticator
         /// <see cref="IAuthenticator.AuthenticateAsync"/>
         async Task IAuthenticator.AuthenticateAsync(CancellationToken cancellationToken)
         {
-            await base.LoginAsync(cancellationToken);
+            await base.LoginAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <see cref="IAuthenticator.Authenticate"/>

--- a/Snowflake.Data/Core/QueryResultsAwaiter.cs
+++ b/Snowflake.Data/Core/QueryResultsAwaiter.cs
@@ -88,7 +88,7 @@ namespace Snowflake.Data.Core
                     }
 
                     status = isAsync
-                        ? await GetQueryStatusAsync(connection, queryId, cancellationToken)
+                        ? await GetQueryStatusAsync(connection, queryId, cancellationToken).ConfigureAwait(false)
                         : GetQueryStatus(connection, queryId);
 
                     if (!QueryStatusExtensions.IsStillRunning(status))

--- a/Snowflake.Data/Core/ReusableChunkParser.cs
+++ b/Snowflake.Data/Core/ReusableChunkParser.cs
@@ -147,7 +147,7 @@ namespace Snowflake.Data.Core
                 }
                 if (inString)
                     throw new SnowflakeDbException(SFError.INTERNAL_ERROR, $"Unexpected end of stream in string");
-            });
+            }).ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
+++ b/Snowflake.Data/Core/SFBlockingChunkDownloaderV3.cs
@@ -121,11 +121,11 @@ namespace Snowflake.Data.Core
                     }
                 }
                 nextChunkToConsumeIndex++;
-                return await chunk;
+                return await chunk.ConfigureAwait(false);
             }
             else
             {
-                return await Task.FromResult<BaseResultChunk>(null);
+                return null;
             }
         }
 
@@ -218,7 +218,7 @@ namespace Snowflake.Data.Core
         private async Task ParseStreamIntoChunk(Stream content, BaseResultChunk resultChunk)
         {
             IChunkParser parser = ChunkParserFactory.Instance.GetParser(resultChunk.ResultFormat, content);
-            await parser.ParseChunk(resultChunk);
+            await parser.ParseChunk(resultChunk).ConfigureAwait(false);
         }
     }
 

--- a/Snowflake.Data/Core/SFMultiStatementsResultSet.cs
+++ b/Snowflake.Data/Core/SFMultiStatementsResultSet.cs
@@ -34,12 +34,12 @@ namespace Snowflake.Data.Core
         {
             if (curResultSet == null)
             {
-                if (!await NextResultAsync(CancellationToken.None))
+                if (!await NextResultAsync(CancellationToken.None).ConfigureAwait(false))
                 {
                     return false;
                 }
             }
-            return await curResultSet.NextAsync();
+            return await curResultSet.NextAsync().ConfigureAwait(false);
         }
 
         internal override bool Next()
@@ -60,7 +60,7 @@ namespace Snowflake.Data.Core
             {
                 curResultSet = await sfStatement.GetResultWithIdAsync(
                                         resultIds[curResultIndex],
-                                        cancellationToken);
+                                        cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -68,7 +68,7 @@ namespace Snowflake.Data.Core
             }
 
             updateResultMetadata();
-            return await Task.FromResult(curResultSet != null);
+            return curResultSet != null;
         }
 
         internal override bool NextResult()

--- a/Snowflake.Data/Core/SFResultSet.cs
+++ b/Snowflake.Data/Core/SFResultSet.cs
@@ -111,7 +111,7 @@ namespace Snowflake.Data.Core
 
             if (_chunkDownloader != null)
             {
-                // GetNextChunk could be blocked if download result is not done yet. 
+                // GetNextChunk could be blocked if download result is not done yet.
                 // So put this piece of code in a seperate task
                 s_logger.Debug($"Get next chunk from chunk downloader, chunk: {_currentChunk.ChunkIndex + 1}/{_totalChunkCount}" +
                                $" rows: {_currentChunk.RowCount}, size compressed: {_currentChunk.CompressedSize}," +
@@ -154,9 +154,9 @@ namespace Snowflake.Data.Core
             return false;
         }
 
-        internal override async Task<bool> NextResultAsync(CancellationToken cancellationToken)
+        internal override Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {
-            return await Task.FromResult(false);
+            return Task.FromResult(false);
         }
 
         internal override bool HasRows()

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -770,7 +770,7 @@ namespace Snowflake.Data.Core
                             var req = BuildResultRequest(lastResultUrl);
                             response = await _restRequester.GetAsync<T>(req, cancellationToken).ConfigureAwait(false);
 
-                            if (!await RenewSessionIfNeededAsync(response, cancellationToken))
+                            if (!await RenewSessionIfNeededAsync(response, cancellationToken).ConfigureAwait(false))
                                 lastResultUrl = queryResponse.data?.getResultUrl;
                         }
                     }
@@ -892,7 +892,7 @@ namespace Snowflake.Data.Core
                 while (!receivedFirstQueryResponse)
                 {
                     response = await _restRequester.GetAsync<QueryStatusResponse>(queryRequest, cancellationToken).ConfigureAwait(false);
-                    if (await RenewSessionIfNeededAsync(response, cancellationToken))
+                    if (await RenewSessionIfNeededAsync(response, cancellationToken).ConfigureAwait(false))
                         queryRequest.authorizationToken = string.Format(SF_AUTHORIZATION_SNOWFLAKE_FMT, SfSession.sessionToken);
                     else
                         receivedFirstQueryResponse = true;


### PR DESCRIPTION
### Description
Summary

  - Add ConfigureAwait(false) to all await calls across the test project to prevent deadlocks when tests run on a
  synchronization context that marshals continuations back to the original thread


### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
