### PR TITLE
NO-SNOW Make Close and CloseAsync consistent with each other.

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1269,7 +1269,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     }
 
     [SFFact]
-    public async Task ShouldBeNotBeClosedIfCloseCancelled()
+    public async Task ShouldNotBeClosedIfCloseCancelled()
     {
         using var c = new SnowflakeDbConnection(_fixture.ConnectionString);
         await c.OpenAsync(CancellationToken.None).ConfigureAwait(false);

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1269,7 +1269,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     }
 
     [SFFact]
-    public async Task ShouldNotBeClosedIfCloseCancelled()
+    public async Task ShouldBeOpenedIfCloseCancelled()
     {
         using var c = new SnowflakeDbConnection(_fixture.ConnectionString);
         await c.OpenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1278,7 +1278,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         c.SfSession = new SFSession(_fixture.ConnectionString, new(), EasyLoggingStarter.Instance, mockRestRequester.Object);
         c.SfSession.sessionToken = "some token";
         await Assert.ThrowsAsync<TaskCanceledException>(() => c.CloseAsync(CancellationToken.None)).ConfigureAwait(false);
-        Assert.NotEqual(ConnectionState.Closed, c.State);
+        Assert.Equal(ConnectionState.Open, c.State)
     }
 
     private static void AssertConnectionIsNotOpen(SnowflakeDbConnection snowflakeDbConnection)

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1269,7 +1269,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
     }
 
     [SFFact]
-    public async Task ShouldBeClosedIfCloseCancelled()
+    public async Task ShouldBeNotBeClosedIfCloseCancelled()
     {
         using var c = new SnowflakeDbConnection(_fixture.ConnectionString);
         await c.OpenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1278,7 +1278,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         c.SfSession = new SFSession(_fixture.ConnectionString, new(), EasyLoggingStarter.Instance, mockRestRequester.Object);
         c.SfSession.sessionToken = "some token";
         await Assert.ThrowsAsync<TaskCanceledException>(() => c.CloseAsync(CancellationToken.None)).ConfigureAwait(false);
-        Assert.Equal(ConnectionState.Closed, c.State);
+        Assert.NotEqual(ConnectionState.Closed, c.State);
     }
 
     private static void AssertConnectionIsNotOpen(SnowflakeDbConnection snowflakeDbConnection)

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionITAsync.cs
@@ -1278,7 +1278,7 @@ public sealed class SFConnectionITAsync : SFBaseTestAsync
         c.SfSession = new SFSession(_fixture.ConnectionString, new(), EasyLoggingStarter.Instance, mockRestRequester.Object);
         c.SfSession.sessionToken = "some token";
         await Assert.ThrowsAsync<TaskCanceledException>(() => c.CloseAsync(CancellationToken.None)).ConfigureAwait(false);
-        Assert.Equal(ConnectionState.Open, c.State)
+        Assert.Equal(ConnectionState.Open, c.State);
     }
 
     private static void AssertConnectionIsNotOpen(SnowflakeDbConnection snowflakeDbConnection)

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -1596,7 +1596,6 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await cmd.ExecuteNonQueryAsync();
 
                 cmd = conn.CreateCommand();
