### PR TITLE
SNOW-3705005 Fix transitive builds with NativeLibrary added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   -  AWS Workload Identity Federation attestation now defaults to a SigV4-presigned `GetCallerIdentity` request.
       The STS `GetWebIdentityToken` path (returning a signed JWT) is available as an opt-in by setting the
       `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN=true` environment variable.
-  -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
+  - Bug fix: Fixed non-windows builds with added NativeLibrary items in their transitively built projects that were no longer available to copy to output directory.
+  - Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are
     present.
 - v5.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
       `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN=true` environment variable.
   -  `CloseAsync` now throws the original exception on failure instead of wrapping it in an `AggregateException`.
   -  Bug fix: Fixed non-windows builds with added NativeLibrary items in their transitively built projects that were no longer available to copy to output directory.
-  -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: `CloseAsync` method of `SnowflakeDbConnection` now resets its state to `Closed` on cancellation and `Broken` on failures.
   -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are

--- a/Snowflake.Data/build/Snowflake.Data.targets
+++ b/Snowflake.Data/build/Snowflake.Data.targets
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Determine the target architecture -->
-  <PropertyGroup>
-    <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-x64' Or '$(PlatformTarget)' == 'x64'">x64</SfMiniCoreArch>
-    <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or '$(PlatformTarget)' == 'ARM64'">arm64</SfMiniCoreArch>
-    <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-x86' Or '$(PlatformTarget)' == 'x86'">x86</SfMiniCoreArch>
-    <SfMiniCoreArch Condition="'$(SfMiniCoreArch)' == ''">x64</SfMiniCoreArch>
-  </PropertyGroup>
+    <!-- Determine the target architecture -->
+    <PropertyGroup>
+        <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-x64' Or '$(PlatformTarget)' == 'x64'">x64</SfMiniCoreArch>
+        <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-arm64' Or '$(PlatformTarget)' == 'ARM64'">arm64</SfMiniCoreArch>
+        <SfMiniCoreArch Condition="'$(RuntimeIdentifier)' == 'win-x86' Or '$(PlatformTarget)' == 'x86'">x86</SfMiniCoreArch>
+        <SfMiniCoreArch Condition="'$(SfMiniCoreArch)' == ''">x64</SfMiniCoreArch>
+    </PropertyGroup>
 
-  <!-- Copy native library for ALL Windows targets -->
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'x64'" />
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'arm64'" />
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'x86'" />
-  </ItemGroup>
+    <!-- Copy native library for ALL Windows targets -->
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'x64'" IsSnowflakeNativeLibrary="True"/>
+        <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'arm64'" IsSnowflakeNativeLibrary="True"/>
+        <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\sf_mini_core.dll" Condition="'$(SfMiniCoreArch)' == 'x86'" IsSnowflakeNativeLibrary="True"/>
+    </ItemGroup>
 
-  <Target Name="CopyMiniCoreNativeLibraries" AfterTargets="Build">
-    <Copy SourceFiles="@(NativeLibrary)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" Condition="'@(NativeLibrary)' != ''" />
-  </Target>
+    <Target Name="CopyMiniCoreNativeLibraries" AfterTargets="Build" Condition="'@(NativeLibrary)' != ''">
+        <Warning Text="Native library not found: %(NativeLibrary.Identity)" Condition="!Exists('%(NativeLibrary.Identity)') AND %(NativeLibrary.IsSnowflakeNativeLibrary) != 'True'"/>
+        <Error Text="Native library not found: %(NativeLibrary.Identity)" Condition="!Exists('%(NativeLibrary.Identity)') AND %(NativeLibrary.IsSnowflakeNativeLibrary) == 'True'"/>
+        <Copy SourceFiles="@(NativeLibrary)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" Condition="Exists('%(NativeLibrary.Identity)')"/>
+    </Target>
 </Project>


### PR DESCRIPTION
SNOW-3705005 Fix transitive builds with NativeLibrary added

  What it does: Differentiates Snowflake's own native libraries (tagged IsSnowflakeNativeLibrary="True") from
  third-party ones added transitively. Missing Snowflake libs produce an <Error> (build breaks), missing third-party
  libs produce a <Warning>. The <Copy> now skips non-existent files instead of failing.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
