### PR TITLE
Skip wiremock-dependent AWS WIF impersonation tests on Jenkins

### DIFF
--- a/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorAwsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/WorkloadIdentityFederationAuthenticatorAwsTest.cs
@@ -105,7 +105,7 @@ public sealed class WorkloadIdentityFederationAuthenticatorAwsTest : WorkloadIde
         Assert.Empty(attestation.UserIdentifierComponents);
     }
 
-    [SFFact]
+    [SFFact(SkipCondition.SkipOnJenkins)]
     public void TestFailAttestationWhenStsCallFails()
     {
         // arrange - STS returns empty token
@@ -154,7 +154,7 @@ public sealed class WorkloadIdentityFederationAuthenticatorAwsTest : WorkloadIde
         Assert.Contains("Could not find AWS region", thrown.Message);
     }
 
-    [SFFact]
+    [SFFact(SkipCondition.SkipOnJenkins)]
     public void TestSuccessfulAwsTransitiveImpersonation()
     {
         // arrange
@@ -170,7 +170,7 @@ public sealed class WorkloadIdentityFederationAuthenticatorAwsTest : WorkloadIde
         AssertSessionSuccessfullyCreated(session);
     }
 
-    [SFFact]
+    [SFFact(SkipCondition.SkipOnJenkins)]
     public void TestSuccessfulAwsTransitiveImpersonationAttestation()
     {
         // arrange


### PR DESCRIPTION
TestFailAttestationWhenStsCallFails, TestSuccessfulAwsTransitiveImpersonation and TestSuccessfulAwsTransitiveImpersonationAttestation reach the AWS STS HTTP call, which is served by Wiremock. Wiremock is disabled on Jenkins (the fixture substitutes a no-op mock runner), so on Jenkins these tests hit a real endpoint and fail with a 30s request timeout (270007), leaving the build UNSTABLE.

Mark them [SFFact(SkipCondition.SkipOnJenkins)] to match the other wiremock-based tests in this file. They continue to run with real Wiremock on the GitHub Actions matrix (Linux/macOS/Windows/Rocky x net6-net10 x AWS/AZURE/GCP), so no coverage is lost.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name