-                DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1;" +
                                   "select 1 where 1=2;" +
                                   "select 1;" +

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -1591,6 +1591,11 @@ namespace Snowflake.Data.Tests.IntegrationTests
         {
             using (var conn = await CreateAndOpenConnectionAsync().ConfigureAwait(false))
             {
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "ALTER SESSION SET ENABLE_FIX_1758055_ADD_ARROW_SUPPORT_FOR_MULTI_STMTS = TRUE";
+                await cmd.ExecuteNonQueryAsync();
+
+                cmd = conn.CreateCommand();
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1;" +
                                   "select 1 where 1=2;" +
@@ -1605,7 +1610,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
 
                 DbDataReader reader = cmd.ExecuteReader();
 
-                Assert.Equal(_resultFormat, ((SnowflakeDbDataReader)reader).ResultFormat);
+                ValidateResultFormat(reader);
 
                 // select 1
                 Assert.True(reader.HasRows);

--- a/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFDbDataReaderIT.cs
@@ -1593,7 +1593,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 var cmd = conn.CreateCommand();
                 cmd.CommandText = "ALTER SESSION SET ENABLE_FIX_1758055_ADD_ARROW_SUPPORT_FOR_MULTI_STMTS = TRUE";
-                await cmd.ExecuteNonQueryAsync();
+                await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
                 cmd = conn.CreateCommand();
                 cmd.CommandText = "select 1;" +

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
@@ -302,7 +302,7 @@ namespace Snowflake.Data.Tests.UnitTests
 
             // Act & Assert
             var ex = Assert.ThrowsAny<Exception>(conn.Close);
-            Assert.True( ex is SnowflakeDbException or AggregateException { InnerException: SnowflakeDbException },
+            Assert.True(ex is SnowflakeDbException or AggregateException { InnerException: SnowflakeDbException },
                 $"Expected SnowflakeDbException but got {ex.GetType().Name}");
 
             Assert.Equal(ConnectionState.Broken, conn.State);

--- a/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SnowflakeDbConnectionTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Snowflake.Data.Configuration;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.Session;
 using Snowflake.Data.Core.Tools;
+using Snowflake.Data.Tests.Mock;
 using Snowflake.Data.Tests.Util;
 
 namespace Snowflake.Data.Tests.UnitTests
@@ -162,6 +164,148 @@ namespace Snowflake.Data.Tests.UnitTests
             {
                 SnowflakeDbConnectionPool.ReplaceConnectionManager(oldConnectionManager);
             }
+        }
+
+        [SFFact]
+        public void TestCloseWhenStateIsBrokenWithSessionTransitionsToClosed()
+        {
+            // Arrange
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(m => m.GetPooling()).Returns(false);
+            connectionManager.Setup(m => m.ReleaseBusySession(It.IsAny<SFSession>()));
+            var oldConnectionManager = SnowflakeDbConnectionPool.ReplaceConnectionManager(connectionManager.Object);
+            try
+            {
+                var conn = new SnowflakeDbConnection();
+                conn.ConnectionString = "account=test;user=test;password=test;";
+                conn.SfSession = new SFSession("account=test;user=test;password=test;", new SessionPropertiesContext());
+                conn._connectionState = ConnectionState.Broken;
+
+                // Act
+                conn.Close();
+
+                // Assert
+                Assert.Equal(ConnectionState.Closed, conn.State);
+                Assert.Null(conn.SfSession);
+            }
+            finally
+            {
+                SnowflakeDbConnectionPool.ReplaceConnectionManager(oldConnectionManager);
+            }
+        }
+
+        [SFFact]
+        public async Task TestCloseAsyncWhenStateIsBrokenWithSessionTransitionsToClosed()
+        {
+            // Arrange
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(m => m.GetPooling()).Returns(false);
+            connectionManager.Setup(m => m.ReleaseBusySession(It.IsAny<SFSession>()));
+            var oldConnectionManager = SnowflakeDbConnectionPool.ReplaceConnectionManager(connectionManager.Object);
+            try
+            {
+                var conn = new SnowflakeDbConnection();
+                conn.ConnectionString = "account=test;user=test;password=test;";
+                conn.SfSession = new SFSession("account=test;user=test;password=test;", new SessionPropertiesContext());
+                conn._connectionState = ConnectionState.Broken;
+
+                // Act
+                await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+
+                // Assert
+                Assert.Equal(ConnectionState.Closed, conn.State);
+                Assert.Null(conn.SfSession);
+            }
+            finally
+            {
+                SnowflakeDbConnectionPool.ReplaceConnectionManager(oldConnectionManager);
+            }
+        }
+
+        [SFFact]
+        public void TestCloseWhenStateIsConnectingDoesNotChangeState()
+        {
+            // Arrange
+            var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = "account=test;user=test;password=test;";
+            conn.SfSession = new SFSession("account=test;user=test;password=test;", new SessionPropertiesContext());
+            conn._connectionState = ConnectionState.Connecting;
+
+            // Act
+            conn.Close();
+
+            // Assert
+            Assert.Equal(ConnectionState.Connecting, conn.State);
+            Assert.NotNull(conn.SfSession);
+        }
+
+        [SFFact]
+        public async Task TestCloseAsyncWhenStateIsConnectingDoesNotChangeState()
+        {
+            // Arrange
+            var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = "account=test;user=test;password=test;";
+            conn.SfSession = new SFSession("account=test;user=test;password=test;", new SessionPropertiesContext());
+            conn._connectionState = ConnectionState.Connecting;
+
+            // Act
+            await conn.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(ConnectionState.Connecting, conn.State);
+            Assert.NotNull(conn.SfSession);
+        }
+
+        [SFFact]
+        public void TestCloseWhenAlreadyClosedIsIdempotent()
+        {
+            // Arrange
+            var conn = new SnowflakeDbConnection();
+            conn._connectionState = ConnectionState.Closed;
+
+            // Act & Assert - no exception thrown
+            conn.Close();
+
+            Assert.Equal(ConnectionState.Closed, conn.State);
+            Assert.Null(conn.SfSession);
+        }
+
+        [SFFact]
+        public async Task TestCloseAsyncWhenCancelledDoesNotChangeState()
+        {
+            // Arrange
+            var mockRestRequester = new MockCloseHangingRestRequester();
+            var conn = new MockSnowflakeDbConnection(mockRestRequester);
+            conn.ConnectionString = "account=test;user=test;password=test;";
+            conn.Open();
+            Assert.Equal(ConnectionState.Open, conn.State);
+
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => conn.CloseAsync(cts.Token)).ConfigureAwait(false);
+
+            Assert.Equal(ConnectionState.Open, conn.State);
+            Assert.NotNull(conn.SfSession);
+        }
+
+        [SFFact]
+        public void TestCloseWhenSessionCloseThrowsSetsStateToBroken()
+        {
+            // Arrange
+            var mockRestRequester = new MockCloseSessionException();
+            var conn = new MockSnowflakeDbConnection(mockRestRequester);
+            conn.ConnectionString = "account=test;user=test;password=test;";
+            conn.Open();
+            Assert.Equal(ConnectionState.Open, conn.State);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAny<Exception>(conn.Close);
+            Assert.True( ex is SnowflakeDbException or AggregateException { InnerException: SnowflakeDbException },
+                $"Expected SnowflakeDbException but got {ex.GetType().Name}");
+
+            Assert.Equal(ConnectionState.Broken, conn.State);
         }
     }
 }

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -48,10 +48,17 @@ namespace Snowflake.Data.Client
             Failure
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="SnowflakeDbConnection"/> with default settings.
+        /// </summary>
         public SnowflakeDbConnection() : this(TomlConnectionBuilder.Instance)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="SnowflakeDbConnection"/> with the specified connection string.
