### PR TITLE
SNOW-3757188 Invoke HEAD for object metadata in S3 instead of GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v5.8.0
+  -  Upgraded `AWSSDK.S3` dependency. Now getting object header invokes HEAD s3 call instead of GET.
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.
   -  Replaced NUnit tests with Xunit in order to modernize and stabilize existing CI/CD setup.

--- a/Snowflake.Data.Tests/Mock/MockS3Client.cs
+++ b/Snowflake.Data.Tests/Mock/MockS3Client.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.S3;
+using Amazon.S3;
 using Amazon.S3.Model;
 using Snowflake.Data.Core.FileTransfer.StorageClient;
 using System;

--- a/Snowflake.Data.Tests/Mock/MockS3Client.cs
+++ b/Snowflake.Data.Tests/Mock/MockS3Client.cs
@@ -31,17 +31,13 @@ namespace Snowflake.Data.Tests.Mock
         internal const int ContentLength = 9999;
 
         // Create AWS exception for mock requests
-        private static Exception CreateMockAwsResponseError(string awsErrorCode, bool isAsync)
+        private static Exception CreateMockAwsResponseError(string awsErrorCode)
         {
             var exception = awsErrorCode.Length > 0
                ? new AmazonS3Exception(S3ErrorMessage) { ErrorCode = awsErrorCode }
                : new Exception("Non-AWS exception");
 
-            if (isAsync)
-                return exception;
-
-            var exceptionContainingS3Error = new Exception(S3ErrorMessage, exception);
-            return exceptionContainingS3Error;  // S3 places the AmazonS3Exception on the InnerException property on non-async calls
+            return exception;
         }
 
         // Create mock response for GetFileHeader
@@ -62,7 +58,7 @@ namespace Snowflake.Data.Tests.Mock
             }
             else
             {
-                throw CreateMockAwsResponseError(statusCode, isAsync);
+                throw CreateMockAwsResponseError(statusCode);
             }
         }
 
@@ -75,7 +71,7 @@ namespace Snowflake.Data.Tests.Mock
             }
             else
             {
-                throw CreateMockAwsResponseError(awsStatusCode, isAsync);
+                throw CreateMockAwsResponseError(awsStatusCode);
             }
         }
 
@@ -92,7 +88,7 @@ namespace Snowflake.Data.Tests.Mock
             }
             else
             {
-                throw CreateMockAwsResponseError(statusCode, isAsync);
+                throw CreateMockAwsResponseError(statusCode);
             }
         }
     }

--- a/Snowflake.Data.Tests/Mock/MockS3Client.cs
+++ b/Snowflake.Data.Tests/Mock/MockS3Client.cs
@@ -1,4 +1,4 @@
-using Amazon.S3;
+﻿using Amazon.S3;
 using Amazon.S3.Model;
 using Snowflake.Data.Core.FileTransfer.StorageClient;
 using System;
@@ -31,32 +31,32 @@ namespace Snowflake.Data.Tests.Mock
         internal const int ContentLength = 9999;
 
         // Create AWS exception for mock requests
-        static Exception CreateMockAwsResponseError(string awsErrorCode, bool isAsync)
+        private static Exception CreateMockAwsResponseError(string awsErrorCode, bool isAsync)
         {
-            Exception exception = awsErrorCode.Length > 0
+            var exception = awsErrorCode.Length > 0
                ? new AmazonS3Exception(S3ErrorMessage) { ErrorCode = awsErrorCode }
                : new Exception("Non-AWS exception");
 
             if (isAsync)
-            {
-                return exception; // S3 throws the AmazonS3Exception on async calls
-            }
+                return exception;
 
-            Exception exceptionContainingS3Error = new Exception(S3ErrorMessage, exception);
+            var exceptionContainingS3Error = new Exception(S3ErrorMessage, exception);
             return exceptionContainingS3Error;  // S3 places the AmazonS3Exception on the InnerException property on non-async calls
         }
 
         // Create mock response for GetFileHeader
