### PR TITLE
SNOW-3740791

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are
     present.
-  -  Bug fix: Fixed an unnecessary second PUT (stage re-resolution) per file during GCS uploads when the server scopes upload credentials with an access token
+  -  Bug fix: Fixed an unnecessary second PUT (stage re-resolution) per file during GCS uploads when the server scopes upload credentials with an access token.
 - v5.7.0
     - Improved input handling in `ChangeDatabase` by using parameterized queries.
     - Improved input validation in `QueryResultsAwaiter` with stricter UUID format checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   -  Bug fix: Fixed session creation token leak when `GetSessionAsync` is cancelled.
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are
     present.
+  -  Bug fix: Fixed an unnecessary second PUT (stage re-resolution) per file during GCS uploads when the server scopes upload credentials with an access token
 - v5.7.0
     - Improved input handling in `ChangeDatabase` by using parameterized queries.
     - Improved input validation in `QueryResultsAwaiter` with stricter UUID format checks.

--- a/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
@@ -85,7 +85,7 @@ public sealed class PutGcsStageResolutionWiremockTest
             _runner.AddMappings(s_loginMapping);
             _runner.AddMappings(s_presignedMapping, new StringTransformations()
                 .ThenTransform("{{putFileName}}", tmpFileName)
-                .ThenTransform("{{putFilePath}}", tmpFilePath)
+                .ThenTransform("{{putFilePath}}", tmpFilePath.Replace("\\", "\\\\"))
                 .ThenTransform("{{wiremockHttpUrl}}", _runner.WiremockBaseHttpUrl));
 
             using var conn = new SnowflakeDbConnection();
@@ -130,7 +130,7 @@ public sealed class PutGcsStageResolutionWiremockTest
 
             _runner.AddMappings(s_loginMapping);
             _runner.AddMappings(s_downscopedMapping, new StringTransformations()
-                .ThenTransform("{{putGlob}}", putGlob)
+                .ThenTransform("{{putGlob}}", putGlob.Replace("\\", "\\\\"))
                 .ThenTransform("{{wiremockHttpsUrl}}", _runner.WiremockBaseHttpsUrl));
 
             using var conn = new SnowflakeDbConnection();

--- a/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
@@ -78,7 +78,7 @@ public sealed class PutGcsStageResolutionWiremockTest
         // arrange
         var tmpFileName = $"gcs_presigned_{Guid.NewGuid():N}.txt";
         var tmpFilePath = Path.Combine(Path.GetTempPath(), tmpFileName);