+        /// </summary>
+        /// <param name="connectionString">The connection string used to connect to Snowflake.</param>
         public SnowflakeDbConnection(string connectionString) : this()
         {
             ConnectionString = connectionString;
@@ -68,29 +75,54 @@ namespace Snowflake.Data.Client
             ExplicitTransaction = null;
         }
 
+        /// <summary>
+        /// Gets or sets the connection string used to connect to Snowflake.
+        /// </summary>
         public override string ConnectionString
         {
             get; set;
         }
 
+        /// <summary>
+        /// Gets or sets the password as a <see cref="SecureString"/> for authentication.
+        /// </summary>
         public SecureString Password
         {
             get; set;
         }
 
+        /// <summary>
+        /// Gets or sets the MFA passcode as a <see cref="SecureString"/> for multi-factor authentication.
+        /// </summary>
         public SecureString Passcode { get; set; }
 
+        /// <summary>
+        /// Gets or sets the OAuth client secret as a <see cref="SecureString"/> for OAuth authentication.
+        /// </summary>
         public SecureString OAuthClientSecret { get; set; }
 
+        /// <summary>
+        /// Gets or sets the OAuth token as a <see cref="SecureString"/> for token-based authentication.
+        /// </summary>
         public SecureString Token { get; set; }
 
+        /// <summary>
+        /// Returns whether the connection is currently open and has an active session.
+        /// </summary>
+        /// <returns><c>true</c> if the connection state is open and a session exists; otherwise, <c>false</c>.</returns>
         public bool IsOpen()
         {
             return _connectionState == ConnectionState.Open && SfSession != null;
         }
 
+        /// <summary>
+        /// Gets the name of the current database if the connection is open; otherwise, returns an empty string.
+        /// </summary>
         public override string Database => IsOpen() ? SfSession.database : string.Empty;
 
+        /// <summary>
+        /// Gets the connection timeout in seconds.
+        /// </summary>
         public override int ConnectionTimeout => this._connectionTimeout;
 
         /// <summary>
@@ -111,11 +143,21 @@ namespace Snowflake.Data.Client
             }
         }
 
+        /// <summary>
+        /// Gets the Snowflake server version if the connection is open; otherwise, returns an empty string.
+        /// </summary>
         public override string ServerVersion => IsOpen() ? SfSession.serverVersion : String.Empty;
 