-        internal static Task<GetObjectResponse> CreateResponseForGetFileHeader(string statusCode, bool isAsync)
+        internal static Task<GetObjectMetadataResponse> CreateResponseForGetFileHeader(string statusCode, bool isAsync)
         {
-            if (statusCode == HttpStatusCode.OK.ToString())
+            if (statusCode == nameof(HttpStatusCode.OK))
             {
-                var getObjectResponse = new GetObjectResponse();
-                getObjectResponse.ContentLength = MockS3Client.ContentLength;
-                getObjectResponse.Metadata.Add(SFS3Client.AMZ_IV, MockS3Client.AmzIV);
-                getObjectResponse.Metadata.Add(SFS3Client.AMZ_KEY, MockS3Client.AmzKey);
-                getObjectResponse.Metadata.Add(SFS3Client.AMZ_MATDESC, MockS3Client.AmzMatdesc);
-                getObjectResponse.Metadata.Add(SFS3Client.SFC_DIGEST, MockS3Client.SfcDigest);
+                var getObjectResponse = new GetObjectMetadataResponse
+                {
+                    ContentLength = ContentLength
+                };
+                getObjectResponse.Metadata.Add(SFS3Client.AMZ_IV, AmzIV);
+                getObjectResponse.Metadata.Add(SFS3Client.AMZ_KEY, AmzKey);
+                getObjectResponse.Metadata.Add(SFS3Client.AMZ_MATDESC, AmzMatdesc);
+                getObjectResponse.Metadata.Add(SFS3Client.SFC_DIGEST, SfcDigest);
 
                 return Task.FromResult(getObjectResponse);
             }

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Xunit;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.FileTransfer.StorageClient;
@@ -355,7 +355,7 @@ namespace Snowflake.Data.Tests.UnitTests
             // arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
-            var response = new GetObjectResponse();
+            var response = new GetObjectMetadataResponse();
             response.Metadata.Add(SFS3Client.AMZ_IV.ToUpper(), "initVector");
             response.Metadata.Add(SFS3Client.AMZ_KEY.ToUpper(), "key");
             response.Metadata.Add(SFS3Client.AMZ_MATDESC.ToUpper(), "description");
@@ -365,7 +365,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var fileHeader = _client.HandleFileHeaderResponse(ref _fileMetadata, response);
 
             // assert
-            Assert.Equal(ResultStatus.UPLOADED.ToString(), _fileMetadata.resultStatus);
+            Assert.Equal(nameof(ResultStatus.UPLOADED), _fileMetadata.resultStatus);
             Assert.Equal("something", fileHeader.digest);
             Assert.Equal("initVector", fileHeader.encryptionMetadata.iv);
             Assert.Equal("key", fileHeader.encryptionMetadata.key);
@@ -378,7 +378,7 @@ namespace Snowflake.Data.Tests.UnitTests
             // arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
-            var response = new GetObjectResponse();
+            var response = new GetObjectMetadataResponse();
             response.Metadata.Add(SFS3Client.AMZ_IV, "initVector");
             response.Metadata.Add(SFS3Client.AMZ_KEY, "key");
             response.Metadata.Add(SFS3Client.AMZ_MATDESC, "description");
@@ -387,7 +387,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var fileHeader = _client.HandleFileHeaderResponse(ref _fileMetadata, response);
 
             // assert
-            Assert.Equal(ResultStatus.UPLOADED.ToString(), _fileMetadata.resultStatus);
+            Assert.Equal(nameof(ResultStatus.UPLOADED), _fileMetadata.resultStatus);
             Assert.Null(fileHeader.digest);
             Assert.Equal("initVector", fileHeader.encryptionMetadata.iv);
             Assert.Equal("key", fileHeader.encryptionMetadata.key);

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -125,13 +125,13 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
-            mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
+            mockAmazonS3Client.Setup(client => client.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
                 .Returns(() => MockS3Client.CreateResponseForGetFileHeader(awsStatusCode, false));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;
 
             // Act
-            FileHeader fileHeader = _client.GetFileHeader(_fileMetadata);
+            var fileHeader = _client.GetFileHeader(_fileMetadata);
 
             // Assert
             AssertForGetFileHeaderTests(expectedResultStatus, fileHeader);
@@ -147,7 +147,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             // Arrange
             var mockAmazonS3Client = new Mock<AmazonS3Client>(AwsKeyId, AwsSecretKey, AwsToken, _clientConfig);
-            mockAmazonS3Client.Setup(client => client.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
+            mockAmazonS3Client.Setup(client => client.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
                 .Returns(() => MockS3Client.CreateResponseForGetFileHeader(awsStatusCode, true));
             _client = new SFS3Client(_fileMetadata.stageInfo, MaxRetry, Parallel, _proxyCredentials, mockAmazonS3Client.Object);
             _fileMetadata.client = _client;

--- a/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFS3ClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.FileTransfer.StorageClient;

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -1,4 +1,4 @@
-using Snowflake.Data.Client;
+﻿using Snowflake.Data.Client;
 using Snowflake.Data.Core.FileTransfer;
 using Snowflake.Data.Log;
 using System;
@@ -373,7 +373,7 @@ namespace Snowflake.Data.Core
             if (0 < SmallFilesMetas.Count)
             {
                 Logger.Debug("Start uploading small files");
-                await UploadFilesInParallelAsync(SmallFilesMetas, TransferMetadata.parallel, cancellationToken).ConfigureAwait(false);
+                await UploadFilesInParallelAsync(SmallFilesMetas, cancellationToken).ConfigureAwait(false);
                 Logger.Debug("End uploading small files");
             }
         }
@@ -1038,9 +1038,9 @@ namespace Snowflake.Data.Core
         /// Upload a list of files in parallel using the given parallelization factor.
         /// </summary>
         /// <param name="fileMetadata">The metadata of the file to upload.</param>
+        /// <param name="cancellationToken">Cancellation support.</param>
         /// <returns>The result outcome for each file.</returns>
-        private async Task UploadFilesInSequentialAsync(
-            SFFileMetadata fileMetadata, CancellationToken cancellationToken)
+        private async Task UploadFilesInSequentialAsync(SFFileMetadata fileMetadata, CancellationToken cancellationToken)
         {
             SFFileMetadata resultMetadata = await UploadSingleFileAsync(fileMetadata, cancellationToken).ConfigureAwait(false);
             bool breakFlag = false;
@@ -1156,14 +1156,10 @@ namespace Snowflake.Data.Core
         /// Upload a list of files in parallel using the given parallelization factor.
         /// </summary>
         /// <param name="filesMetadata">The list of files to upload in parallel.</param>
-        /// <param name="parallel">The number of files to upload in parallel.</param>
+        /// <param name="cancellationToken">Cancellation support.</param>
         /// <returns>The result outcome for each file.</returns>
-        private async Task UploadFilesInParallelAsync(
-            List<SFFileMetadata> filesMetadata,
-            int parallel,
-            CancellationToken cancellationToken)
+        private async Task UploadFilesInParallelAsync(List<SFFileMetadata> filesMetadata, CancellationToken cancellationToken)
         {
-            var listOfActions = new List<Action>();
             foreach (SFFileMetadata fileMetadata in filesMetadata)
             {
                 await UploadFilesInSequentialAsync(fileMetadata, cancellationToken).ConfigureAwait(false);

--- a/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
+++ b/Snowflake.Data/Core/FileTransfer/SFFileTransferAgent.cs
@@ -1,4 +1,4 @@
-﻿using Snowflake.Data.Client;
+using Snowflake.Data.Client;
 using Snowflake.Data.Core.FileTransfer;
 using Snowflake.Data.Log;
 using System;

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -302,7 +302,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         {
             // Always return a regional URL
             clientConfig.USEast1RegionalEndpointValue = S3UsEast1RegionalEndpointValue.Regional;
-            if ((null != region) && (0 != region.Length))
+            if (!string.IsNullOrEmpty(region))
             {
                 var regionEndpoint = RegionEndpoint.GetBySystemName(region);
                 clientConfig.RegionEndpoint = regionEndpoint;
@@ -328,7 +328,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             // The region information used to determine the endpoint for the service.
             // RegionEndpoint and ServiceURL are mutually exclusive properties.
             // If both stageInfo.endPoint and stageInfo.region have a value, the endPoint takes precedence
-            else if ((null != region) && (0 != region.Length))
+            else if (!string.IsNullOrEmpty(region))
             {
                 var regionEndpoint = RegionEndpoint.GetBySystemName(region);
                 clientConfig.RegionEndpoint = regionEndpoint;
@@ -348,25 +348,22 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public void UploadFile(SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata)
         {
             // Get the client
-            var SFS3Client = (SFS3Client)fileMetadata.client;
-            var client = SFS3Client.S3Client;
-            var putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
+            var sfS3Client = (SFS3Client)fileMetadata.client;
+            var client = sfS3Client.S3Client;
+            var putObjectRequest = GetPutObjectRequest(fileMetadata, fileBytesStream, encryptionMetadata);
 
             try
             {
-                // Issue the POST/PUT request
-                var task = client.PutObjectAsync(putObjectRequest);
-                task.ConfigureAwait(false);
-                task.Wait();
+                _ = client.PutObjectAsync(putObjectRequest).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
-                HandleUploadFileErr(ex.InnerException, fileMetadata);
+                HandleUploadFileErr(ex, fileMetadata);
                 return;
             }
 
             fileMetadata.destFileSize = fileMetadata.uploadSize;
-            fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
+            fileMetadata.resultStatus = nameof(ResultStatus.UPLOADED);
         }
 
         /// <summary>
@@ -378,14 +375,14 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public async Task UploadFileAsync(SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
         {
             // Get the client
-            var SFS3Client = (SFS3Client)fileMetadata.client;
-            var client = SFS3Client.S3Client;
-            var putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
+            var sfS3Client = (SFS3Client)fileMetadata.client;
+            var client = sfS3Client.S3Client;
+            var putObjectRequest = GetPutObjectRequest(fileMetadata, fileBytesStream, encryptionMetadata);
 
             try
             {
                 // Issue the POST/PUT request
-                await client.PutObjectAsync(putObjectRequest).ConfigureAwait(false);
+                await client.PutObjectAsync(putObjectRequest, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -394,18 +391,17 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             }
 
             fileMetadata.destFileSize = fileMetadata.uploadSize;
-            fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
+            fileMetadata.resultStatus = nameof(ResultStatus.UPLOADED);
         }
 
         /// <summary>
         /// Upload the file to the S3 location.
         /// </summary>
-        /// <param name="client"> Amazon S3 client.</param>
         /// <param name="fileMetadata">The S3 file metadata.</param>
         /// <param name="fileBytesStream">The file bytes to upload.</param>
         /// <param name="encryptionMetadata">The encryption metadata for the header.</param>
         /// <returns>The Put Object request.</returns>
-        private PutObjectRequest GetPutObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata)
+        private PutObjectRequest GetPutObjectRequest(SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata)
         {
             var stageInfo = fileMetadata.stageInfo;
             var location = ExtractBucketNameAndPath(stageInfo.location);
@@ -440,33 +436,25 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public void DownloadFile(SFFileMetadata fileMetadata, string fullDstPath, int maxConcurrency)
         {
             // Get the client
-            var SFS3Client = (SFS3Client)fileMetadata.client;
-            var client = SFS3Client.S3Client;
-            var getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
+            var sfS3Client = (SFS3Client)fileMetadata.client;
+            var client = sfS3Client.S3Client;
+            var getObjectRequest = GetGetObjectRequest(fileMetadata);
 
             try
             {
-                // Issue the GET request
-                var task = client.GetObjectAsync(getObjectRequest);
-                task.ConfigureAwait(false);
-                task.Wait();
+                var taskAwaiter = client.GetObjectAsync(getObjectRequest).GetAwaiter();
 
-                using (var response = task.Result)
-                {
-                    // Write to file
-                    using (var fileStream = FileOperations.Instance.Create(fullDstPath))
-                    {
-                        response.ResponseStream.CopyTo(fileStream);
-                    }
-                }
+                using var response = taskAwaiter.GetResult();
+                using var fileStream = FileOperations.Instance.Create(fullDstPath);
+                response.ResponseStream.CopyTo(fileStream);
             }
             catch (Exception ex)
             {
-                HandleDownloadFileErr(ex.InnerException, fileMetadata);
+                HandleDownloadFileErr(ex, fileMetadata);
                 return;
             }
 
-            fileMetadata.resultStatus = ResultStatus.DOWNLOADED.ToString();
+            fileMetadata.resultStatus = nameof(ResultStatus.DOWNLOADED);
         }
 
         /// <summary>
@@ -480,18 +468,14 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             // Get the client
             var SFS3Client = (SFS3Client)fileMetadata.client;
             var client = SFS3Client.S3Client;
-            var getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
+            var getObjectRequest = GetGetObjectRequest(fileMetadata);
 
             try
             {
                 // Issue the GET request
-                using (var response = await client.GetObjectAsync(getObjectRequest, cancellationToken).ConfigureAwait(false))
-
-                // Write to file
-                using (var fileStream = FileOperations.Instance.Create(fullDstPath))
-                {
-                    response.ResponseStream.CopyTo(fileStream);
-                }
+                using var response = await client.GetObjectAsync(getObjectRequest, cancellationToken).ConfigureAwait(false);
+                using var fileStream = FileOperations.Instance.Create(fullDstPath);
+                response.ResponseStream.CopyTo(fileStream);
             }
             catch (Exception ex)
             {
@@ -499,10 +483,10 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 return;
             }
 
-            fileMetadata.resultStatus = ResultStatus.DOWNLOADED.ToString();
+            fileMetadata.resultStatus = nameof(ResultStatus.DOWNLOADED);
         }
 
-        private GetObjectRequest GetGetObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata)
+        private GetObjectRequest GetGetObjectRequest(SFFileMetadata fileMetadata)
         {
             var stageInfo = fileMetadata.stageInfo;
             var location = ExtractBucketNameAndPath(stageInfo.location);
@@ -511,7 +495,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             return new GetObjectRequest
             {
                 BucketName = location.bucket,
-                Key = location.key + fileMetadata.srcFileName,
+                Key = $"{location.key}{fileMetadata.srcFileName}",
             };
         }
 
@@ -547,7 +531,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// </summary>
         /// <param name="ex">Exception from file header.</param>
         /// <param name="fileMetadata">The file metadata.</param>
-        private void HandleUploadFileErr(Exception ex, SFFileMetadata fileMetadata)
+        private static void HandleUploadFileErr(Exception ex, SFFileMetadata fileMetadata)
         {
             Logger.Error("Failed to upload file: " + ex.Message);
 
@@ -556,18 +540,18 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 case AmazonS3Exception exAws:
                     if (exAws.ErrorCode == EXPIRED_TOKEN)
                     {
-                        fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
+                        fileMetadata.resultStatus = nameof(ResultStatus.RENEW_TOKEN);
                     }
                     else
                     {
                         fileMetadata.lastError = exAws;
-                        fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
+                        fileMetadata.resultStatus = nameof(ResultStatus.NEED_RETRY);
                     }
                     break;
 
                 case Exception exOther:
                     fileMetadata.lastError = exOther;
-                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
+                    fileMetadata.resultStatus = nameof(ResultStatus.NEED_RETRY);
                     break;
             }
         }
@@ -577,27 +561,28 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// </summary>
         /// <param name="ex">Exception from file header.</param>
         /// <param name="fileMetadata">The file metadata.</param>
-        private void HandleDownloadFileErr(Exception ex, SFFileMetadata fileMetadata)
+        private static void HandleDownloadFileErr(Exception ex, SFFileMetadata fileMetadata)
         {
-            Logger.Error("Failed to download file: " + ex.Message);
+            Logger.Error($"Failed to download file: {ex.Message}");
 
             switch (ex)
             {
                 case AmazonS3Exception exAws:
-                    if (exAws.ErrorCode == EXPIRED_TOKEN)
+                    switch (exAws.ErrorCode)
                     {
-                        fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
-                    }
-                    else
-                    {
-                        fileMetadata.lastError = exAws;
-                        fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
+                        case EXPIRED_TOKEN:
+                            fileMetadata.resultStatus = nameof(ResultStatus.RENEW_TOKEN);
+                            break;
+                        default:
+                            fileMetadata.lastError = exAws;
+                            fileMetadata.resultStatus = nameof(ResultStatus.NEED_RETRY);
+                            break;
                     }
                     break;
 
-                case Exception exOther:
+                case { } exOther:
                     fileMetadata.lastError = exOther;
-                    fileMetadata.resultStatus = ResultStatus.NEED_RETRY.ToString();
+                    fileMetadata.resultStatus = nameof(ResultStatus.NEED_RETRY);
                     break;
             }
         }

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -198,7 +198,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             }
             catch (Exception ex)
             {
-                HandleFileHeaderErr(ex.InnerException, fileMetadata); // S3 places the AmazonS3Exception on the InnerException on non-async calls
+                HandleFileHeaderErr(ex, fileMetadata);
                 return null;
             }
         }

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime.Internal;
 using Snowflake.Data.Core.Tools;
 
 namespace Snowflake.Data.Core.FileTransfer.StorageClient
@@ -519,31 +520,26 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// </summary>
         /// <param name="ex">Exception from file header.</param>
         /// <param name="fileMetadata">The file metadata.</param>
-        private void HandleFileHeaderErr(Exception ex, SFFileMetadata fileMetadata)
+        private static void HandleFileHeaderErr(Exception ex, SFFileMetadata fileMetadata)
         {
-            Logger.Error("Failed to get file header: " + ex.Message);
+            Logger.Error($"Failed to get file header: {ex.Message}");
 
-            switch (ex)
+            fileMetadata.resultStatus = ex switch
             {
-                case AmazonS3Exception exAws:
-                    if (exAws.ErrorCode == EXPIRED_TOKEN || exAws.ErrorCode == HttpStatusCode.BadRequest.ToString())
-                    {
-                        fileMetadata.resultStatus = ResultStatus.RENEW_TOKEN.ToString();
-                    }
-                    else if (exAws.ErrorCode == NO_SUCH_KEY)
-                    {
-                        fileMetadata.resultStatus = ResultStatus.NOT_FOUND_FILE.ToString();
-                    }
-                    else
-                    {
-                        fileMetadata.resultStatus = ResultStatus.ERROR.ToString();
-                    }
-
-                    break;
-                default:
-                    fileMetadata.resultStatus = ResultStatus.ERROR.ToString();
-                    break;
-            }
+                AmazonS3Exception exAws => exAws.ErrorCode switch
+                {
+                    EXPIRED_TOKEN or nameof(HttpStatusCode.BadRequest) => nameof(ResultStatus.RENEW_TOKEN),
+                    NO_SUCH_KEY => nameof(ResultStatus.NOT_FOUND_FILE),
+                    _ => nameof(ResultStatus.ERROR)
+                },
+                HttpErrorResponseException exAws => exAws.Response?.StatusCode switch
+                {
+                    HttpStatusCode.BadRequest => nameof(ResultStatus.RENEW_TOKEN),
+                    HttpStatusCode.NotFound => nameof(ResultStatus.NOT_FOUND_FILE),
+                    _ => nameof(ResultStatus.ERROR)
+                },
+                _ => nameof(ResultStatus.ERROR)
+            };
         }
 
         /// <summary>

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -89,8 +89,8 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             Logger.Debug("Setting up a new AWS client ");
 
             // Get the key id and secret key from the response
-            stageInfo.stageCredentials.TryGetValue(AWS_KEY_ID, out string awsAccessKeyId);
-            stageInfo.stageCredentials.TryGetValue(AWS_SECRET_KEY, out string awsSecretAccessKey);
+            stageInfo.stageCredentials.TryGetValue(AWS_KEY_ID, out var awsAccessKeyId);
+            stageInfo.stageCredentials.TryGetValue(AWS_SECRET_KEY, out var awsSecretAccessKey);
 
             AmazonS3Config clientConfig;
 
@@ -116,7 +116,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 parallel);
 
             // Get the AWS token value and create the S3 client
-            if (stageInfo.stageCredentials.TryGetValue(AWS_TOKEN, out string awsSessionToken))
+            if (stageInfo.stageCredentials.TryGetValue(AWS_TOKEN, out var awsSessionToken))
             {
                 S3Client = new AmazonS3Client(
                     awsAccessKeyId,
@@ -154,8 +154,8 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             //    stageLocation = Path.GetFullPath(stageLocation);
             //}
 
-            string bucketName = stageLocation;
-            string s3path = "";
+            var bucketName = stageLocation;
+            var s3path = "";
 
             // Split stage location as bucket name and path
             if (stageLocation.Contains("/"))
@@ -184,23 +184,16 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <returns>The file header of the S3 file.</returns>
         public FileHeader GetFileHeader(SFFileMetadata fileMetadata)
         {
-            // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
 
-            GetObjectRequest request = GetFileHeaderRequest(ref client, fileMetadata);
+            var request = GetFileHeaderRequest(fileMetadata);
 
             try
             {
-                // Issue the GET request
-                var task = client.GetObjectAsync(request);
-                task.ConfigureAwait(false);
-                task.Wait();
-
-                using (GetObjectResponse response = task.Result)
-                {
-                    return HandleFileHeaderResponse(ref fileMetadata, response);
-                }
+                var taskAwaiter = client.GetObjectMetadataAsync(request).GetAwaiter();
+                var response = taskAwaiter.GetResult();
+                return HandleFileHeaderResponse(ref fileMetadata, response);
             }
             catch (Exception ex)
             {
@@ -217,25 +210,21 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <returns>The file header of the S3 file.</returns>
         public async Task<FileHeader> GetFileHeaderAsync(SFFileMetadata fileMetadata, CancellationToken cancellationToken)
         {
-            // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
 
-            GetObjectRequest request = GetFileHeaderRequest(ref client, fileMetadata);
+            var request = GetFileHeaderRequest(fileMetadata);
 
-            GetObjectResponse response = null;
             try
             {
-                // Issue the GET request
-                response = await client.GetObjectAsync(request, cancellationToken).ConfigureAwait(false);
+                var response = await client.GetObjectMetadataAsync(request, cancellationToken).ConfigureAwait(false);
+                return HandleFileHeaderResponse(ref fileMetadata, response);
             }
             catch (Exception ex)
             {
                 HandleFileHeaderErr(ex, fileMetadata); // S3 throws the AmazonS3Exception on async calls
                 return null;
             }
-
-            return HandleFileHeaderResponse(ref fileMetadata, response);
         }
 
         /// <summary>
@@ -244,16 +233,16 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <param name="client">The Amazon S3 client.</param>
         /// <param name="fileMetadata">The S3 file metadata.</param>
         /// <returns>The file header request.</returns>
-        private GetObjectRequest GetFileHeaderRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata)
+        private GetObjectMetadataRequest GetFileHeaderRequest(SFFileMetadata fileMetadata)
         {
-            PutGetStageInfo stageInfo = fileMetadata.stageInfo;
-            RemoteLocation location = ExtractBucketNameAndPath(stageInfo.location);
+            var stageInfo = fileMetadata.stageInfo;
+            var location = ExtractBucketNameAndPath(stageInfo.location);
 
             // Create the S3 request object
-            GetObjectRequest request = new GetObjectRequest
+            var request = new GetObjectMetadataRequest
             {
                 BucketName = location.bucket,
-                Key = location.key + fileMetadata.RemoteFileName()
+                Key = $"{location.key}{fileMetadata.RemoteFileName()}"
             };
             return request;
         }
@@ -264,12 +253,12 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <param name="fileMetadata">The S3 file metadata.</param>
         /// <param name="response">The Amazon S3 response.</param>
         /// <returns>The file header of the S3 file.</returns>
-        internal FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, GetObjectResponse response)
+        internal FileHeader HandleFileHeaderResponse(ref SFFileMetadata fileMetadata, GetObjectMetadataResponse response)
         {
             // Update the result status of the file metadata
-            fileMetadata.resultStatus = ResultStatus.UPLOADED.ToString();
+            fileMetadata.resultStatus = nameof(ResultStatus.UPLOADED);
 
-            SFEncryptionMetadata encryptionMetadata = new SFEncryptionMetadata
+            var encryptionMetadata = new SFEncryptionMetadata
             {
                 iv = GetMetadataCaseInsensitive(response.Metadata, AMZ_IV),
                 key = GetMetadataCaseInsensitive(response.Metadata, AMZ_KEY),
@@ -314,7 +303,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             clientConfig.USEast1RegionalEndpointValue = S3UsEast1RegionalEndpointValue.Regional;
             if ((null != region) && (0 != region.Length))
             {
-                RegionEndpoint regionEndpoint = RegionEndpoint.GetBySystemName(region);
+                var regionEndpoint = RegionEndpoint.GetBySystemName(region);
                 clientConfig.RegionEndpoint = regionEndpoint;
             }
 
@@ -340,7 +329,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
             // If both stageInfo.endPoint and stageInfo.region have a value, the endPoint takes precedence
             else if ((null != region) && (0 != region.Length))
             {
-                RegionEndpoint regionEndpoint = RegionEndpoint.GetBySystemName(region);
+                var regionEndpoint = RegionEndpoint.GetBySystemName(region);
                 clientConfig.RegionEndpoint = regionEndpoint;
             }
 
@@ -358,9 +347,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public void UploadFile(SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata)
         {
             // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
-            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
+            var putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
 
             try
             {
@@ -388,9 +377,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public async Task UploadFileAsync(SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata, CancellationToken cancellationToken)
         {
             // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
-            PutObjectRequest putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
+            var putObjectRequest = GetPutObjectRequest(ref client, fileMetadata, fileBytesStream, encryptionMetadata);
 
             try
             {
@@ -417,12 +406,12 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         /// <returns>The Put Object request.</returns>
         private PutObjectRequest GetPutObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata, Stream fileBytesStream, SFEncryptionMetadata encryptionMetadata)
         {
-            PutGetStageInfo stageInfo = fileMetadata.stageInfo;
-            RemoteLocation location = ExtractBucketNameAndPath(stageInfo.location);
+            var stageInfo = fileMetadata.stageInfo;
+            var location = ExtractBucketNameAndPath(stageInfo.location);
 
             // Create S3 PUT request
             fileBytesStream.Position = 0;
-            PutObjectRequest putObjectRequest = new PutObjectRequest
+            var putObjectRequest = new PutObjectRequest
             {
                 BucketName = location.bucket,
                 Key = location.key + fileMetadata.destFileName,
@@ -450,9 +439,9 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public void DownloadFile(SFFileMetadata fileMetadata, string fullDstPath, int maxConcurrency)
         {
             // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
-            GetObjectRequest getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
+            var getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
 
             try
             {
@@ -461,7 +450,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 task.ConfigureAwait(false);
                 task.Wait();
 
-                using (GetObjectResponse response = task.Result)
+                using (var response = task.Result)
                 {
                     // Write to file
                     using (var fileStream = FileOperations.Instance.Create(fullDstPath))
@@ -488,14 +477,14 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
         public async Task DownloadFileAsync(SFFileMetadata fileMetadata, string fullDstPath, int maxConcurrency, CancellationToken cancellationToken)
         {
             // Get the client
-            SFS3Client SFS3Client = (SFS3Client)fileMetadata.client;
-            AmazonS3Client client = SFS3Client.S3Client;
-            GetObjectRequest getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
+            var SFS3Client = (SFS3Client)fileMetadata.client;
+            var client = SFS3Client.S3Client;
+            var getObjectRequest = GetGetObjectRequest(ref client, fileMetadata);
 
             try
             {
                 // Issue the GET request
-                using (GetObjectResponse response = await client.GetObjectAsync(getObjectRequest, cancellationToken).ConfigureAwait(false))
+                using (var response = await client.GetObjectAsync(getObjectRequest, cancellationToken).ConfigureAwait(false))
 
                 // Write to file
                 using (var fileStream = FileOperations.Instance.Create(fullDstPath))
@@ -514,8 +503,8 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
 
         private GetObjectRequest GetGetObjectRequest(ref AmazonS3Client client, SFFileMetadata fileMetadata)
         {
-            PutGetStageInfo stageInfo = fileMetadata.stageInfo;
-            RemoteLocation location = ExtractBucketNameAndPath(stageInfo.location);
+            var stageInfo = fileMetadata.stageInfo;
+            var location = ExtractBucketNameAndPath(stageInfo.location);
 
             // Create S3 GET request
             return new GetObjectRequest

--- a/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
+++ b/Snowflake.Data/Core/FileTransfer/StorageClient/SFS3Client.cs
@@ -513,13 +513,7 @@ namespace Snowflake.Data.Core.FileTransfer.StorageClient
                 AmazonS3Exception exAws => exAws.ErrorCode switch
                 {
                     EXPIRED_TOKEN or nameof(HttpStatusCode.BadRequest) => nameof(ResultStatus.RENEW_TOKEN),
-                    NO_SUCH_KEY => nameof(ResultStatus.NOT_FOUND_FILE),
-                    _ => nameof(ResultStatus.ERROR)
-                },
-                HttpErrorResponseException exAws => exAws.Response?.StatusCode switch
-                {
-                    HttpStatusCode.BadRequest => nameof(ResultStatus.RENEW_TOKEN),
-                    HttpStatusCode.NotFound => nameof(ResultStatus.NOT_FOUND_FILE),
+                    NO_SUCH_KEY or nameof(HttpStatusCode.NotFound) => nameof(ResultStatus.NOT_FOUND_FILE),
                     _ => nameof(ResultStatus.ERROR)
                 },
                 _ => nameof(ResultStatus.ERROR)

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net481;net8.0;net8.0-windows;net9.0;net9.0-windows;net10.0;net10.0-windows</TargetFrameworks>
     <Title>Snowflake.Data</Title>
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.Arrow" Version="14.0.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.20.4" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.100.3" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Azure.Storage.Common" Version="12.12.0" />


### PR DESCRIPTION
### Description
re change: Switches from GetObjectAsync (HTTP GET — downloads full object body) to GetObjectMetadataAsync (HTTP
  HEAD — retrieves only headers) when checking file metadata on S3. You only need the
  metadata headers (encryption IV, key, matdesc, digest), not the file content.

  Changes summary:
  1. GetObjectRequest → GetObjectMetadataRequest
  2. GetObjectResponse → GetObjectMetadataResponse
  3. Removed using block around response (HEAD response has no body stream to dispose)
  4. Fixed sync path: replaced task.Wait() + task.Result pattern with GetAwaiter().GetResult() (avoids wrapping
  exceptions in AggregateException)
  5. Removed unused ref AmazonS3Client client parameter from GetFileHeaderRequest
  6. Cosmetic: var usage, string interpolation, nameof() instead of .ToString()

  ---
  AWSSDK.S3 Upgrade: 4.0.20.4 → 4.0.100.3

  The upgrade is safe. No breaking changes in the S3 API surface being used.

  Between 4.0.20.4 and 4.0.100.3, the changelog shows:
  - 4.0.25.1 — fix for PutObject with non-seekable zero-length streams
  - 4.0.25.0 — new annotation APIs (additive), PooledContentStream perf optimization
  - 4.0.24.0 — new BDD endpoint ruleset representation
  - 4.0.23.6 — fix for UploadPart with unseekable streams

  None of these touch GetObjectMetadataAsync, GetObjectMetadataResponse, MetadataCollection, PutObjectAsync, or GetObjectAsync in breaking ways. 

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