-        await File.WriteAllTextAsync(tmpFilePath, "presigned-test-data").ConfigureAwait(false);
+        File.WriteAllText(tmpFilePath, "presigned-test-data");
 
         try
         {
@@ -121,7 +121,7 @@ public sealed class PutGcsStageResolutionWiremockTest
         var fileNames = new[] { "a.txt", "b.txt", "c.txt" };
         foreach (var name in fileNames)
         {
-            await File.WriteAllTextAsync(Path.Combine(tmpDir, name), $"data-{name}");
+            File.WriteAllText(Path.Combine(tmpDir, name), $"data-{name}");
         }
 
         try

--- a/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/PutGcsStageResolutionWiremockTest.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Snowflake.Data.Client;
+using Snowflake.Data.Tests.Util;
+using Xunit;
+
+namespace Snowflake.Data.Tests.UnitTests;
+
+// A GCS upload session uses one credential style throughout: presigned URLs or a
+// downscoped access token, never a mix. The two styles differ in how many stage
+// resolutions the connector performs, which these tests pin by counting
+// /queries/v1/query-request POSTs:
+//   - Presigned: stageInfo has no access token, so the connector re-resolves the
+//     PUT once per destination file to mint each object's presigned URL
+//     (1 initial resolution + N per-file refreshes).
+//   - Downscoped token: stageInfo.creds.GCS_ACCESS_TOKEN is folder-scoped and
+//     covers every file, so the connector resolves exactly once regardless of
+//     file count and never re-resolves.
+[CollectionDefinition(nameof(PutGcsStageResolutionWiremockFixture), DisableParallelization = true)]
+public sealed class PutGcsStageResolutionWiremockFixture : ICollectionFixture<PutGcsStageResolutionWiremockFixture>, IDisposable
+{
+    internal readonly IWiremockRunner Runner;
+    private readonly RemoteCertificateValidationCallback _previousCallback;
+
+    public PutGcsStageResolutionWiremockFixture()
+    {
+        if (SkipConditionEvaluator.Evaluate(SkipCondition.SkipOnJenkins).ShouldSkip)
+        {
+            Runner = new Mock<IWiremockRunner>().Object;
+            return;
+        }
+
+        // Trust WireMock's self-signed certificate for WebRequest-based GCS uploads (HTTPS)
+        _previousCallback = ServicePointManager.ServerCertificateValidationCallback;
+        ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
+
+        Runner = WiremockRunner.NewWiremock();
+    }
+
+    public void Dispose()
+    {
+        ServicePointManager.ServerCertificateValidationCallback = _previousCallback;
+        Runner.Stop();
+    }
+}
+
+[Collection(nameof(PutGcsStageResolutionWiremockFixture))]
+public sealed class PutGcsStageResolutionWiremockTest
+{
+    private static readonly string s_mappingDir = Path.Combine("wiremock", "PutGcsStageResolution");
+    private static readonly string s_loginMapping = Path.Combine(s_mappingDir, "login_success.json");
+    private static readonly string s_presignedMapping = Path.Combine(s_mappingDir, "query_put_gcs_presigned_ok.json");
+    private static readonly string s_downscopedMapping = Path.Combine(s_mappingDir, "query_put_gcs_downscoped_ok.json");
+    private static readonly HttpClient s_http = new();
+
+    private readonly IWiremockRunner _runner;
+
+    public PutGcsStageResolutionWiremockTest(PutGcsStageResolutionWiremockFixture fixture)
+    {
+        _runner = fixture.Runner;
+        _runner.ResetMapping();
+        // Clear the request journal so assertions only see requests from the current test
+        s_http.DeleteAsync($"{_runner.WiremockBaseHttpUrl}/__admin/requests").Result.EnsureSuccessStatusCode();
+    }
+
+    [SFFact(SkipCondition.SkipOnJenkins)]
+    public async Task TestPresignedGcsPutSendsTwoQueryRequests()
+    {
+        // arrange
+        var tmpFileName = $"gcs_presigned_{Guid.NewGuid():N}.txt";
+        var tmpFilePath = Path.Combine(Path.GetTempPath(), tmpFileName);
+        await File.WriteAllTextAsync(tmpFilePath, "presigned-test-data").ConfigureAwait(false);
+
+        try
+        {
+            _runner.AddMappings(s_loginMapping);
+            _runner.AddMappings(s_presignedMapping, new StringTransformations()
+                .ThenTransform("{{putFileName}}", tmpFileName)
+                .ThenTransform("{{putFilePath}}", tmpFilePath)
+                .ThenTransform("{{wiremockHttpUrl}}", _runner.WiremockBaseHttpUrl));
+
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = BuildConnectionString();
+            await conn.OpenAsync().ConfigureAwait(false);
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"PUT file://{tmpFilePath} @~";
+
+            // act
+            cmd.ExecuteNonQuery();
+
+            // assert — 2 query-requests: initial resolution + per-file presigned URL refresh
+            var queryRequests = GetWiremockRequestsTo("/queries/v1/query-request");
+            Assert.Equal(2, queryRequests.Count);
+
+            // assert — 1 PUT to the fake GCS upload endpoint
+            var uploadRequests = GetWiremockRequestsTo("/fake-gcs-upload", method: "PUT");
+            Assert.Single(uploadRequests);
+        }
+        finally
+        {
+            File.Delete(tmpFilePath);
+        }
+    }
+
+    [SFFact(SkipCondition.SkipOnJenkins)]
+    public async Task TestDownscopedGcsPutSendsOneQueryRequest()
+    {
+        // arrange
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"gcs_downscoped_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        var fileNames = new[] { "a.txt", "b.txt", "c.txt" };
+        foreach (var name in fileNames)
+        {
+            await File.WriteAllTextAsync(Path.Combine(tmpDir, name), $"data-{name}");
+        }
+
+        try
+        {
+            var putGlob = Path.Combine(tmpDir, "*");
+
+            _runner.AddMappings(s_loginMapping);
+            _runner.AddMappings(s_downscopedMapping, new StringTransformations()
+                .ThenTransform("{{putGlob}}", putGlob)
+                .ThenTransform("{{wiremockHttpsUrl}}", _runner.WiremockBaseHttpsUrl));
+
+            using var conn = new SnowflakeDbConnection();
+            conn.ConnectionString = BuildConnectionString();
+            await conn.OpenAsync().ConfigureAwait(false);
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"PUT file://{putGlob} @~";
+
+            // act
+            cmd.ExecuteNonQuery();
+
+            // assert — exactly 1 query-request: single resolution, no per-file refresh
+            var queryRequests = GetWiremockRequestsTo("/queries/v1/query-request");
+            Assert.Single(queryRequests);
+
+            // assert — 3 PUT requests to GCS bucket (one per file)
+            var uploadRequests = GetWiremockRequestsTo("/gcs-bucket/", method: "PUT");
+            Assert.Equal(3, uploadRequests.Count);
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    private List<JToken> GetWiremockRequestsTo(string urlPath, string method = "POST")
+    {
+        var requestBody = JObject.FromObject(new
+        {
+            urlPathPattern = $"{urlPath}.*",
+            method
+        }).ToString();
+
+        var response = s_http.PostAsync(
+            _runner.WiremockBaseHttpUrl + "/__admin/requests/find",
+            new StringContent(requestBody, Encoding.UTF8, "application/json")).Result;
+
+        var json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+        return (json["requests"] as JArray)?.ToList() ?? new List<JToken>();
+    }
+
+    private static string BuildConnectionString()
+    {
+        return new StringBuilder()
+            .Append("account=testaccount;")
+            .Append("user=test;")
+            .Append("password=test;")
+            .Append($"host={WiremockRunner.Host};")
+            .Append($"port={WiremockRunner.DefaultHttpPort};")
+            .Append("scheme=http;")
+            .Append("poolingEnabled=false;")
+            .ToString();
+    }
+}

--- a/Snowflake.Data.Tests/Util/WiremockRunner.cs
+++ b/Snowflake.Data.Tests/Util/WiremockRunner.cs
@@ -13,6 +13,7 @@ namespace Snowflake.Data.Tests.Util
     public interface IWiremockRunner : IDisposable
     {
         string WiremockBaseHttpUrl { get; }
+        string WiremockBaseHttpsUrl { get; }
         void Stop();
         void ResetMapping();
         void AddMappings(string file, StringTransformations transformations = null);

--- a/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/login_success.json
+++ b/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/login_success.json
@@ -1,0 +1,39 @@
+{
+    "mappings": [
+        {
+            "name": "Successful password login",
+            "request": {
+                "urlPathPattern": "/session/v1/login-request",
+                "method": "POST"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "masterToken": "masterToken123",
+                        "token": "sessionToken123",
+                        "sessionId": 1234567890,
+                        "parameters": [],
+                        "sessionInfo": {
+                            "databaseName": null,
+                            "schemaName": null,
+                            "warehouseName": null,
+                            "roleName": null
+                        },
+                        "idToken": null,
+                        "idTokenValidityInSeconds": 0,
+                        "responseData": null,
+                        "mfaToken": null,
+                        "mfaTokenValidityInSeconds": 0
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        }
+    ]
+}

--- a/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/query_put_gcs_downscoped_ok.json
+++ b/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/query_put_gcs_downscoped_ok.json
@@ -1,0 +1,60 @@
+{
+    "mappings": [
+        {
+            "name": "PUT command resolution (downscoped access-token mode): returns a folder-scoped GCS_ACCESS_TOKEN so the connector resolves once and never re-resolves per file",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request.*",
+                "method": "POST",
+                "bodyPatterns": [
+                    { "contains": "PUT file://" }
+                ]
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "command": "UPLOAD",
+                        "src_locations": ["{{putGlob}}"],
+                        "parallel": 4,
+                        "autoCompress": false,
+                        "overwrite": true,
+                        "sourceCompression": "none",
+                        "stageInfo": {
+                            "locationType": "GCS",
+                            "location": "gcs-bucket/path/",
+                            "presignedUrl": null,
+                            "creds": {
+                                "GCS_ACCESS_TOKEN": "mock-downscoped-token"
+                            },
+                            "region": "us-central1",
+                            "endPoint": "{{wiremockHttpsUrl}}"
+                        },
+                        "encryptionMaterial": null,
+                        "queryId": "fake-put-downscoped-query-id",
+                        "statementTypeId": 4096
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "GCS object upload (token mode) - matches PUT to gcs-bucket path",
+            "request": {
+                "urlPathPattern": "/gcs-bucket/.*",
+                "method": "PUT"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {}
+            }
+        }
+    ]
+}

--- a/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/query_put_gcs_presigned_ok.json
+++ b/Snowflake.Data.Tests/wiremock/PutGcsStageResolution/query_put_gcs_presigned_ok.json
@@ -1,0 +1,96 @@
+{
+    "mappings": [
+        {
+            "name": "Initial PUT command resolution (returns stageInfo with presignedUrl=null, forcing per-file re-resolution)",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request.*",
+                "method": "POST",
+                "bodyPatterns": [
+                    { "doesNotContain": "PUT file://{{putFileName}}" }
+                ]
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "command": "UPLOAD",
+                        "src_locations": ["{{putFilePath}}"],
+                        "parallel": 4,
+                        "autoCompress": false,
+                        "overwrite": true,
+                        "sourceCompression": "none",
+                        "stageInfo": {
+                            "locationType": "GCS",
+                            "location": "gcs-bucket/path/",
+                            "presignedUrl": null,
+                            "creds": {},
+                            "region": "us-central1"
+                        },
+                        "encryptionMaterial": null,
+                        "queryId": "fake-put-presigned-query-id",
+                        "statementTypeId": 4096
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Successful per-file presigned-URL refresh (returns a real presignedUrl)",
+            "request": {
+                "urlPathPattern": "/queries/v1/query-request.*",
+                "method": "POST",
+                "bodyPatterns": [
+                    { "contains": "PUT file://{{putFileName}}" }
+                ]
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {
+                    "data": {
+                        "command": "UPLOAD",
+                        "src_locations": ["{{putFileName}}"],
+                        "parallel": 4,
+                        "autoCompress": false,
+                        "overwrite": true,
+                        "sourceCompression": "none",
+                        "stageInfo": {
+                            "locationType": "GCS",
+                            "location": "gcs-bucket/path/",
+                            "presignedUrl": "{{wiremockHttpUrl}}/fake-gcs-upload",
+                            "creds": {},
+                            "region": "us-central1"
+                        },
+                        "encryptionMaterial": null,
+                        "queryId": "fake-put-presigned-refresh-query-id",
+                        "statementTypeId": 4096
+                    },
+                    "code": null,
+                    "message": null,
+                    "success": true
+                }
+            }
+        },
+        {
+            "name": "Fake GCS upload endpoint (target of the refreshed presignedUrl)",
+            "request": {
+                "urlPathPattern": "/fake-gcs-upload",
+                "method": "PUT"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "jsonBody": {}
+            }
+        }
+    ]
+}

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Snowflake.Data.Configuration;
+using Snowflake.Data.Core.FileTransfer.StorageClient;
 using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Core
@@ -191,7 +192,7 @@ namespace Snowflake.Data.Core
                 }
 
                 // Update the file metadata with GCS presigned URL
-                updatePresignedUrl();
+                UpdatePresignedUrl();
 
                 foreach (SFFileMetadata fileMetadata in FilesMetas)
                 {
@@ -249,7 +250,7 @@ namespace Snowflake.Data.Core
             }
 
             // Update the file metadata with GCS presigned URL
-            await updatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
+            await UpdatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (SFFileMetadata fileMetadata in FilesMetas)
             {
@@ -431,83 +432,99 @@ namespace Snowflake.Data.Core
         /// <summary>
         /// Get the presigned URL and update the file metadata.
         /// </summary>
-        private void updatePresignedUrl()
+        private void UpdatePresignedUrl()
         {
             // Presigned url only applies to GCS
-            if (TransferMetadata.stageInfo.locationType == "GCS")
+            if (TransferMetadata.stageInfo.locationType != "GCS")
+                return;
+
+            if (CommandTypes.DOWNLOAD == CommandType)
             {
-                if (CommandTypes.UPLOAD == CommandType)
+                for (var index = 0; index < FilesMetas.Count; index++)
                 {
-                    foreach (SFFileMetadata fileMeta in FilesMetas)
-                    {
-                        string filePathToReplace = getFilePathFromPutCommand(Query);
-                        string fileNameToReplaceWith = fileMeta.destFileName;
-                        string queryWithSingleFile = Query;
-                        queryWithSingleFile = queryWithSingleFile.Replace(filePathToReplace, fileNameToReplaceWith);
-
-                        SFStatement sfStatement = new SFStatement(Session);
-                        sfStatement.isPutGetQuery = true;
-
-                        PutGetExecResponse response =
-                            sfStatement.ExecuteHelper<PutGetExecResponse, PutGetResponseData>(
-                                0,
-                                queryWithSingleFile,
-                                null,
-                                false);
-
-                        fileMeta.stageInfo = response.data.stageInfo;
-                        fileMeta.presignedUrl = response.data.stageInfo.presignedUrl;
-                    }
+                    FilesMetas[index].presignedUrl = TransferMetadata.presignedUrls[index];
                 }
-                else if (CommandTypes.DOWNLOAD == CommandType)
-                {
-                    for (int index = 0; index < FilesMetas.Count; index++)
-                    {
-                        FilesMetas[index].presignedUrl = TransferMetadata.presignedUrls[index];
-                    }
-                }
+
+                return;
+            }
+
+            if (CommandType != CommandTypes.UPLOAD)
+                return;
+
+            // Skip entirely in access-token mode: a downscoped token is folder-scoped and already covers every file, so there is nothing per-file to fetch.
+            if (TransferMetadata.stageInfo.stageCredentials?.TryGetValue(SFGCSClient.GCS_ACCESS_TOKEN, out var value) == true && !string.IsNullOrEmpty(value))
+                return;
+
+            foreach (var fileMeta in FilesMetas)
+            {
+                var filePathToReplace = getFilePathFromPutCommand(Query);
+                var fileNameToReplaceWith = fileMeta.destFileName;
+                var queryWithSingleFile = Query;
+                queryWithSingleFile = queryWithSingleFile.Replace(filePathToReplace, fileNameToReplaceWith);
+
+                var sfStatement = new SFStatement(Session);
+                sfStatement.isPutGetQuery = true;
+
+                var response =
+                    sfStatement.ExecuteHelper<PutGetExecResponse, PutGetResponseData>(
+                        0,
+                        queryWithSingleFile,
+                        null,
+                        false);
+
+                fileMeta.stageInfo = response.data.stageInfo;
+                fileMeta.presignedUrl = response.data.stageInfo.presignedUrl;
             }
         }
 
         /// <summary>
         /// Get the presigned URL async method and update the file metadata.
         /// </summary>
-        internal async Task updatePresignedUrlAsync(CancellationToken cancellationToken)
+        private async Task UpdatePresignedUrlAsync(CancellationToken cancellationToken)
         {
             // Presigned url only applies to GCS
-            if (TransferMetadata.stageInfo.locationType == "GCS")
+            if (TransferMetadata.stageInfo.locationType != "GCS")
+                return;
+
+            if (CommandType == CommandTypes.DOWNLOAD)
             {
-                if (CommandTypes.UPLOAD == CommandType)
+                for (var index = 0; index < FilesMetas.Count; index++)
                 {
-                    foreach (SFFileMetadata fileMeta in FilesMetas)
-                    {
-                        string filePathToReplace = getFilePathFromPutCommand(Query);
-                        string fileNameToReplaceWith = fileMeta.destFileName;
-                        string queryWithSingleFile = Query;
-                        queryWithSingleFile = queryWithSingleFile.Replace(filePathToReplace, fileNameToReplaceWith);
-
-                        SFStatement sfStatement = new SFStatement(Session);
-                        sfStatement.isPutGetQuery = true;
-
-                        PutGetExecResponse response = await
-                            sfStatement.ExecuteAsyncHelper<PutGetExecResponse, PutGetResponseData>(
-                                0,
-                                queryWithSingleFile,
-                                null,
-                                false,
-                                cancellationToken).ConfigureAwait(false);
-
-                        fileMeta.stageInfo = response.data.stageInfo;
-                        fileMeta.presignedUrl = response.data.stageInfo.presignedUrl;
-                    }
+                    FilesMetas[index].presignedUrl = TransferMetadata.presignedUrls[index];
                 }
-                else if (CommandTypes.DOWNLOAD == CommandType)
+
+                return;
+            }
+
+            if (CommandType != CommandTypes.UPLOAD)
+                return;
+
+            // Skip entirely in access-token mode: a downscoped token is folder-scoped and already covers every file, so there is nothing per-file to fetch.
+            if (TransferMetadata.stageInfo.stageCredentials?.TryGetValue(SFGCSClient.GCS_ACCESS_TOKEN, out var value) == true && !string.IsNullOrEmpty(value))
+                return;
+
+            foreach (var fileMeta in FilesMetas)
+            {
+                var filePathToReplace = getFilePathFromPutCommand(Query);
+                var fileNameToReplaceWith = fileMeta.destFileName;
+                var queryWithSingleFile = Query;
+                queryWithSingleFile = queryWithSingleFile.Replace(filePathToReplace, fileNameToReplaceWith);
+
+                var sfStatement = new SFStatement(Session)
                 {
-                    for (int index = 0; index < FilesMetas.Count; index++)
-                    {
-                        FilesMetas[index].presignedUrl = TransferMetadata.presignedUrls[index];
-                    }
-                }
+                    isPutGetQuery = true
+                };
+
+                var response = await
+                    sfStatement.ExecuteAsyncHelper<PutGetExecResponse, PutGetResponseData>(
+                        0,
+                        queryWithSingleFile,
+                        null,
+                        false,
+                        cancellationToken).ConfigureAwait(false);
+
+                fileMeta.stageInfo = response.data.stageInfo;
+                fileMeta.presignedUrl = response.data.stageInfo.presignedUrl;
             }
         }
 
@@ -992,7 +1009,7 @@ namespace Snowflake.Data.Core
                 }
                 else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
                 {
-                    updatePresignedUrl();
+                    UpdatePresignedUrl();
                 }
 
                 // Break out of loop if file is successfully uploaded or already exists
@@ -1036,7 +1053,7 @@ namespace Snowflake.Data.Core
                 }
                 else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
                 {
-                    await updatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
+                    await UpdatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
                 }
 
                 // Break out of loop if file is successfully uploaded or already exists
@@ -1077,7 +1094,7 @@ namespace Snowflake.Data.Core
             }
             else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
             {
-                updatePresignedUrl();
+                UpdatePresignedUrl();
             }
 
             ResultsMetas.Add(resultMetadata);
@@ -1104,7 +1121,7 @@ namespace Snowflake.Data.Core
             }
             else if (resultMetadata.resultStatus == ResultStatus.RENEW_PRESIGNED_URL.ToString())
             {
-                await updatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
+                await UpdatePresignedUrlAsync(cancellationToken).ConfigureAwait(false);
             }
 
             ResultsMetas.Add(resultMetadata);

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFGCSClient.cs
@@ -34,7 +34,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <summary>
         /// The attribute in the credential map containing the access token.
         /// </summary>
