### PR TITLE
SNOW-3552882 OpenAsyncResets connection state to Closed on failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   -  AWS Workload Identity Federation attestation now defaults to a SigV4-presigned `GetCallerIdentity` request.
       The STS `GetWebIdentityToken` path (returning a signed JWT) is available as an opt-in by setting the
       `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN=true` environment variable.
+  -  `OpenAsync` method of `SnowflakeDbConnection` now throws the original exception on failure instead of wrapping it in an `AggregateException`.
   -  Bug fix: `OpenAsync` method of `SnowflakeDbConnection` now resets its state to `Closed` on failures.
   -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   -  AWS Workload Identity Federation attestation now defaults to a SigV4-presigned `GetCallerIdentity` request.
       The STS `GetWebIdentityToken` path (returning a signed JWT) is available as an opt-in by setting the
       `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN=true` environment variable.
+  -  Bug fix: `OpenAsync` method of `SnowflakeDbConnection` now resets its state to `Closed` on failures.
   -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are
     present.

--- a/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/ConnectionMultiplePoolsAsyncIT.cs
@@ -279,8 +279,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
         public async Task TestWaitForTheIdleConnectionWhenExceedingMaxConnectionsLimitAsync()
         {
             // arrange
-            var connectionString = _fixture.ConnectionString +
-                                   "application=TestWaitForMaxSize2;waitingForIdleSessionTimeout=1s;maxPoolSize=2;minPoolSize=1;poolingEnabled=true";
+            var connectionString = $"{_fixture.ConnectionString}application=TestWaitForMaxSize2;waitingForIdleSessionTimeout=1s;maxPoolSize=2;minPoolSize=1;poolingEnabled=true";
             var pool = SnowflakeDbConnectionPool.GetPool(connectionString);
             Assert.Equal(0, pool.GetCurrentPoolSize());
             var conn1 = await OpenConnectionAsync(connectionString).ConfigureAwait(false);
@@ -294,9 +293,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
             // assert
             Assert.Contains("Unable to connect", thrown.Message);
-            Assert.True(thrown.InnerException is AggregateException);
-            var nestedException = ((AggregateException)thrown.InnerException).InnerException;
-            Assert.Contains("Could not obtain a connection from the pool within a given timeout", nestedException.Message);
+            Assert.Contains("Could not obtain a connection from the pool within a given timeout", thrown.InnerException!.Message);
             Assert.InRange(watch.ElapsedMilliseconds, 1000, long.MaxValue);
             Assert.Equal(2, pool.GetCurrentPoolSize());
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionIT.cs
@@ -245,6 +245,19 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Assert.False(conn.HasActiveExplicitTransaction());
             }
         }