+        /// <summary>
+        /// Gets the current state of the connection.
+        /// </summary>
         public override ConnectionState State => _connectionState;
         internal SnowflakeDbTransaction ExplicitTransaction { get; set; } // tracks only explicit transaction operations
 
+        /// <summary>
+        /// Marks the underlying session to not be returned to the connection pool when the connection is closed.
+        /// </summary>
+        /// <exception cref="Exception">Thrown when no session has been created for this connection.</exception>
         public void PreventPooling()
         {
             if (SfSession == null)
@@ -171,6 +213,10 @@ namespace Snowflake.Data.Client
             }
         }
 
+        /// <summary>
+        /// Changes the current database for an open connection by executing a USE DATABASE command.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to switch to.</param>
         public override void ChangeDatabase(string databaseName)
         {
             logger.Debug($"ChangeDatabase to:{databaseName}");
@@ -187,6 +233,9 @@ namespace Snowflake.Data.Client
             }
         }
 
+        /// <summary>
+        /// Closes the connection to the database. If connection pooling is enabled, the session may be returned to the pool.
+        /// </summary>
         public override void Close()
         {
             logger.Debug("Close Connection.");
@@ -216,6 +265,10 @@ namespace Snowflake.Data.Client
         }
 
 #if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Asynchronously closes the connection to the database.
+        /// </summary>
+        /// <returns>A task representing the asynchronous close operation.</returns>
         // CloseAsync was added to IDbConnection as part of .NET Standard 2.1, first supported by .NET Core 3.0.
         // Adding an override for CloseAsync will prevent the need for casting to SnowflakeDbConnection to call CloseAsync(CancellationToken).
         public override async Task CloseAsync()
@@ -224,6 +277,12 @@ namespace Snowflake.Data.Client
         }
 #endif
 
+        /// <summary>
+        /// Asynchronously closes the connection to the database with cancellation support.
+        /// If connection pooling is enabled, the session may be returned to the pool.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation. If the operation is successfully canceled, <see cref="ConnectionState"/> of this connection will remain unchanged.</param>
+        /// <returns>A task representing the asynchronous close operation.</returns>
         public virtual async Task CloseAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Close Connection.");
@@ -266,6 +325,10 @@ namespace Snowflake.Data.Client
                    transactionRollbackStatus == TransactionRollbackStatus.Success;
         }
 
+        /// <summary>
+        /// Opens a connection to the Snowflake.
+        /// </summary>
+        /// <exception cref="SnowflakeDbException">Thrown when the connection cannot be established.</exception>
         public override void Open()
         {
             logger.Debug("Open Connection.");
@@ -315,6 +378,13 @@ namespace Snowflake.Data.Client
                 ConnectionString = _tomlConnectionBuilder.GetConnectionStringFromToml();
         }
 
+        /// <summary>
+        /// Asynchronously opens a connection to the Snowflake.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task representing the asynchronous open operation.</returns>
+        /// <exception cref="SnowflakeDbException">Thrown when the connection cannot be established.</exception>
+        /// <exception cref="TaskCanceledException">Thrown when the operation is canceled.</exception>
         public override async Task OpenAsync(CancellationToken cancellationToken)
         {
             logger.Debug("Open Connection Async.");
@@ -432,11 +502,21 @@ namespace Snowflake.Data.Client
             base.Dispose(disposing);
         }
 
+        /// <summary>
+        /// Determines whether the given query status indicates the query is still running.
+        /// </summary>
+        /// <param name="status">The query status to check.</param>
+        /// <returns><c>true</c> if the query is still running; otherwise, <c>false</c>.</returns>
         public bool IsStillRunning(QueryStatus status)
         {
             return QueryStatusExtensions.IsStillRunning(status);
         }
 
+        /// <summary>
+        /// Determines whether the given query status indicates an error.
+        /// </summary>
+        /// <param name="status">The query status to check.</param>
+        /// <returns><c>true</c> if the query status represents an error; otherwise, <c>false</c>.</returns>
         public bool IsAnError(QueryStatus status)
         {
             return QueryStatusExtensions.IsAnError(status);

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -89,11 +89,6 @@ namespace Snowflake.Data.Client
             return _connectionState == ConnectionState.Open && SfSession != null;
         }
 