-        private static readonly string GCS_ACCESS_TOKEN = "GCS_ACCESS_TOKEN";
+        internal static readonly string GCS_ACCESS_TOKEN = "GCS_ACCESS_TOKEN";
 
         /// <summary>
         /// The logger.


### PR DESCRIPTION
### Description
## Summary
  - Eliminated redundant per-file stage re-resolution (PUT query-request) during GCS uploads when the server provides
  a downscoped access token instead of presigned URLs.
  - Previously, the connector would re-execute the PUT query once per file to refresh stage metadata — even in
  downscoped-token mode where the folder-scoped token already covers all files. This change early-returns from
  `UpdatePresignedUrl`/`UpdatePresignedUrlAsync` when `GCS_ACCESS_TOKEN` is present in `stageCredentials`.
  - Added WireMock-based unit tests that pin the expected number of query-requests for both credential styles:
    - **Presigned URL mode**: 1 initial resolution + 1 per-file refresh (2 total for 1 file)
    - **Downscoped token mode**: exactly 1 resolution regardless of file count (verified with 3 files)

  ## Test plan
  - [x] `PutGcsStageResolutionWiremockTest.TestPresignedGcsPutSendsTwoQueryRequests` — verifies presigned-URL uploads
  still perform per-file re-resolution
  - [x] `PutGcsStageResolutionWiremockTest.TestDownscopedGcsPutSendsOneQueryRequest` — verifies downscoped-token
  uploads skip per-file re-resolution
  - [x] Existing GCS integration tests continue to pass (presigned + token modes)
  - [x] Manual validation against a Snowflake account with GCS internal stage

  Pull Request description generated with [Claude Code](https://claude.com/claude-code)

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