+
+        [SFTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ShouldBeClosedIfConnectionFails(bool isAsync)
+        {
+            // invalid connection string
+            var connectionString = "ACCOUNT=testaccount;user=testuser;password=fake;connection_timeout=5;maxHttpRetries=0;";
+            using var connection = new SnowflakeDbConnection(connectionString);
+            if (isAsync) await Assert.ThrowsAsync<SnowflakeDbException>(connection.OpenAsync).ConfigureAwait(false);
+            else Assert.Throws<SnowflakeDbException>(connection.Open);
+            Assert.Equal(ConnectionState.Closed, connection.State);
+        }
     }
 }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -346,41 +346,26 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     [SFFact]
     public async Task TestValidateDefaultParameters()
     {
-        string connectionString = String.Format("scheme={0};host={1};port={2};certRevocationCheckMode=enabled;" +
-                                                "account={3};role={4};db={5};schema={6};warehouse={7};user={8};password={9};",
-            _fixture.testConfig.protocol,
-            _fixture.testConfig.host,
-            _fixture.testConfig.port,
-            _fixture.testConfig.account,
-            _fixture.testConfig.role,
-            _fixture.testConfig.database,
-            _fixture.testConfig.schema,
-            "WAREHOUSE_NEVER_EXISTS",
-            _fixture.testConfig.user,
-            _fixture.testConfig.password);
+        var connectionString = $"scheme={_fixture.testConfig.protocol};host={_fixture.testConfig.host};port={_fixture.testConfig.port};certRevocationCheckMode=enabled;account={_fixture.testConfig.account};role={_fixture.testConfig.role};db={_fixture.testConfig.database};schema={_fixture.testConfig.schema};warehouse=WAREHOUSE_NEVER_EXISTS;user={_fixture.testConfig.user};password={_fixture.testConfig.password};";
 
         // By default should validate parameters
-        using (var conn = new SnowflakeDbConnection())
+        using var conn = new SnowflakeDbConnection();
+        try
         {
-            try
-            {
-                conn.ConnectionString = connectionString;
-                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-                Assert.Fail();
-            }
-            catch (SnowflakeDbException e)
-            {
-                var aggregateEx = (AggregateException)((AggregateException)e.InnerException).InnerExceptions[0];
-                Assert.Equal(390201, ((SnowflakeDbException)aggregateEx.InnerExceptions[0]).ErrorCode);
-            }
+            conn.ConnectionString = connectionString;
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            Assert.Fail();
+        }
+        catch (SnowflakeDbException e)
+        {
+            var sfException = (SnowflakeDbException)((AggregateException)e.InnerException!).InnerExceptions[0];
+            Assert.Equal(390201, sfException.ErrorCode);
         }
 
         // This should succeed
-        using (var conn = new SnowflakeDbConnection())
-        {
-            conn.ConnectionString = connectionString + ";VALIDATE_DEFAULT_PARAMETERS=false";
-            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-        }
+        using var conn2 = new SnowflakeDbConnection();
+        conn2.ConnectionString = connectionString + ";VALIDATE_DEFAULT_PARAMETERS=false";
+        await conn2.OpenAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
     [SFFact]
@@ -673,23 +658,18 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     {
         try
         {
-            using (var conn = new SnowflakeDbConnection())
-            {
-                conn.ConnectionString
-                    = _fixture.ConnectionStringWithoutAuth
-                      + ";authenticator=oauth;token=notAValidOAuthToken";
-                await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
-                Assert.Equal(ConnectionState.Open, conn.State);
-                Assert.Fail();
-            }
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = $"{_fixture.ConnectionStringWithoutAuth};authenticator=oauth;token=notAValidOAuthToken";
+            await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(ConnectionState.Open, conn.State);
+            Assert.Fail();
         }
         catch (SnowflakeDbException e)
         {
             // Invalid OAuth access token
             var aggregateEx = ((AggregateException)e.InnerException);
-            var aggregateEx2 = ((AggregateException)aggregateEx.InnerException);
-            var innerEx = aggregateEx2.InnerExceptions.First() as SnowflakeDbException;
-            Assert.Equal(390303, innerEx.ErrorCode);
+            var innerEx = aggregateEx!.InnerException as SnowflakeDbException;
+            Assert.Equal(390303, innerEx!.ErrorCode);
         }
     }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -346,6 +346,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     [SFFact]
     public async Task TestValidateDefaultParameters()
     {
+        var expectedErrorCode = SFError.OBJ_NONEXISTANT_OR_NOT_AUTHORIZED.GetAttribute<SFErrorAttr>().errorCode;
         var connectionString = $"scheme={_fixture.testConfig.protocol};host={_fixture.testConfig.host};port={_fixture.testConfig.port};certRevocationCheckMode=enabled;account={_fixture.testConfig.account};role={_fixture.testConfig.role};db={_fixture.testConfig.database};schema={_fixture.testConfig.schema};warehouse=WAREHOUSE_NEVER_EXISTS;user={_fixture.testConfig.user};password={_fixture.testConfig.password};";
 
         // By default should validate parameters
@@ -359,7 +360,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         catch (SnowflakeDbException e)
         {
             var sfException = (SnowflakeDbException)((AggregateException)e.InnerException!).InnerExceptions[0];
-            Assert.Equal(390201, sfException.ErrorCode);
+            Assert.Equal(expectedErrorCode, sfException.ErrorCode);
         }
 
         // This should succeed
@@ -656,6 +657,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     [SFFact]
     public async Task TestInValidOAuthTokenConnection()
     {
+        var expectedErrorCode = SFError.EXT_OAUTH_ACCESS_TOKEN_INVALID.GetAttribute<SFErrorAttr>().errorCode;
         try
         {
             using var conn = new SnowflakeDbConnection();
@@ -669,7 +671,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
             // Invalid OAuth access token
             var aggregateEx = ((AggregateException)e.InnerException);
             var innerEx = aggregateEx!.InnerException as SnowflakeDbException;
-            Assert.Equal(390303, innerEx!.ErrorCode);
+            Assert.Equal(expectedErrorCode, innerEx!.ErrorCode);
         }
     }
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
@@ -73,10 +73,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             Environment.SetEnvironmentVariable(EnvVars.DefaultConnectionName.Name, "notfoundconnection");
             try
             {
-                using (var conn = new SnowflakeDbConnection())
-                {
-                    await Assert.ThrowsAsync<Exception>(() => conn.OpenAsync()).ConfigureAwait(false);
-                }
+                using var conn = new SnowflakeDbConnection();
+                await Assert.ThrowsAsync<SnowflakeDbException>(conn.OpenAsync).ConfigureAwait(false);
             }
             finally
             {

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -286,8 +286,8 @@ namespace Snowflake.Data.Client
             }
             try
             {
-                FillConnectionStringFromTomlConfigIfNotSet();
                 OnSessionConnecting();
+                FillConnectionStringFromTomlConfigIfNotSet();
                 var sessionContext = new SessionPropertiesContext
                 {
                     Password = Password,
@@ -324,16 +324,14 @@ namespace Snowflake.Data.Client
                 ConnectionString = _tomlConnectionBuilder.GetConnectionStringFromToml();
         }
 
-        public override Task OpenAsync(CancellationToken cancellationToken)
+        public override async Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Connection Async.");
             if (_connectionState != ConnectionState.Closed)
             {
                 logger.Debug($"Open with a connection already opened: {_connectionState}");
-                return Task.CompletedTask;
+                return;
             }
-            OnSessionConnecting();
-            FillConnectionStringFromTomlConfigIfNotSet();
             var sessionContext = new SessionPropertiesContext
             {
                 Password = Password,
@@ -342,36 +340,31 @@ namespace Snowflake.Data.Client
                 Token = Token
             };
 
-            return SnowflakeDbConnectionPool
-                .GetSessionAsync(ConnectionString, sessionContext, cancellationToken)
-                .ContinueWith(previousTask =>
-                {
-                    if (previousTask.IsFaulted)
-                    {
-                        // Exception from SfSession.OpenAsync
-                        Exception sfSessionEx = previousTask.Exception;
-                        _connectionState = ConnectionState.Closed;
-                        logger.Error("Unable to connect", sfSessionEx);
-                        throw new SnowflakeDbException(
-                            sfSessionEx,
-                            SnowflakeDbException.CONNECTION_FAILURE_SSTATE,
-                            SFError.INTERNAL_ERROR,
-                            "Unable to connect");
-                    }
-                    else if (previousTask.IsCanceled)
-                    {
-                        _connectionState = ConnectionState.Closed;
-                        logger.Debug("Connection canceled");
-                        throw new TaskCanceledException("Connecting was cancelled");
-                    }
-                    else
-                    {
-                        // Only continue if the session was opened successfully
-                        SfSession = previousTask.Result;
-                        logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
-                        OnSessionEstablished();
-                    }
-                }, TaskContinuationOptions.None); // this continuation should be executed always (even if the whole operation was canceled) because it sets the proper state of the connection
+            try
+            {
+                OnSessionConnecting();
+                FillConnectionStringFromTomlConfigIfNotSet();
+                var session = await SnowflakeDbConnectionPool.GetSessionAsync(ConnectionString, sessionContext, cancellationToken).ConfigureAwait(false);
+                SfSession = session;
+                logger.Debug($"Connection open with pooled session: {SfSession.sessionId}");
+                OnSessionEstablished();
+            }
+            catch (OperationCanceledException)
+            {
+                _connectionState = ConnectionState.Closed;
+                logger.Debug("Connection canceled");
+                throw new TaskCanceledException("Connecting was cancelled");
+            }
+            catch (Exception ex)
+            {
+                _connectionState = ConnectionState.Closed;
+                logger.Error("Unable to connect", ex);
+
+                if (ex is SnowflakeDbException)
+                    throw;
+
+                throw new SnowflakeDbException(ex, SnowflakeDbException.CONNECTION_FAILURE_SSTATE, SFError.INTERNAL_ERROR, "Unable to connect");
+            }
         }
 
         public Mutex GetArrayBindingMutex()

--- a/Snowflake.Data/Core/SFError.cs
+++ b/Snowflake.Data/Core/SFError.cs
@@ -123,6 +123,9 @@ namespace Snowflake.Data.Core
         [SFErrorAttr(errorCode = 390129)]
         EXT_AUTHN_EXCEPTION,
 
+        [SFErrorAttr(errorCode = 390201)]
+        OBJ_NONEXISTANT_OR_NOT_AUTHORIZED,
+
         [SFErrorAttr(errorCode = 390318)]
         EXT_OAUTH_ACCESS_TOKEN_EXPIRED,
 


### PR DESCRIPTION
### Description
- Refactors OpenAsync from .ContinueWith() continuation pattern to native async/await with structured exception
  handling, fixing a bug where connection state could remain stuck in Connecting after a failed async open
  - Preserves SnowflakeDbException error codes by re-throwing as-is (only wraps non-Snowflake exceptions)
  - Aligns ordering of OnSessionConnecting() / FillConnectionStringFromTomlConfigIfNotSet() between Open() and
  OpenAsync()
  - Adds integration test covering both sync and async paths

  Motivation

  When OpenAsync failed (e.g., bad credentials, unreachable host), the connection's State property could remain
  Connecting instead of resetting to Closed. This prevented callers from retrying or disposing the connection cleanly.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