-        private bool IsNonClosedWithSession()
-        {
-            return _connectionState != ConnectionState.Closed && SfSession != null;
-        }
-
         public override string Database => IsOpen() ? SfSession.database : string.Empty;
 
         public override int ConnectionTimeout => this._connectionTimeout;
@@ -196,19 +191,20 @@ namespace Snowflake.Data.Client
         {
             logger.Debug("Close Connection.");
 
+            if (SfSession == null || _connectionState is not ConnectionState.Open and not ConnectionState.Broken)
+            {
+                logger.Debug("Session not opened. Nothing to do.");
+                return;
+            }
+
             try
             {
-                if (IsNonClosedWithSession())
-                {
-                    var returnedToPool = TryToReturnSessionToPool();
-                    if (!returnedToPool)
-                    {
-                        SfSession.close();
-                    }
+                var returnedToPool = TryToReturnSessionToPool();
+                if (!returnedToPool)
+                    SfSession.close();
 
-                    SfSession = null;
-                }
-
+                logger.Debug("Session closed successfully");
+                SfSession = null;
                 _connectionState = ConnectionState.Closed;
             }
             catch (Exception exception)
@@ -235,30 +231,24 @@ namespace Snowflake.Data.Client
             if (cancellationToken.IsCancellationRequested)
                 return;
 
-            if (!IsNonClosedWithSession())
+            if (SfSession == null || _connectionState is not ConnectionState.Open and not ConnectionState.Broken)
             {
                 logger.Debug("Session not opened. Nothing to do.");
                 return;
             }
 
-            var returnedToPool = TryToReturnSessionToPool();
-            if (returnedToPool)
-            {
-                _connectionState = ConnectionState.Closed;
-                SfSession = null;
-                return;
-            }
-
             try
             {
-                await SfSession.CloseAsync(cancellationToken).ConfigureAwait(false);
+                var returnedToPool = TryToReturnSessionToPool();
+                if (!returnedToPool)
+                    await SfSession.CloseAsync(cancellationToken).ConfigureAwait(false);
+
                 logger.Debug("Session closed successfully");
-                _connectionState = ConnectionState.Closed;
                 SfSession = null;
+                _connectionState = ConnectionState.Closed;
             }
             catch (OperationCanceledException)
             {
-                _connectionState = ConnectionState.Closed;
                 logger.Debug("Session close canceled");
                 throw;
             }
@@ -279,6 +269,7 @@ namespace Snowflake.Data.Client
         public override void Open()
         {
             logger.Debug("Open Connection.");
+
             if (_connectionState != ConnectionState.Closed)
             {
                 logger.Debug($"Open with a connection already opened: {_connectionState}");

--- a/Snowflake.Data/Client/SnowflakeDbConnection.cs
+++ b/Snowflake.Data/Client/SnowflakeDbConnection.cs
@@ -281,7 +281,7 @@ namespace Snowflake.Data.Client
         /// Asynchronously closes the connection to the database with cancellation support.
         /// If connection pooling is enabled, the session may be returned to the pool.
         /// </summary>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation. If the operation is successfully canceled, <see cref="ConnectionState"/> of this connection will remain unchanged.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation. If the operation is successfully canceled, <see cref="ConnectionState"/> of this connection will remain unchanged, Cancellation is not a rollback: if the close request already reached the server, the session may be terminated server-side even though this connection still reports <c>Open</c>.</param>
         /// <returns>A task representing the asynchronous close operation.</returns>
         public virtual async Task CloseAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
### Description
Summary

  - Refactors Close() and CloseAsync() to follow an identical control flow pattern: guard clause → try (pool/close →
  null session → set Closed) → catch (set Broken, rethrow)
  - Moves OnSessionConnecting() before FillConnectionStringFromTomlConfigIfNotSet() in Open()/OpenAsync() so state
  transitions are consistent
  - Adds 7 unit tests covering Close/CloseAsync state transition edge cases (Broken→Closed, Connecting guard,
  idempotent close, cancellation behavior, exception→Broken)

  Test plan

  - Run dotnet test --framework net9.0 -- --filter-class "*SnowflakeDbConnectionTest" — all 11 tests pass
  - Verify Close() on a Broken connection with a session transitions to Closed (not silently leaking)
  - Verify CloseAsync() cancellation does not falsely report Closed state
  - Verify Close() exception sets state to Broken and rethrows
  - Integration test: open → close → verify Closed; open → force error → close → verify recovery

  Pull Request description generated with https://claude.ai/claude-code

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
