### PR TITLE
SNOW-3784414: fix token cache key — v2 canonical-JSON SHA256 key with PascalCase prefix and lowercase normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 # Changelog
 - v5.9.0
     - Fixed token cache key collisions for multi-account (shared IdP) and multi-role
-      scenarios by switching to a versioned, SHA256-hashed canonical-JSON key applied
-      uniformly across Windows Credential Manager and file backends.
+      scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the
+      token type in the key prefix, applied uniformly across Windows Credential Manager
+      and file backends.
 - v5.8.0
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
       scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the
       token type in the key prefix, applied uniformly across Windows Credential Manager
       and file backends.
+    - Fixed token cache key normalization to use lowercase for consistency with
+      case-insensitive Snowflake identifiers; token type in the key prefix now uses
+      PascalCase (`MfaToken`, `OauthAccessToken`) instead of `SCREAMING_SNAKE_CASE`.
 - v5.8.0
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 #### For the official .NET Release Notes please refer to https://docs.snowflake.com/en/release-notes/clients-drivers/dotnet
 
 # Changelog
+- v5.9.0
+    - Fixed token cache key collisions for multi-account (shared IdP) and multi-role
+      scenarios by switching to a versioned, SHA256-hashed canonical-JSON key applied
+      uniformly across Windows Credential Manager and file backends.
 - v5.8.0
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
   - Added configurable timeouts for chunk download stream reads. `SF_CHUNK_DOWNLOAD_IDLE_TIMEOUT` (default 180s) detects stalled connections between reads; `SF_CHUNK_DOWNLOAD_READ_TIMEOUT` (default disabled) sets a per-read deadline. Both are configured in seconds; set to `0` to disable.
   - Bug fix: Token cache file on Linux/macOS is now written as UTF-8 without a BOM for cross-driver compatibility.
   - Fixed token cache key collisions for multi-account (shared IdP) and multi-role
-    scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the
-    token type in the key prefix, applied uniformly across Windows Credential Manager
-    and file backends.
-  - Fixed token cache key normalization to use lowercase for consistency with
-    case-insensitive Snowflake identifiers; token type in the key prefix now uses
+    scenarios by switching to a versioned, SHA256-hashed canonical-JSON key
+    (`SnowflakeTokenCache.v2.<PascalCaseType>.<sha256>`) with flow-specific
+    `keyData` fields, applied uniformly across Windows Credential Manager and file
+    backends. Identifiers are normalised to lowercase; quoted values (including SQL
+    `""` escaped quotes) are returned verbatim. Token type in the key prefix uses
     PascalCase (`MfaToken`, `OauthAccessToken`) instead of `SCREAMING_SNAKE_CASE`.
 - v6.0.0
   -  Added `CancellationToken` support to chunk download and parsing pipeline. Query result fetching now respects cancellation during both JSON and Arrow chunk parsing.

--- a/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Data;
 using Xunit;
 using Snowflake.Data.Client;
+using Snowflake.Data.Core;
 using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Log;
 
@@ -204,9 +205,15 @@ namespace Snowflake.Data.AuthenticationTests
             }
         }
 
-        internal void RemoveTokenFromCache(string tokenHost, string user, TokenType tokenType)
+        internal void RemoveTokenFromCache(string idpUrl, string snowflakeHost, string user, string role, TokenType tokenType)
         {
-            var cacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(tokenHost, user, tokenType);
+            var cacheKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: tokenType.GetAttribute<StringAttr>().value,
+                idp: idpUrl,
+                snowflake: snowflakeHost,
+                username: user,
+                role: role ?? string.Empty
+            ));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(cacheKey);
         }
 

--- a/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
@@ -208,11 +208,11 @@ namespace Snowflake.Data.AuthenticationTests
         internal void RemoveTokenFromCache(string idpUrl, string snowflakeHost, string user, string role, TokenType tokenType)
         {
             var cacheKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: tokenType.GetAttribute<StringAttr>().value,
-                idp: idpUrl,
-                snowflake: snowflakeHost,
-                username: user,
-                role: role ?? string.Empty
+                TokenType: tokenType.GetAttribute<StringAttr>().value,
+                Idp: idpUrl,
+                SnowflakeUrl: snowflakeHost,
+                Username: user,
+                Role: role ?? string.Empty
             ));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(cacheKey);
         }

--- a/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/AuthTestHelper.cs
@@ -208,7 +208,7 @@ namespace Snowflake.Data.AuthenticationTests
         internal void RemoveTokenFromCache(string idpUrl, string snowflakeHost, string user, string role, TokenType tokenType)
         {
             var cacheKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                TokenType: tokenType.GetAttribute<StringAttr>().value,
+                TokenType: tokenType.ToCacheKeyPrefix(),
                 Idp: idpUrl,
                 SnowflakeUrl: snowflakeHost,
                 Username: user,

--- a/Snowflake.Data.Tests/AuthenticationTests/MfaTest.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/MfaTest.cs
@@ -30,7 +30,8 @@ namespace Snowflake.Data.AuthenticationTests
             cacheTestHelper.ConnectAndExecuteSimpleQuery(connectionString);
             cacheTestHelper.VerifyExceptionIsNotThrown();
 
-            authTestHelper.RemoveTokenFromCache(parameters[SFSessionProperty.HOST], parameters[SFSessionProperty.USER], TokenType.MFAToken);
+            var mfaHost = parameters[SFSessionProperty.HOST];
+            authTestHelper.RemoveTokenFromCache(mfaHost, mfaHost, parameters[SFSessionProperty.USER], string.Empty, TokenType.MFAToken);
         }
     }
 }

--- a/Snowflake.Data.Tests/AuthenticationTests/OktaAuthorizationCodeTest.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/OktaAuthorizationCodeTest.cs
@@ -94,6 +94,8 @@ namespace Snowflake.Data.AuthenticationTests
             parameters.Add(SFSessionProperty.POOLINGENABLED, "false");
             parameters[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL] = "true";
             var host = parameters[SFSessionProperty.HOST];
+            var idpUrl = parameters.TryGetValue(SFSessionProperty.OAUTHTOKENREQUESTURL, out var tokenUrl) ? tokenUrl : string.Empty;
+            var role = parameters.TryGetValue(SFSessionProperty.ROLE, out var roleVal) ? roleVal : string.Empty;
 
             _connectionString = AuthConnectionString.ConvertToConnectionString(parameters);
             Thread connectThread = authTestHelper.GetConnectAndExecuteSimpleQueryThread(_connectionString);
@@ -111,8 +113,8 @@ namespace Snowflake.Data.AuthenticationTests
             }
             finally
             {
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthAccessToken);
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthRefreshToken);
+                authTestHelper.RemoveTokenFromCache(idpUrl, host, _login, role, TokenType.OAuthAccessToken);
+                authTestHelper.RemoveTokenFromCache(idpUrl, host, _login, role, TokenType.OAuthRefreshToken);
             }
         }
     }

--- a/Snowflake.Data.Tests/AuthenticationTests/SnowflakeAuthorizationCodeTest.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/SnowflakeAuthorizationCodeTest.cs
@@ -96,6 +96,10 @@ namespace Snowflake.Data.AuthenticationTests
             parameters[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL] = "true";
             _connectionString = AuthConnectionString.ConvertToConnectionString(parameters);
             var host = parameters[SFSessionProperty.HOST];
+            var port = parameters[SFSessionProperty.PORT];
+            var scheme = parameters.TryGetValue(SFSessionProperty.SCHEME, out var schemeVal) ? schemeVal : "https";
+            var role = parameters.TryGetValue(SFSessionProperty.ROLE, out var roleVal) ? roleVal : string.Empty;
+            var tokenEndpoint = $"{scheme}://{host}:{port}/oauth/token-request";
             Thread connectThread = authTestHelper.GetConnectAndExecuteSimpleQueryThread(_connectionString);
             Thread provideCredentialsThread = authTestHelper.GetProvideCredentialsThread("internalOauthSnowflakeSuccess", _login, _password);
 
@@ -111,8 +115,8 @@ namespace Snowflake.Data.AuthenticationTests
             }
             finally
             {
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthAccessToken);
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthRefreshToken);
+                authTestHelper.RemoveTokenFromCache(tokenEndpoint, host, _login, role, TokenType.OAuthAccessToken);
+                authTestHelper.RemoveTokenFromCache(tokenEndpoint, host, _login, role, TokenType.OAuthRefreshToken);
             }
         }
 

--- a/Snowflake.Data.Tests/AuthenticationTests/SnowflakeAuthorizationCodeWilidcardsTest.cs
+++ b/Snowflake.Data.Tests/AuthenticationTests/SnowflakeAuthorizationCodeWilidcardsTest.cs
@@ -95,6 +95,10 @@ namespace Snowflake.Data.AuthenticationTests
             parameters.Add(SFSessionProperty.POOLINGENABLED, "false");
             parameters[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL] = "true";
             var host = parameters[SFSessionProperty.HOST];
+            var port = parameters[SFSessionProperty.PORT];
+            var scheme = parameters.TryGetValue(SFSessionProperty.SCHEME, out var schemeVal) ? schemeVal : "https";
+            var role = parameters.TryGetValue(SFSessionProperty.ROLE, out var roleVal) ? roleVal : string.Empty;
+            var tokenEndpoint = $"{scheme}://{host}:{port}/oauth/token-request";
             _connectionString = AuthConnectionString.ConvertToConnectionString(parameters);
 
             Thread connectThread = authTestHelper.GetConnectAndExecuteSimpleQueryThread(_connectionString);
@@ -111,8 +115,8 @@ namespace Snowflake.Data.AuthenticationTests
             }
             finally
             {
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthAccessToken);
-                authTestHelper.RemoveTokenFromCache(host, _login, TokenType.OAuthRefreshToken);
+                authTestHelper.RemoveTokenFromCache(tokenEndpoint, host, _login, role, TokenType.OAuthAccessToken);
+                authTestHelper.RemoveTokenFromCache(tokenEndpoint, host, _login, role, TokenType.OAuthRefreshToken);
             }
         }
     }

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -334,10 +334,10 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
     private void RemoveOAuthCache(TestConfig testConfig)
     {
-        var idpUrl = _fixture.testConfig.oauthTokenRequestUrl;
-        var snowflakeHost = _fixture.testConfig.host;
-        var user = _fixture.testConfig.user;
-        var role = _fixture.testConfig.role ?? string.Empty;
+        var idpUrl = testConfig.oauthTokenRequestUrl;
+        var snowflakeHost = testConfig.host;
+        var user = testConfig.user;
+        var role = testConfig.role ?? string.Empty;
         var credentialManager = SnowflakeCredentialManagerFactory.GetCredentialManager();
         credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
             tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -334,12 +334,25 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
     private void RemoveOAuthCache(TestConfig testConfig)
     {
-        var host = new Uri(_fixture.testConfig.oauthTokenRequestUrl).Host;
-        var accessCacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, _fixture.testConfig.user, TokenType.OAuthAccessToken);
-        var refreshCacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, _fixture.testConfig.user, TokenType.OAuthRefreshToken);
+        var idpUrl = _fixture.testConfig.oauthTokenRequestUrl;
+        var snowflakeHost = _fixture.testConfig.host;
+        var user = _fixture.testConfig.user;
+        var role = _fixture.testConfig.role ?? string.Empty;
         var credentialManager = SnowflakeCredentialManagerFactory.GetCredentialManager();
-        credentialManager.RemoveCredentials(accessCacheKey);
-        credentialManager.RemoveCredentials(refreshCacheKey);
+        credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+            tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+            idp: idpUrl,
+            snowflake: snowflakeHost,
+            username: user,
+            role: role
+        )));
+        credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+            tokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+            idp: idpUrl,
+            snowflake: snowflakeHost,
+            username: user,
+            role: role
+        )));
     }
 
     private string ConnectionStringForOAuthFlows(TestConfig testConfig, string authenticator)
@@ -413,7 +426,13 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
                   + $";authenticator=externalbrowser;user={_fixture.testConfig.user};CLIENT_STORE_TEMPORARY_CREDENTIAL=true;";
 
             // Create a credential manager and save a wrong token for the test user
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(_fixture.testConfig.host, _fixture.testConfig.user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                idp: _fixture.testConfig.host,
+                snowflake: _fixture.testConfig.host,
+                username: _fixture.testConfig.user,
+                role: string.Empty
+            ));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "wrongToken");
 

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -340,14 +340,14 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         var role = testConfig.role ?? string.Empty;
         var credentialManager = SnowflakeCredentialManagerFactory.GetCredentialManager();
         credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-            TokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+            TokenType: TokenType.OAuthAccessToken.ToCacheKeyPrefix(),
             Idp: idpUrl,
             SnowflakeUrl: snowflakeHost,
             Username: user,
             Role: role
         )));
         credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-            TokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+            TokenType: TokenType.OAuthRefreshToken.ToCacheKeyPrefix(),
             Idp: idpUrl,
             SnowflakeUrl: snowflakeHost,
             Username: user,
@@ -427,7 +427,7 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
             // Create a credential manager and save a wrong token for the test user
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                TokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                TokenType: TokenType.IdToken.ToCacheKeyPrefix(),
                 Idp: _fixture.testConfig.host,
                 SnowflakeUrl: _fixture.testConfig.host,
                 Username: _fixture.testConfig.user,

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionManualIT.cs
@@ -340,18 +340,18 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
         var role = testConfig.role ?? string.Empty;
         var credentialManager = SnowflakeCredentialManagerFactory.GetCredentialManager();
         credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-            tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
-            idp: idpUrl,
-            snowflake: snowflakeHost,
-            username: user,
-            role: role
+            TokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+            Idp: idpUrl,
+            SnowflakeUrl: snowflakeHost,
+            Username: user,
+            Role: role
         )));
         credentialManager.RemoveCredentials(SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-            tokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
-            idp: idpUrl,
-            snowflake: snowflakeHost,
-            username: user,
-            role: role
+            TokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+            Idp: idpUrl,
+            SnowflakeUrl: snowflakeHost,
+            Username: user,
+            Role: role
         )));
     }
 
@@ -427,11 +427,11 @@ public sealed class SFConnectionManualIT : SFBaseTestAsync
 
             // Create a credential manager and save a wrong token for the test user
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
-                idp: _fixture.testConfig.host,
-                snowflake: _fixture.testConfig.host,
-                username: _fixture.testConfig.user,
-                role: string.Empty
+                TokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                Idp: _fixture.testConfig.host,
+                SnowflakeUrl: _fixture.testConfig.host,
+                Username: _fixture.testConfig.user,
+                Role: string.Empty
             ));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "wrongToken");

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
@@ -27,7 +27,8 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         protected const string SessionId = "1234567890";
         protected const string User = "testUser";
         protected const string AuthorizationScope = "session:role:ANALYST";
-        protected const string TokenHost = "localhost";
+        protected const string Role = "ANALYST";
+        protected const string SnowflakeHost = "localhost";
         protected const string ClientSecret = "123";
 
         internal void AssertSessionSuccessfullyCreated(SFSession session)
@@ -45,20 +46,29 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
 
         internal string ExtractTokenFromCache(TokenType tokenType)
         {
-            var cacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(TokenHost, User, tokenType);
+            var cacheKey = BuildOAuthCacheKey(tokenType);
             return SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(cacheKey);
         }
 
         internal void SaveTokenToCache(TokenType tokenType, string token)
         {
-            var cacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(TokenHost, User, tokenType);
+            var cacheKey = BuildOAuthCacheKey(tokenType);
             SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(cacheKey, token);
         }
 
         internal void RemoveTokenFromCache(TokenType tokenType)
         {
-            var cacheKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(TokenHost, User, tokenType);
+            var cacheKey = BuildOAuthCacheKey(tokenType);
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(cacheKey);
         }
+
+        private string BuildOAuthCacheKey(TokenType tokenType) =>
+            SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: tokenType.GetAttribute<StringAttr>().value,
+                idp: s_externalTokenRequestUrl,
+                snowflake: SnowflakeHost,
+                username: User,
+                role: Role
+            ));
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
@@ -28,7 +28,9 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         protected const string User = "testUser";
         protected const string AuthorizationScope = "session:role:ANALYST";
         protected const string Role = "ANALYST";
-        protected const string SnowflakeHost = "localhost";
+        // Must mirror the `host` set in the flow's connection string (WiremockRunner.Host), because the
+        // v2 cache key's `snowflake` dimension is taken from the HOST session property, not the IdP URL.
+        protected const string SnowflakeHost = WiremockRunner.Host;
         protected const string ClientSecret = "123";
 
         internal void AssertSessionSuccessfullyCreated(SFSession session)

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
@@ -66,11 +66,11 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
 
         private string BuildOAuthCacheKey(TokenType tokenType) =>
             SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: tokenType.GetAttribute<StringAttr>().value,
-                idp: s_externalTokenRequestUrl,
-                snowflake: SnowflakeHost,
-                username: User,
-                role: Role
+                TokenType: tokenType.GetAttribute<StringAttr>().value,
+                Idp: s_externalTokenRequestUrl,
+                SnowflakeUrl: SnowflakeHost,
+                Username: User,
+                Role: Role
             ));
     }
 }

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/BaseOAuthFlowTest.cs
@@ -66,7 +66,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
 
         private string BuildOAuthCacheKey(TokenType tokenType) =>
             SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                TokenType: tokenType.GetAttribute<StringAttr>().value,
+                TokenType: tokenType.ToCacheKeyPrefix(),
                 Idp: s_externalTokenRequestUrl,
                 SnowflakeUrl: SnowflakeHost,
                 Username: User,

--- a/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthCacheKeysTests.cs
+++ b/Snowflake.Data.Tests/UnitTests/Authenticator/OAuthCacheKeysTests.cs
@@ -21,8 +21,10 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         public void TestCacheAvailableForAuthorizationCodeFlow(string user, bool clientStoreTemporaryCredentials, bool expectedIsAvailable)
         {
             // arrange
-            var host = "snowflakecomputing.com";
-            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow(host, user, clientStoreTemporaryCredentials, SnowflakeCredentialManagerFactory.GetCredentialManager);
+            var idpUrl = "https://idp.snowflakecomputing.com/oauth/token";
+            var snowflakeHost = "snowflakecomputing.com";
+            var role = "PUBLIC";
+            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow(idpUrl, snowflakeHost, user, role, clientStoreTemporaryCredentials, SnowflakeCredentialManagerFactory.GetCredentialManager);
 
             // act
             var isAvailable = cacheKeys.IsAvailable();
@@ -49,7 +51,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         {
             // arrange
             var credentialManager = new Mock<ISnowflakeCredentialManager>();
-            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow(null, null, false, () => credentialManager.Object);
+            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow(null, null, null, null, false, () => credentialManager.Object);
 
             // act
             cacheKeys.GetAccessToken();
@@ -84,7 +86,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         {
             // arrange
             var credentialManager = new SFCredentialManagerInMemoryImpl();
-            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow("snowflakecomputing.com", "testUser", true, () => credentialManager);
+            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow("https://idp.snowflakecomputing.com/oauth/token", "snowflakecomputing.com", "testUser", "PUBLIC", true, () => credentialManager);
 
             // act/assert
             Assert.True(cacheKeys.IsAvailable());
@@ -100,7 +102,7 @@ namespace Snowflake.Data.Tests.UnitTests.Authenticator
         {
             // arrange
             var credentialManager = new SFCredentialManagerInMemoryImpl();
-            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow("snowflakecomputing.com", "testUser", true, () => credentialManager);
+            var cacheKeys = OAuthCacheKeys.CreateForAuthorizationCodeFlow("https://idp.snowflakecomputing.com/oauth/token", "snowflakecomputing.com", "testUser", "PUBLIC", true, () => credentialManager);
 
             // act/assert
             Assert.True(cacheKeys.IsAvailable());

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -9,6 +9,141 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
 {
     public class SnowflakeCredentialManagerFactoryTest : IDisposable
     {
+        [SFFact]
+        public void TestBuildCacheKeyGoldenHash()
+        {
+            // quoted segments are preserved verbatim by NormalizeIdentifier — pre-uppercase them to match
+            // the canonical JSON: {"idp":"LOGIN...","role":"\"ANALYST ROLE WITH SPACES\":...","username":"\"FIRST LAST\"@..."}
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
+                idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
+                snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+                username: "\"FIRST LAST\"@long-corporate-domain.example.com",
+                role: "\"ANALYST ROLE WITH SPACES\":north_america:prod:readonly"
+            ));
+            Assert.Equal("SnowflakeTokenCache.v2.75ff2ad65a68afb402f125f62894697673c5ef3d863aba466d16b7a81053d1f4", key);
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyHasCorrectPrefix()
+        {
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            Assert.StartsWith("SnowflakeTokenCache.v2.", key);
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyHashIsLowercaseHex()
+        {
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            var hash = key.Substring("SnowflakeTokenCache.v2.".Length);
+            Assert.Equal(64, hash.Length);
+            Assert.Equal(hash, hash.ToLowerInvariant());
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyThrowsWhenSnowflakeEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "", "user", "")));
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyThrowsWhenUsernameEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "snowflake", "", "")));
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationDifferentSnowflakeHost()
+        {
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct2.snowflakecomputing.com", "user", "role"));
+            Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationDifferentRole()
+        {
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ANALYST"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ENGINEER"));
+            Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationMfaEmptyRoleIsStable()
+        {
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            Assert.Equal(key1, key2);
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationDifferentTokenType()
+        {
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_REFRESH_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlStripsScheme()
+        {
+            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://example.com/path"));
+            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("http://example.com/path"));
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlStripsUserinfo()
+        {
+            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlDropsQueryAndFragment()
+        {
+            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlTrimsRootOnlyTrailingSlash()
+        {
+            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/"));
+            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path"));
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlPreservesPortAndPath()
+        {
+            Assert.Equal("LOGIN.MICROSOFTONLINE.COM:443/TENANT-ID/OAUTH2/V2.0",
+                SnowflakeCredentialManagerFactory.NormalizeUrl("https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0"));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierUnquotedIsUppercased()
+        {
+            Assert.Equal("USER@DOMAIN.COM", SnowflakeCredentialManagerFactory.NormalizeIdentifier("user@domain.com"));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierQuotedSegmentPreservedVerbatim()
+        {
+            Assert.Equal("\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM",
+                SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"First Last\"@long-corporate-domain.example.com"));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierMixedQuotedAndUnquoted()
+        {
+            Assert.Equal("\"Analyst Role With Spaces\":NORTH_AMERICA:PROD:READONLY",
+                SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Analyst Role With Spaces\":north_america:prod:readonly"));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierEmptyReturnsEmpty()
+        {
+            Assert.Equal(string.Empty, SnowflakeCredentialManagerFactory.NormalizeIdentifier(string.Empty));
+        }
+
+
         private void TearDown()
         {
             SnowflakeCredentialManagerFactory.UseDefaultCredentialManager();

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -10,31 +10,48 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
     public class SnowflakeCredentialManagerFactoryTest : IDisposable
     {
         [SFFact]
-        public void TestBuildCacheKeyGoldenHash()
+        public void TestBuildCacheKeyGoldenHashA_OAuth()
         {
-            // quoted segments are preserved verbatim by NormalizeIdentifier — pre-uppercase them to match the expected hash
+            // Vector A: OAuth flow — 4-field keyData, mixed-case quoted segments preserved verbatim.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                 tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
                 idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
-                username: "\"FIRST LAST\"@long-corporate-domain.example.com",
-                role: "\"ANALYST ROLE WITH SPACES\":north_america:prod:readonly"
+                username: "\"First Last\"@long-corporate-domain.example.com",
+                role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.75ff2ad65a68afb402f125f62894697673c5ef3d863aba466d16b7a81053d1f4", key);
+            Assert.Equal("SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f", key);
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyGoldenHashB_Mfa()
+        {
+            // Vector B: MFA flow — 2-field keyData (snowflake + username only), mixed-case quoted segment preserved.
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: "MFA_TOKEN",
+                idp: "",
+                snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+                username: "\"First Last\"@long-corporate-domain.example.com",
+                role: ""
+            ));
+            Assert.Equal("SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHasCorrectPrefix()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            Assert.StartsWith("SnowflakeTokenCache.v2.", key);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            Assert.StartsWith("SnowflakeTokenCache.v2.MFA_TOKEN.", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHashIsLowercaseHex()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            var hash = key.Substring("SnowflakeTokenCache.v2.".Length);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var segments = key.Split('.');
+            // Format: SnowflakeTokenCache.v2.<TOKEN_TYPE>.<hash>
+            Assert.Equal(4, segments.Length);
+            var hash = segments[3];
             Assert.Equal(64, hash.Length);
             Assert.Equal(hash, hash.ToLowerInvariant());
         }
@@ -42,19 +59,24 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenSnowflakeEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "", "user", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "", "user", "")));
         }
 
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenUsernameEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "snowflake", "", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "", "")));
         }
 
         [SFFact]
-        public void TestBuildCacheKeyThrowsWhenIdpEmpty()
+        public void TestDimensionIsolationMfaVsOAuth()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "user", "")));
+            // MFA and OAuth for the same user/host must produce different keys (different prefix + field set).
+            var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                "MFA_TOKEN", "", "acct.snowflakecomputing.com", "user", ""));
+            var oauthKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                "OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
+            Assert.NotEqual(mfaKey, oauthKey);
         }
 
         [SFFact]
@@ -85,8 +107,8 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyIsDeterministic()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
             Assert.Equal(key1, key2);
         }
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -52,6 +52,12 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         }
 
         [SFFact]
+        public void TestBuildCacheKeyThrowsWhenIdpEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "user", "")));
+        }
+
+        [SFFact]
         public void TestDimensionIsolationDifferentSnowflakeHost()
         {
             var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
@@ -68,7 +74,16 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         }
 
         [SFFact]
-        public void TestDimensionIsolationMfaEmptyRoleIsStable()
+        public void TestDimensionIsolationDifferentIdp()
+        {
+            // Same Snowflake account and user, different IdP — the multi-account/shared-IdP collision case.
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantA", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantB", "acct.snowflakecomputing.com", "user", "role"));
+            Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyIsDeterministic()
         {
             var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
             var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
@@ -94,12 +109,23 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         public void TestNormalizeUrlStripsUserinfo()
         {
             Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
+            Assert.Equal("HOST.EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.example.com/path"));
+        }
+
+        [SFFact]
+        public void TestNormalizeUrlPreservesAtSignInPath()
+        {
+            // An '@' after the authority is part of the path and must survive; only userinfo is stripped.
+            Assert.Equal("HOST.EXAMPLE.COM/OAUTH/@HANDLE/TOKEN",
+                SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.example.com/oauth/@handle/token"));
         }
 
         [SFFact]
         public void TestNormalizeUrlDropsQueryAndFragment()
         {
             Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
+            // An '@' inside the dropped query string must not be mistaken for userinfo.
+            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?email=user@domain.com"));
         }
 
         [SFFact]
@@ -140,6 +166,21 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         public void TestNormalizeIdentifierEmptyReturnsEmpty()
         {
             Assert.Equal(string.Empty, SnowflakeCredentialManagerFactory.NormalizeIdentifier(string.Empty));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierUppercasesAsciiOnly()
+        {
+            // Matches the reference's ASCII-only case-folding: non-ASCII letters are left unchanged
+            // so keys stay byte-identical across drivers.
+            Assert.Equal("CAF\u00e9", SnowflakeCredentialManagerFactory.NormalizeIdentifier("caf\u00e9"));
+            Assert.Equal("STRA\u00dfE", SnowflakeCredentialManagerFactory.NormalizeIdentifier("stra\u00dfe"));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierPreservesSqlEscapedQuotes()
+        {
+            Assert.Equal("\"Foo\"\"Bar\":BAZ", SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Foo\"\"Bar\":baz"));
         }
 
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -12,44 +12,45 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyGoldenHashA_OAuth()
         {
-            // Vector A: OAuth flow — 4-field keyData, mixed-case quoted segments preserved verbatim.
+            // Vector A: OAuth flow — 4-field keyData, lowercase normalization, quoted values verbatim.
+            // "DpopBundledAccessToken" passed directly — no named constant for this type.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
+                tokenType: "DpopBundledAccessToken",
                 idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
                 username: "\"First Last\"@long-corporate-domain.example.com",
                 role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f", key);
+            Assert.Equal("SnowflakeTokenCache.v2.DpopBundledAccessToken.741b6d66d252666d6821bfd19e0151511cf4efdaaeba2b3c87673aa4de6d2c0b", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyGoldenHashB_Mfa()
         {
-            // Vector B: MFA flow — 2-field keyData (snowflake + username only), mixed-case quoted segment preserved.
+            // Vector B: MFA flow — 2-field keyData, lowercase normalization, quoted username verbatim.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "MFA_TOKEN",
+                tokenType: "MfaToken",
                 idp: "",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
                 username: "\"First Last\"@long-corporate-domain.example.com",
                 role: ""
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8", key);
+            Assert.Equal("SnowflakeTokenCache.v2.MfaToken.10c5dde84bb8f584c0df06ea826d418c4f580e08f9db10187c0cb5e2a732a0d6", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHasCorrectPrefix()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
-            Assert.StartsWith("SnowflakeTokenCache.v2.MFA_TOKEN.", key);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            Assert.StartsWith("SnowflakeTokenCache.v2.MfaToken.", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHashIsLowercaseHex()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
             var segments = key.Split('.');
-            // Format: SnowflakeTokenCache.v2.<TOKEN_TYPE>.<hash>
+            // Format: SnowflakeTokenCache.v2.<TokenType>.<hash>
             Assert.Equal(4, segments.Length);
             var hash = segments[3];
             Assert.Equal(64, hash.Length);
@@ -59,13 +60,13 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenSnowflakeEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "", "user", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "", "user", "")));
         }
 
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenUsernameEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "snowflake", "", "")));
         }
 
         [SFFact]
@@ -73,25 +74,25 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         {
             // MFA and OAuth for the same user/host must produce different keys (different prefix + field set).
             var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                "MFA_TOKEN", "", "acct.snowflakecomputing.com", "user", ""));
+                "MfaToken", "", "acct.snowflakecomputing.com", "user", ""));
             var oauthKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                "OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
+                "OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
             Assert.NotEqual(mfaKey, oauthKey);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentSnowflakeHost()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct2.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct2.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentRole()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ANALYST"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ENGINEER"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "analyst"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "engineer"));
             Assert.NotEqual(key1, key2);
         }
 
@@ -99,88 +100,99 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         public void TestDimensionIsolationDifferentIdp()
         {
             // Same Snowflake account and user, different IdP — the multi-account/shared-IdP collision case.
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantA", "acct.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantB", "acct.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "login.microsoftonline.com/tenantA", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "login.microsoftonline.com/tenantB", "acct.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestBuildCacheKeyIsDeterministic()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
             Assert.Equal(key1, key2);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentTokenType()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_REFRESH_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthRefreshToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestNormalizeUrlStripsScheme()
         {
-            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://example.com/path"));
-            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("http://example.com/path"));
+            Assert.Equal("example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://example.com/path"));
+            Assert.Equal("example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("http://example.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlStripsUserinfo()
         {
-            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
-            Assert.Equal("HOST.EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.example.com/path"));
+            Assert.Equal("host.com", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
+            Assert.Equal("host.example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.example.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlPreservesAtSignInPath()
         {
             // An '@' after the authority is part of the path and must survive; only userinfo is stripped.
-            Assert.Equal("HOST.EXAMPLE.COM/OAUTH/@HANDLE/TOKEN",
+            Assert.Equal("host.example.com/oauth/@handle/token",
                 SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.example.com/oauth/@handle/token"));
         }
 
         [SFFact]
         public void TestNormalizeUrlDropsQueryAndFragment()
         {
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
             // An '@' inside the dropped query string must not be mistaken for userinfo.
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?email=user@domain.com"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?email=user@domain.com"));
         }
 
         [SFFact]
         public void TestNormalizeUrlTrimsRootOnlyTrailingSlash()
         {
-            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/"));
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path"));
+            Assert.Equal("host.com", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlPreservesPortAndPath()
         {
-            Assert.Equal("LOGIN.MICROSOFTONLINE.COM:443/TENANT-ID/OAUTH2/V2.0",
+            Assert.Equal("login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 SnowflakeCredentialManagerFactory.NormalizeUrl("https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierUnquotedIsUppercased()
+        public void TestNormalizeIdentifierUnquotedIsLowercased()
         {
-            Assert.Equal("USER@DOMAIN.COM", SnowflakeCredentialManagerFactory.NormalizeIdentifier("user@domain.com"));
+            Assert.Equal("user@domain.com", SnowflakeCredentialManagerFactory.NormalizeIdentifier("USER@DOMAIN.COM"));
+            Assert.Equal("analyst_role", SnowflakeCredentialManagerFactory.NormalizeIdentifier("ANALYST_ROLE"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierQuotedSegmentPreservedVerbatim()
+        public void TestNormalizeIdentifierQuotedValueIsVerbatim()
         {
-            Assert.Equal("\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM",
+            // Any double-quote anywhere in the value → return verbatim, unchanged.
+            Assert.Equal("\"First Last\"@long-corporate-domain.example.com",
                 SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"First Last\"@long-corporate-domain.example.com"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierMixedQuotedAndUnquoted()
+        public void TestNormalizeIdentifierQuotedValueNotAtStart()
         {
-            Assert.Equal("\"Analyst Role With Spaces\":NORTH_AMERICA:PROD:READONLY",
+            // A quote that is NOT at position 0 still triggers the verbatim path.
+            Assert.Equal("prefix-\"seg\"",
+                SnowflakeCredentialManagerFactory.NormalizeIdentifier("prefix-\"seg\""));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierMixedQuotedAndUnquotedIsVerbatim()
+        {
+            // Contains quotes → entire value returned verbatim (mixed case preserved).
+            Assert.Equal("\"Analyst Role With Spaces\":north_america:prod:readonly",
                 SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Analyst Role With Spaces\":north_america:prod:readonly"));
         }
 
@@ -191,18 +203,18 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierUppercasesAsciiOnly()
+        public void TestNormalizeIdentifierLowercasesNonAscii()
         {
-            // Matches the reference's ASCII-only case-folding: non-ASCII letters are left unchanged
-            // so keys stay byte-identical across drivers.
-            Assert.Equal("CAF\u00e9", SnowflakeCredentialManagerFactory.NormalizeIdentifier("caf\u00e9"));
-            Assert.Equal("STRA\u00dfE", SnowflakeCredentialManagerFactory.NormalizeIdentifier("stra\u00dfe"));
+            // No quotes → ToLowerInvariant applied to all characters.
+            Assert.Equal("caf\u00e9", SnowflakeCredentialManagerFactory.NormalizeIdentifier("caf\u00e9"));
+            Assert.Equal("stra\u00dfe", SnowflakeCredentialManagerFactory.NormalizeIdentifier("stra\u00dfe"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierPreservesSqlEscapedQuotes()
+        public void TestNormalizeIdentifierSqlEscapedQuotesAreVerbatim()
         {
-            Assert.Equal("\"Foo\"\"Bar\":BAZ", SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Foo\"\"Bar\":baz"));
+            // SQL-escaped double-quote inside the value still triggers verbatim path.
+            Assert.Equal("\"Foo\"\"Bar\":baz", SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Foo\"\"Bar\":baz"));
         }
 
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -12,8 +12,7 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyGoldenHash()
         {
-            // quoted segments are preserved verbatim by NormalizeIdentifier — pre-uppercase them to match
-            // the canonical JSON: {"idp":"LOGIN...","role":"\"ANALYST ROLE WITH SPACES\":...","username":"\"FIRST LAST\"@..."}
+            // quoted segments are preserved verbatim by NormalizeIdentifier — pre-uppercase them to match the expected hash
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                 tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
                 idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 using Snowflake.Data.Client;
+using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Core.CredentialManager.Infrastructure;
 using Snowflake.Data.Tests.Util;
 
@@ -119,6 +120,51 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
             var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
             var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthRefreshToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestToCacheKeyPrefixOAuthStringsMatchIsOAuthDispatch()
+        {
+            // The BuildCacheKey dispatch uses literal string matching; these must stay in sync.
+            Assert.Equal("OauthAccessToken", TokenType.OAuthAccessToken.ToCacheKeyPrefix());
+            Assert.Equal("OauthRefreshToken", TokenType.OAuthRefreshToken.ToCacheKeyPrefix());
+            // MFA and ID are non-OAuth — different prefix, different key shape
+            Assert.Equal("MfaToken", TokenType.MFAToken.ToCacheKeyPrefix());
+            Assert.Equal("IdToken", TokenType.IdToken.ToCacheKeyPrefix());
+        }
+
+        [SFFact]
+        public void TestMfaKeyIgnoresIdpAndRole()
+        {
+            var base_ = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            var withIdp = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "idp.example.com", "host.snowflake.com", "user", ""));
+            var withRole = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", "analyst"));
+            Assert.Equal(base_, withIdp);
+            Assert.Equal(base_, withRole);
+        }
+
+        [SFFact]
+        public void TestUsernameIsCaseFoldedInKey()
+        {
+            var lower = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            var upper = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "HOST.SNOWFLAKE.COM", "USER", ""));
+            Assert.Equal(lower, upper);
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationDifferentUsername()
+        {
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "alice", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "bob", ""));
+            Assert.NotEqual(key1, key2);
+        }
+
+        [SFFact]
+        public void TestDimensionIsolationIdTokenVsMfaToken()
+        {
+            var idKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("IdToken", "", "host.snowflake.com", "user", ""));
+            var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            Assert.NotEqual(idKey, mfaKey);
         }
 
         [SFFact]

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -15,11 +15,11 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
             // Vector A: OAuth flow — 4-field keyData, lowercase normalization, quoted values verbatim.
             // "DpopBundledAccessToken" passed directly — no named constant for this type.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "DpopBundledAccessToken",
-                idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
-                snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
-                username: "\"First Last\"@long-corporate-domain.example.com",
-                role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
+                TokenType: "DpopBundledAccessToken",
+                Idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
+                SnowflakeUrl: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+                Username: "\"First Last\"@long-corporate-domain.example.com",
+                Role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
             ));
             Assert.Equal("SnowflakeTokenCache.v2.DpopBundledAccessToken.741b6d66d252666d6821bfd19e0151511cf4efdaaeba2b3c87673aa4de6d2c0b", key);
         }
@@ -29,11 +29,11 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         {
             // Vector B: MFA flow — 2-field keyData, lowercase normalization, quoted username verbatim.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "MfaToken",
-                idp: "",
-                snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
-                username: "\"First Last\"@long-corporate-domain.example.com",
-                role: ""
+                TokenType: "MfaToken",
+                Idp: "",
+                SnowflakeUrl: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+                Username: "\"First Last\"@long-corporate-domain.example.com",
+                Role: ""
             ));
             Assert.Equal("SnowflakeTokenCache.v2.MfaToken.10c5dde84bb8f584c0df06ea826d418c4f580e08f9db10187c0cb5e2a732a0d6", key);
         }

--- a/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
@@ -90,7 +90,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "mockIdToken");
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -119,7 +119,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -149,7 +149,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -180,7 +180,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, invalidIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -208,7 +208,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "validIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, expectedIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -371,7 +371,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "mockIdToken");
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -401,7 +401,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -432,7 +432,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -464,7 +464,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, invalidIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -493,7 +493,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "validIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.IdToken);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, expectedIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);

--- a/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFExternalBrowserTest.cs
@@ -90,7 +90,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "mockIdToken");
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -119,7 +119,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -149,7 +149,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -180,7 +180,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, invalidIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -208,7 +208,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "validIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, expectedIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -371,7 +371,7 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, "mockIdToken");
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -401,7 +401,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -432,7 +432,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "testUser";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(key);
             var restRequester = new Mock.MockExternalBrowserRestRequester()
             {
@@ -464,7 +464,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "mockIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, invalidIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);
@@ -493,7 +493,7 @@ namespace Snowflake.Data.Tests.UnitTests
             var expectedIdToken = "validIdToken";
             var user = "test";
             var host = $"{user}.snowflakecomputing.com";
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.GetAttribute<StringAttr>().value, host, host, user, string.Empty));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(TokenType.IdToken.ToCacheKeyPrefix(), host, host, user, string.Empty));
             var credentialManager = SFCredentialManagerInMemoryImpl.Instance;
             credentialManager.SaveCredentials(key, expectedIdToken);
             SnowflakeCredentialManagerFactory.SetCredentialManager(credentialManager);

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -41,8 +41,14 @@ namespace Snowflake.Data.Client
         private static ISnowflakeCredentialManager s_credentialManager = s_defaultCredentialManager;
 
         /// <summary>
-        /// Builds a v2 token cache key: <c>SnowflakeTokenCache.v2.&lt;sha256hex(canonical_json)&gt;</c>.
-        /// All inputs are normalized before hashing.
+        /// Builds a v2 token cache key:
+        /// <c>SnowflakeTokenCache.v2.&lt;TOKEN_TYPE&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
+        /// The token type appears in the readable prefix so keystore tooling can identify token
+        /// classes without decoding the opaque hash. <c>keyData</c> is flow-specific and never
+        /// contains <c>token_type</c>: OAuth flows include <c>idp</c>, <c>role</c>,
+        /// <c>snowflake</c>, and <c>username</c>; MFA and ID token flows include only
+        /// <c>snowflake</c> and <c>username</c> (role is not embedded in those auth calls and
+        /// authentication always targets the Snowflake host directly).
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
@@ -50,23 +56,34 @@ namespace Snowflake.Data.Client
                 throw new ArgumentException("snowflake URL must not be empty");
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
-            // An empty idp would silently collapse the cross-IdP dimension of the key and
-            // reintroduce the collision class this format guards against, so it is rejected.
-            if (string.IsNullOrEmpty(input.Idp))
-                throw new ArgumentException("idp must not be empty");
 
-            var keyData = new SortedDictionary<string, string>
+            bool isOAuth = input.TokenType is "OAUTH_ACCESS_TOKEN"
+                            or "OAUTH_REFRESH_TOKEN"
+                            or "DPOP_BUNDLED_ACCESS_TOKEN";
+
+            SortedDictionary<string, string> keyData;
+            if (isOAuth)
             {
-                ["idp"]        = NormalizeUrl(input.Idp),
-                ["role"]       = NormalizeIdentifier(input.Role),
-                ["snowflake"]  = NormalizeUrl(input.SnowflakeUrl),
-                ["token_type"] = input.TokenType,
-                ["username"]   = NormalizeIdentifier(input.Username),
-            };
+                keyData = new SortedDictionary<string, string>
+                {
+                    ["idp"]       = NormalizeUrl(input.Idp),
+                    ["role"]      = NormalizeIdentifier(input.Role),
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"]  = NormalizeIdentifier(input.Username),
+                };
+            }
+            else  // MFA_TOKEN, ID_TOKEN
+            {
+                keyData = new SortedDictionary<string, string>
+                {
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"]  = NormalizeIdentifier(input.Username),
+                };
+            }
 
             string json = JsonConvert.SerializeObject(keyData, Formatting.None);
             string hash = ToSha256HashLower(json);
-            return $"SnowflakeTokenCache.v2.{hash}";
+            return $"SnowflakeTokenCache.v2.{input.TokenType}.{hash}";
         }
 
         /// <summary>

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Snowflake.Data.Client
 {
-    /// <summary>Carries the five dimensions for a v2 token cache key.</summary>
+    /// <summary>Input parameters for building a v2 token cache key.</summary>
     internal sealed class CacheKeyInput
     {
         public string TokenType { get; }
@@ -43,7 +43,7 @@ namespace Snowflake.Data.Client
 
         /// <summary>
         /// Builds a v2 token cache key: <c>SnowflakeTokenCache.v2.&lt;sha256hex(canonical_json)&gt;</c>.
-        /// Normalizes all dimensions before hashing; hashing occurs exactly once here.
+        /// All inputs are normalized before hashing.
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
@@ -104,7 +104,7 @@ namespace Snowflake.Data.Client
             }
         }
 
-        [Obsolete("Use BuildCacheKey(CacheKeyInput) instead. This method produces a v1 key that is not cross-driver compatible.")]
+        [Obsolete("Use BuildCacheKey(CacheKeyInput) instead. This method produces a legacy key format.")]
         internal static string GetSecureCredentialKey(string host, string user, TokenType tokenType)
         {
             return $"{host.ToUpper()}:{user.ToUpper()}:{tokenType.ToString().ToUpper()}".ToSha256Hash();

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Core.CredentialManager.Infrastructure;
@@ -18,7 +17,7 @@ namespace Snowflake.Data.Client
     {
         public string TokenType { get; }
         public string Idp { get; }
-        public string Snowflake { get; }
+        public string SnowflakeUrl { get; }
         public string Username { get; }
         public string Role { get; }
 
@@ -26,7 +25,7 @@ namespace Snowflake.Data.Client
         {
             TokenType = tokenType;
             Idp = idp;
-            Snowflake = snowflake;
+            SnowflakeUrl = snowflake;
             Username = username;
             Role = role;
         }
@@ -47,16 +46,20 @@ namespace Snowflake.Data.Client
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
-            if (string.IsNullOrEmpty(input.Snowflake))
+            if (string.IsNullOrEmpty(input.SnowflakeUrl))
                 throw new ArgumentException("snowflake URL must not be empty");
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
+            // An empty idp would silently collapse the cross-IdP dimension of the key and
+            // reintroduce the collision class this format guards against, so it is rejected.
+            if (string.IsNullOrEmpty(input.Idp))
+                throw new ArgumentException("idp must not be empty");
 
             var keyData = new SortedDictionary<string, string>
             {
                 ["idp"]        = NormalizeUrl(input.Idp),
                 ["role"]       = NormalizeIdentifier(input.Role),
-                ["snowflake"]  = NormalizeUrl(input.Snowflake),
+                ["snowflake"]  = NormalizeUrl(input.SnowflakeUrl),
                 ["token_type"] = input.TokenType,
                 ["username"]   = NormalizeIdentifier(input.Username),
             };
@@ -66,31 +69,51 @@ namespace Snowflake.Data.Client
             return $"SnowflakeTokenCache.v2.{hash}";
         }
 
-        /// <summary>Strips scheme, userinfo, query, fragment; uppercases the remainder; trims a root-only trailing slash.</summary>
+        /// <summary>
+        /// Strips the scheme and any userinfo prefix, drops query and fragment, then uppercases the
+        /// remaining authority (host and any explicitly-stated port) and path, trimming trailing slashes.
+        /// The raw string is used (not a parsed URL) so an explicit default port such as <c>:443</c> is preserved.
+        /// </summary>
         internal static string NormalizeUrl(string url)
         {
             if (string.IsNullOrEmpty(url))
                 return string.Empty;
-            var s = Regex.Replace(url, @"^https?://", "");
-            var atIdx = s.IndexOf('@');
-            if (atIdx >= 0) s = s.Substring(atIdx + 1);
+
+            // Strip the scheme prefix ("scheme://") from the raw string, preserving any explicit port.
+            var schemeIdx = url.IndexOf("://", StringComparison.Ordinal);
+            var s = schemeIdx >= 0 ? url.Substring(schemeIdx + 3) : url;
+
+            // Drop query string and fragment; they never appear in cache keys.
             s = s.Split('?')[0].Split('#')[0];
-            s = s.TrimEnd('/');
-            return s.ToUpperInvariant();
+
+            // Strip userinfo ("user:pass@") from the authority only. The authority ends at the first
+            // '/', so an '@' before that slash is a userinfo delimiter; an '@' inside the path survives.
+            var slashIdx = s.IndexOf('/');
+            var authorityEnd = slashIdx >= 0 ? slashIdx : s.Length;
+            var authority = s.Substring(0, authorityEnd);
+            var path = s.Substring(authorityEnd);
+            var atIdx = authority.IndexOf('@');
+            if (atIdx >= 0)
+                authority = authority.Substring(atIdx + 1);
+
+            return (authority + path).TrimEnd('/').ToUpperInvariant();
         }
 
-        /// <summary>Uppercases unquoted segments; preserves the content of double-quoted segments verbatim (including surrounding quotes).</summary>
+        /// <summary>
+        /// Uppercases unquoted segments (ASCII only, matching Snowflake identifier case-folding);
+        /// preserves the content of double-quoted segments verbatim (including surrounding quotes).
+        /// </summary>
         internal static string NormalizeIdentifier(string identifier)
         {
             if (string.IsNullOrEmpty(identifier))
                 return string.Empty;
-            var sb = new StringBuilder();
+            var sb = new StringBuilder(identifier.Length);
             bool inQuotes = false;
             foreach (char c in identifier)
             {
                 if (c == '"') { inQuotes = !inQuotes; sb.Append(c); }
                 else if (inQuotes) sb.Append(c);
-                else sb.Append(char.ToUpperInvariant(c));
+                else sb.Append(c >= 'a' && c <= 'z' ? (char)(c - ('a' - 'A')) : c);
             }
             return sb.ToString();
         }
@@ -109,7 +132,6 @@ namespace Snowflake.Data.Client
         {
             return $"{host.ToUpper()}:{user.ToUpper()}:{tokenType.ToString().ToUpper()}".ToSha256Hash();
         }
-
 
         public static void UseDefaultCredentialManager()
         {

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -1,13 +1,37 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
 using Snowflake.Data.Core;
 using Snowflake.Data.Core.CredentialManager;
 using Snowflake.Data.Core.CredentialManager.Infrastructure;
 using Snowflake.Data.Core.Tools;
 using Snowflake.Data.Log;
+using Newtonsoft.Json;
 
 namespace Snowflake.Data.Client
 {
+    /// <summary>Carries the five dimensions for a v2 token cache key.</summary>
+    internal sealed class CacheKeyInput
+    {
+        public string TokenType { get; }
+        public string Idp { get; }
+        public string Snowflake { get; }
+        public string Username { get; }
+        public string Role { get; }
+
+        public CacheKeyInput(string tokenType, string idp, string snowflake, string username, string role)
+        {
+            TokenType = tokenType;
+            Idp = idp;
+            Snowflake = snowflake;
+            Username = username;
+            Role = role;
+        }
+    }
+
     public class SnowflakeCredentialManagerFactory
     {
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<SnowflakeCredentialManagerFactory>();
@@ -17,6 +41,70 @@ namespace Snowflake.Data.Client
 
         private static ISnowflakeCredentialManager s_credentialManager = s_defaultCredentialManager;
 
+        /// <summary>
+        /// Builds a v2 token cache key: <c>SnowflakeTokenCache.v2.&lt;sha256hex(canonical_json)&gt;</c>.
+        /// Normalizes all dimensions before hashing; hashing occurs exactly once here.
+        /// </summary>
+        internal static string BuildCacheKey(CacheKeyInput input)
+        {
+            if (string.IsNullOrEmpty(input.Snowflake))
+                throw new ArgumentException("snowflake URL must not be empty");
+            if (string.IsNullOrEmpty(input.Username))
+                throw new ArgumentException("username must not be empty");
+
+            var keyData = new SortedDictionary<string, string>
+            {
+                ["idp"]        = NormalizeUrl(input.Idp),
+                ["role"]       = NormalizeIdentifier(input.Role),
+                ["snowflake"]  = NormalizeUrl(input.Snowflake),
+                ["token_type"] = input.TokenType,
+                ["username"]   = NormalizeIdentifier(input.Username),
+            };
+
+            string json = JsonConvert.SerializeObject(keyData, Formatting.None);
+            string hash = ToSha256HashLower(json);
+            return $"SnowflakeTokenCache.v2.{hash}";
+        }
+
+        /// <summary>Strips scheme, userinfo, query, fragment; uppercases the remainder; trims a root-only trailing slash.</summary>
+        internal static string NormalizeUrl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return string.Empty;
+            var s = Regex.Replace(url, @"^https?://", "");
+            var atIdx = s.IndexOf('@');
+            if (atIdx >= 0) s = s.Substring(atIdx + 1);
+            s = s.Split('?')[0].Split('#')[0];
+            s = s.TrimEnd('/');
+            return s.ToUpperInvariant();
+        }
+
+        /// <summary>Uppercases unquoted segments; preserves the content of double-quoted segments verbatim (including surrounding quotes).</summary>
+        internal static string NormalizeIdentifier(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+                return string.Empty;
+            var sb = new StringBuilder();
+            bool inQuotes = false;
+            foreach (char c in identifier)
+            {
+                if (c == '"') { inQuotes = !inQuotes; sb.Append(c); }
+                else if (inQuotes) sb.Append(c);
+                else sb.Append(char.ToUpperInvariant(c));
+            }
+            return sb.ToString();
+        }
+
+        private static string ToSha256HashLower(string text)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
+                return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+            }
+        }
+
+        [Obsolete("Use BuildCacheKey(CacheKeyInput) instead. This method produces a v1 key that is not cross-driver compatible.")]
         internal static string GetSecureCredentialKey(string host, string user, TokenType tokenType)
         {
             return $"{host.ToUpper()}:{user.ToUpper()}:{tokenType.ToString().ToUpper()}".ToSha256Hash();

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -42,13 +42,12 @@ namespace Snowflake.Data.Client
 
         /// <summary>
         /// Builds a v2 token cache key:
-        /// <c>SnowflakeTokenCache.v2.&lt;TOKEN_TYPE&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
-        /// The token type appears in the readable prefix so keystore tooling can identify token
-        /// classes without decoding the opaque hash. <c>keyData</c> is flow-specific and never
-        /// contains <c>token_type</c>: OAuth flows include <c>idp</c>, <c>role</c>,
-        /// <c>snowflake</c>, and <c>username</c>; MFA and ID token flows include only
-        /// <c>snowflake</c> and <c>username</c> (role is not embedded in those auth calls and
-        /// authentication always targets the Snowflake host directly).
+        /// <c>SnowflakeTokenCache.v2.&lt;TokenType&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
+        /// The PascalCase token type appears in the readable prefix so keystore tooling can
+        /// identify token classes without decoding the opaque hash. <c>keyData</c> is
+        /// flow-specific and never contains the token type: OAuth flows include <c>idp</c>,
+        /// <c>role</c>, <c>snowflake</c>, and <c>username</c> (all lowercased); MFA and ID
+        /// token flows include only <c>snowflake</c> and <c>username</c>.
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
@@ -57,9 +56,9 @@ namespace Snowflake.Data.Client
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
 
-            bool isOAuth = input.TokenType is "OAUTH_ACCESS_TOKEN"
-                            or "OAUTH_REFRESH_TOKEN"
-                            or "DPOP_BUNDLED_ACCESS_TOKEN";
+            bool isOAuth = input.TokenType is "OauthAccessToken"
+                            or "OauthRefreshToken"
+                            or "DpopBundledAccessToken";
 
             SortedDictionary<string, string> keyData;
             if (isOAuth)
@@ -87,7 +86,7 @@ namespace Snowflake.Data.Client
         }
 
         /// <summary>
-        /// Strips the scheme and any userinfo prefix, drops query and fragment, then uppercases the
+        /// Strips the scheme and any userinfo prefix, drops query and fragment, then lowercases the
         /// remaining authority (host and any explicitly-stated port) and path, trimming trailing slashes.
         /// The raw string is used (not a parsed URL) so an explicit default port such as <c>:443</c> is preserved.
         /// </summary>
@@ -113,26 +112,21 @@ namespace Snowflake.Data.Client
             if (atIdx >= 0)
                 authority = authority.Substring(atIdx + 1);
 
-            return (authority + path).TrimEnd('/').ToUpperInvariant();
+            return (authority + path).TrimEnd('/').ToLowerInvariant();
         }
 
         /// <summary>
-        /// Uppercases unquoted segments (ASCII only, matching Snowflake identifier case-folding);
-        /// preserves the content of double-quoted segments verbatim (including surrounding quotes).
+        /// Normalizes a Snowflake identifier for use as a cache key field.
+        /// If the value contains any double-quote character (<c>"</c>), it is returned
+        /// verbatim — the quotes signal case-sensitive SQL semantics that must not be altered.
+        /// Otherwise the entire value is lowercased: unquoted identifiers are case-insensitive
+        /// in Snowflake so lowercasing produces a stable canonical form.
         /// </summary>
         internal static string NormalizeIdentifier(string identifier)
         {
             if (string.IsNullOrEmpty(identifier))
                 return string.Empty;
-            var sb = new StringBuilder(identifier.Length);
-            bool inQuotes = false;
-            foreach (char c in identifier)
-            {
-                if (c == '"') { inQuotes = !inQuotes; sb.Append(c); }
-                else if (inQuotes) sb.Append(c);
-                else sb.Append(c >= 'a' && c <= 'z' ? (char)(c - ('a' - 'A')) : c);
-            }
-            return sb.ToString();
+            return identifier.Contains("\"") ? identifier : identifier.ToLowerInvariant();
         }
 
         private static string ToSha256HashLower(string text)

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -13,23 +13,7 @@ using Newtonsoft.Json;
 namespace Snowflake.Data.Client
 {
     /// <summary>Input parameters for building a v2 token cache key.</summary>
-    internal sealed class CacheKeyInput
-    {
-        public string TokenType { get; }
-        public string Idp { get; }
-        public string SnowflakeUrl { get; }
-        public string Username { get; }
-        public string Role { get; }
-
-        public CacheKeyInput(string tokenType, string idp, string snowflake, string username, string role)
-        {
-            TokenType = tokenType;
-            Idp = idp;
-            SnowflakeUrl = snowflake;
-            Username = username;
-            Role = role;
-        }
-    }
+    internal readonly record struct CacheKeyInput(string TokenType, string Idp, string SnowflakeUrl, string Username, string Role);
 
     public class SnowflakeCredentialManagerFactory
     {
@@ -56,32 +40,26 @@ namespace Snowflake.Data.Client
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
 
-            bool isOAuth = input.TokenType is "OauthAccessToken"
-                            or "OauthRefreshToken"
-                            or "DpopBundledAccessToken";
+            var isOAuth = input.TokenType is "OauthAccessToken"
+                           or "OauthRefreshToken"
+                           or "DpopBundledAccessToken";
 
-            SortedDictionary<string, string> keyData;
-            if (isOAuth)
-            {
-                keyData = new SortedDictionary<string, string>
-                {
-                    ["idp"]       = NormalizeUrl(input.Idp),
-                    ["role"]      = NormalizeIdentifier(input.Role),
-                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
-                    ["username"]  = NormalizeIdentifier(input.Username),
-                };
-            }
-            else  // MFA_TOKEN, ID_TOKEN
-            {
-                keyData = new SortedDictionary<string, string>
-                {
-                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
-                    ["username"]  = NormalizeIdentifier(input.Username),
-                };
-            }
+            var keyData = isOAuth
+                ? new SortedDictionary<string, string>
+                  {
+                      ["idp"]       = NormalizeUrl(input.Idp),
+                      ["role"]      = NormalizeIdentifier(input.Role),
+                      ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                      ["username"]  = NormalizeIdentifier(input.Username),
+                  }
+                : new SortedDictionary<string, string>
+                  {
+                      ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                      ["username"]  = NormalizeIdentifier(input.Username),
+                  };
 
-            string json = JsonConvert.SerializeObject(keyData, Formatting.None);
-            string hash = ToSha256HashLower(json);
+            var json = JsonConvert.SerializeObject(keyData, Formatting.None);
+            var hash = ToSha256HashLower(json);
             return $"SnowflakeTokenCache.v2.{input.TokenType}.{hash}";
         }
 
@@ -119,6 +97,7 @@ namespace Snowflake.Data.Client
         /// Normalizes a Snowflake identifier for use as a cache key field.
         /// If the value contains any double-quote character (<c>"</c>), it is returned
         /// verbatim — the quotes signal case-sensitive SQL semantics that must not be altered.
+        /// SQL escaped-quotes (<c>""</c>) contain a <c>"</c> and are therefore also returned verbatim.
         /// Otherwise the entire value is lowercased: unquoted identifiers are case-insensitive
         /// in Snowflake so lowercasing produces a stable canonical form.
         /// </summary>
@@ -131,17 +110,9 @@ namespace Snowflake.Data.Client
 
         private static string ToSha256HashLower(string text)
         {
-            using (var sha = SHA256.Create())
-            {
-                var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
-                return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
-            }
-        }
-
-        [Obsolete("Use BuildCacheKey(CacheKeyInput) instead. This method produces a legacy key format.")]
-        internal static string GetSecureCredentialKey(string host, string user, TokenType tokenType)
-        {
-            return $"{host.ToUpper()}:{user.ToUpper()}:{tokenType.ToString().ToUpper()}".ToSha256Hash();
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
+            return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
         }
 
         public static void UseDefaultCredentialManager()

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -46,17 +46,17 @@ namespace Snowflake.Data.Client
 
             var keyData = isOAuth
                 ? new SortedDictionary<string, string>
-                  {
-                      ["idp"]       = NormalizeUrl(input.Idp),
-                      ["role"]      = NormalizeIdentifier(input.Role),
-                      ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
-                      ["username"]  = NormalizeIdentifier(input.Username),
-                  }
+                {
+                    ["idp"] = NormalizeUrl(input.Idp),
+                    ["role"] = NormalizeIdentifier(input.Role),
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"] = NormalizeIdentifier(input.Username),
+                }
                 : new SortedDictionary<string, string>
-                  {
-                      ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
-                      ["username"]  = NormalizeIdentifier(input.Username),
-                  };
+                {
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"] = NormalizeIdentifier(input.Username),
+                };
 
             var json = JsonConvert.SerializeObject(keyData, Formatting.None);
             var hash = ToSha256HashLower(json);

--- a/Snowflake.Data/CompilerServices/IsExternalInit.cs
+++ b/Snowflake.Data/CompilerServices/IsExternalInit.cs
@@ -1,6 +1,6 @@
 namespace System.Runtime.CompilerServices
 {
 #if !NET5_0_OR_GREATER
-    internal static class IsExternalInit {}
+    internal static class IsExternalInit { }
 #endif
 }

--- a/Snowflake.Data/CompilerServices/IsExternalInit.cs
+++ b/Snowflake.Data/CompilerServices/IsExternalInit.cs
@@ -1,0 +1,6 @@
+namespace System.Runtime.CompilerServices
+{
+#if !NET5_0_OR_GREATER
+    internal static class IsExternalInit {}
+#endif
+}

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -58,6 +58,7 @@ namespace Snowflake.Data.Core.Authenticator
             {
                 var host = session.properties[SFSessionProperty.HOST];
                 session.properties.TryGetValue(SFSessionProperty.ROLE, out var role);
+                // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                 _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                     tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
                     idp: host,

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -56,10 +56,15 @@ namespace Snowflake.Data.Core.Authenticator
             var clientStoreTemporaryCredential = bool.Parse(session.properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]);
             if (!string.IsNullOrEmpty(user) && clientStoreTemporaryCredential)
             {
-                _idTokenKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(
-                    session.properties[SFSessionProperty.HOST],
-                    user,
-                    TokenType.IdToken);
+                var host = session.properties[SFSessionProperty.HOST];
+                session.properties.TryGetValue(SFSessionProperty.ROLE, out var role);
+                _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                    tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                    idp: host,
+                    snowflake: host,
+                    username: user,
+                    role: role ?? string.Empty
+                ));
             }
         }
 

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -58,7 +58,7 @@ namespace Snowflake.Data.Core.Authenticator
             {
                 var host = session.properties[SFSessionProperty.HOST];
                 _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
                     idp: "",
                     snowflake: host,
                     username: user,

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -57,14 +57,12 @@ namespace Snowflake.Data.Core.Authenticator
             if (!string.IsNullOrEmpty(user) && clientStoreTemporaryCredential)
             {
                 var host = session.properties[SFSessionProperty.HOST];
-                session.properties.TryGetValue(SFSessionProperty.ROLE, out var role);
-                // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                 _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                     tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
-                    idp: host,
+                    idp: "",
                     snowflake: host,
                     username: user,
-                    role: role ?? string.Empty
+                    role: ""
                 ));
             }
         }

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -56,14 +56,7 @@ namespace Snowflake.Data.Core.Authenticator
             var clientStoreTemporaryCredential = bool.Parse(session.properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]);
             if (!string.IsNullOrEmpty(user) && clientStoreTemporaryCredential)
             {
-                var host = session.properties[SFSessionProperty.HOST];
-                _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
-                    idp: "",
-                    snowflake: host,
-                    username: user,
-                    role: ""
-                ));
+                _idTokenKey = BuildIdTokenCacheKey();
             }
         }
 
@@ -307,5 +300,13 @@ namespace Snowflake.Data.Core.Authenticator
             }
             return Convert.ToBase64String(randomness);
         }
+
+        private string BuildIdTokenCacheKey() =>
+            SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                TokenType: TokenType.IdToken.ToCacheKeyPrefix(),
+                Idp: "",
+                SnowflakeUrl: session.properties[SFSessionProperty.HOST],
+                Username: session.properties[SFSessionProperty.USER],
+                Role: ""));
     }
 }

--- a/Snowflake.Data/Core/Authenticator/OAuthAuthorizationCodeAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/OAuthAuthorizationCodeAuthenticator.cs
@@ -56,10 +56,12 @@ You can close this window now and go back where you started from.
 
         protected override OAuthCacheKeys GetOAuthCacheKeys()
         {
-            var host = new Uri(GetTokenEndpoint()).Host;
+            var tokenEndpoint = GetTokenEndpoint();
+            var snowflakeHost = session.properties[SFSessionProperty.HOST];
             var user = session.properties[SFSessionProperty.USER];
+            session.properties.TryGetValue(SFSessionProperty.ROLE, out var role);
             var clientStoreTemporaryCredentials = bool.Parse(session.properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]);
-            return OAuthCacheKeys.CreateForAuthorizationCodeFlow(host, user, clientStoreTemporaryCredentials, SnowflakeCredentialManagerFactory.GetCredentialManager);
+            return OAuthCacheKeys.CreateForAuthorizationCodeFlow(tokenEndpoint, snowflakeHost, user, role ?? string.Empty, clientStoreTemporaryCredentials, SnowflakeCredentialManagerFactory.GetCredentialManager);
         }
 
         protected override OAuthAccessTokenRequest RunFlowToAccessTokenRequest()

--- a/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
+++ b/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
@@ -20,14 +20,14 @@ namespace Snowflake.Data.Core.Authenticator
             if (IsCacheAvailableForAuthorizationCodeFlow(user, clientStoreTemporaryCredentials, true))
             {
                 accessTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.OAuthAccessToken.ToCacheKeyPrefix(),
                     idp: idpUrl,
                     snowflake: snowflakeHost,
                     username: user,
                     role: role ?? string.Empty
                 ));
                 refreshTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.OAuthRefreshToken.ToCacheKeyPrefix(),
                     idp: idpUrl,
                     snowflake: snowflakeHost,
                     username: user,

--- a/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
+++ b/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
@@ -13,14 +13,26 @@ namespace Snowflake.Data.Core.Authenticator
 
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<OAuthCacheKeys>();
 
-        public static OAuthCacheKeys CreateForAuthorizationCodeFlow(string host, string user, bool clientStoreTemporaryCredentials, Func<ISnowflakeCredentialManager> credentialManagerProvider)
+        public static OAuthCacheKeys CreateForAuthorizationCodeFlow(string idpUrl, string snowflakeHost, string user, string role, bool clientStoreTemporaryCredentials, Func<ISnowflakeCredentialManager> credentialManagerProvider)
         {
             string accessTokenKey = string.Empty;
             string refreshTokenKey = string.Empty;
             if (IsCacheAvailableForAuthorizationCodeFlow(user, clientStoreTemporaryCredentials, true))
             {
-                accessTokenKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.OAuthAccessToken);
-                refreshTokenKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(host, user, TokenType.OAuthRefreshToken);
+                accessTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                    tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+                    idp: idpUrl,
+                    snowflake: snowflakeHost,
+                    username: user,
+                    role: role ?? string.Empty
+                ));
+                refreshTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                    tokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+                    idp: idpUrl,
+                    snowflake: snowflakeHost,
+                    username: user,
+                    role: role ?? string.Empty
+                ));
             }
             return new OAuthCacheKeys(accessTokenKey, refreshTokenKey, credentialManagerProvider);
         }

--- a/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
+++ b/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
@@ -20,18 +20,18 @@ namespace Snowflake.Data.Core.Authenticator
             if (IsCacheAvailableForAuthorizationCodeFlow(user, clientStoreTemporaryCredentials, true))
             {
                 accessTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthAccessToken.ToCacheKeyPrefix(),
-                    idp: idpUrl,
-                    snowflake: snowflakeHost,
-                    username: user,
-                    role: role ?? string.Empty
+                    TokenType: TokenType.OAuthAccessToken.ToCacheKeyPrefix(),
+                    Idp: idpUrl,
+                    SnowflakeUrl: snowflakeHost,
+                    Username: user,
+                    Role: role ?? string.Empty
                 ));
                 refreshTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthRefreshToken.ToCacheKeyPrefix(),
-                    idp: idpUrl,
-                    snowflake: snowflakeHost,
-                    username: user,
-                    role: role ?? string.Empty
+                    TokenType: TokenType.OAuthRefreshToken.ToCacheKeyPrefix(),
+                    Idp: idpUrl,
+                    SnowflakeUrl: snowflakeHost,
+                    Username: user,
+                    Role: role ?? string.Empty
                 ));
             }
             return new OAuthCacheKeys(accessTokenKey, refreshTokenKey, credentialManagerProvider);

--- a/Snowflake.Data/Core/CredentialManager/TokenType.cs
+++ b/Snowflake.Data/Core/CredentialManager/TokenType.cs
@@ -11,4 +11,22 @@ namespace Snowflake.Data.Core.CredentialManager
         [StringAttr(value = "OAUTH_REFRESH_TOKEN")]
         OAuthRefreshToken
     }
+
+    internal static class TokenTypeExtensions
+    {
+        /// <summary>
+        /// Returns the PascalCase token-type string used as the third segment of the
+        /// cache key prefix (<c>SnowflakeTokenCache.v2.&lt;TokenType&gt;.&lt;hash&gt;</c>).
+        /// This is distinct from <c>GetAttribute&lt;StringAttr&gt;().value</c>, which returns
+        /// the REST-protocol wire value and must not be used to build cache keys.
+        /// </summary>
+        internal static string ToCacheKeyPrefix(this TokenType tokenType) => tokenType switch
+        {
+            TokenType.IdToken          => "IdToken",
+            TokenType.MFAToken         => "MfaToken",
+            TokenType.OAuthAccessToken => "OauthAccessToken",
+            TokenType.OAuthRefreshToken => "OauthRefreshToken",
+            _ => throw new System.ArgumentOutOfRangeException(nameof(tokenType), tokenType, "Unknown TokenType")
+        };
+    }
 }

--- a/Snowflake.Data/Core/CredentialManager/TokenType.cs
+++ b/Snowflake.Data/Core/CredentialManager/TokenType.cs
@@ -22,8 +22,8 @@ namespace Snowflake.Data.Core.CredentialManager
         /// </summary>
         internal static string ToCacheKeyPrefix(this TokenType tokenType) => tokenType switch
         {
-            TokenType.IdToken          => "IdToken",
-            TokenType.MFAToken         => "MfaToken",
+            TokenType.IdToken => "IdToken",
+            TokenType.MFAToken => "MfaToken",
             TokenType.OAuthAccessToken => "OauthAccessToken",
             TokenType.OAuthRefreshToken => "OauthRefreshToken",
             _ => throw new System.ArgumentOutOfRangeException(nameof(tokenType), tokenType, "Unknown TokenType")

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -131,13 +131,25 @@ namespace Snowflake.Data.Core
                 if (bool.Parse(properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]) &&
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
-                    var idTokenKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(properties[SFSessionProperty.HOST], properties[SFSessionProperty.USER], TokenType.IdToken);
+                    var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                        tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                        idp: properties[SFSessionProperty.HOST],
+                        snowflake: properties[SFSessionProperty.HOST],
+                        username: properties[SFSessionProperty.USER],
+                        role: properties.TryGetValue(SFSessionProperty.ROLE, out var idTokenRole) ? idTokenRole : string.Empty
+                    ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(idTokenKey, authnResponse.data.idToken);
                 }
                 if (!string.IsNullOrEmpty(authnResponse.data.mfaToken))
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
-                    var key = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(properties[SFSessionProperty.HOST], properties[SFSessionProperty.USER], TokenType.MFAToken);
+                    var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        idp: properties[SFSessionProperty.HOST],
+                        snowflake: properties[SFSessionProperty.HOST],
+                        username: properties[SFSessionProperty.USER],
+                        role: string.Empty
+                    ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(key, authnResponse.data.mfaToken);
                 }
                 logger.Debug($"Session opened: {sessionId}");
@@ -159,7 +171,13 @@ namespace Snowflake.Data.Core
                 {
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
-                    var mfaKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(properties[SFSessionProperty.HOST], properties[SFSessionProperty.USER], TokenType.MFAToken);
+                    var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        idp: properties[SFSessionProperty.HOST],
+                        snowflake: properties[SFSessionProperty.HOST],
+                        username: properties[SFSessionProperty.USER],
+                        role: string.Empty
+                    ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(mfaKey);
                 }
                 throw e;
@@ -230,7 +248,13 @@ namespace Snowflake.Data.Core
                 if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var _authenticatorType) &&
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
-                    var mfaKey = SnowflakeCredentialManagerFactory.GetSecureCredentialKey(properties[SFSessionProperty.HOST], properties[SFSessionProperty.USER], TokenType.MFAToken);
+                    var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        idp: properties[SFSessionProperty.HOST],
+                        snowflake: properties[SFSessionProperty.HOST],
+                        username: properties[SFSessionProperty.USER],
+                        role: string.Empty
+                    ));
                     _mfaToken = SecureStringHelper.Encode(SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(mfaKey));
                 }
             }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -131,26 +131,24 @@ namespace Snowflake.Data.Core
                 if (bool.Parse(properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]) &&
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
-                    // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                     var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: properties.TryGetValue(SFSessionProperty.ROLE, out var idTokenRole) ? idTokenRole : string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(idTokenKey, authnResponse.data.idToken);
                 }
                 if (!string.IsNullOrEmpty(authnResponse.data.mfaToken))
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(key, authnResponse.data.mfaToken);
                 }
@@ -173,13 +171,12 @@ namespace Snowflake.Data.Core
                 {
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(mfaKey);
                 }
@@ -251,13 +248,12 @@ namespace Snowflake.Data.Core
                 if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var _authenticatorType) &&
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     _mfaToken = SecureStringHelper.Encode(SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(mfaKey));
                 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -131,6 +131,7 @@ namespace Snowflake.Data.Core
                 if (bool.Parse(properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]) &&
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
+                    // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                     var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
                         idp: properties[SFSessionProperty.HOST],
@@ -143,6 +144,7 @@ namespace Snowflake.Data.Core
                 if (!string.IsNullOrEmpty(authnResponse.data.mfaToken))
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
+                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
                         idp: properties[SFSessionProperty.HOST],
@@ -171,6 +173,7 @@ namespace Snowflake.Data.Core
                 {
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
+                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
                         idp: properties[SFSessionProperty.HOST],
@@ -248,6 +251,7 @@ namespace Snowflake.Data.Core
                 if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var _authenticatorType) &&
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
+                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
                         idp: properties[SFSessionProperty.HOST],

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Core
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
                     var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -144,7 +144,7 @@ namespace Snowflake.Data.Core
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
                     var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -172,7 +172,7 @@ namespace Snowflake.Data.Core
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -249,7 +249,7 @@ namespace Snowflake.Data.Core
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -131,26 +131,14 @@ namespace Snowflake.Data.Core
                 if (bool.Parse(properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]) &&
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
-                    var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
-                        idp: "",
-                        snowflake: properties[SFSessionProperty.HOST],
-                        username: properties[SFSessionProperty.USER],
-                        role: ""
-                    ));
-                    SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(idTokenKey, authnResponse.data.idToken);
+                    SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(
+                        BuildTokenCacheKey(TokenType.IdToken), authnResponse.data.idToken);
                 }
                 if (!string.IsNullOrEmpty(authnResponse.data.mfaToken))
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
-                    var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
-                        idp: "",
-                        snowflake: properties[SFSessionProperty.HOST],
-                        username: properties[SFSessionProperty.USER],
-                        role: ""
-                    ));
-                    SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(key, authnResponse.data.mfaToken);
+                    SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(
+                        BuildTokenCacheKey(TokenType.MFAToken), authnResponse.data.mfaToken);
                 }
                 logger.Debug($"Session opened: {sessionId}");
                 _startTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -171,14 +159,8 @@ namespace Snowflake.Data.Core
                 {
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
-                    var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
-                        idp: "",
-                        snowflake: properties[SFSessionProperty.HOST],
-                        username: properties[SFSessionProperty.USER],
-                        role: ""
-                    ));
-                    SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(mfaKey);
+                    SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(
+                        BuildTokenCacheKey(TokenType.MFAToken));
                 }
                 throw e;
             }
@@ -248,14 +230,8 @@ namespace Snowflake.Data.Core
                 if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var _authenticatorType) &&
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
-                    var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
-                        idp: "",
-                        snowflake: properties[SFSessionProperty.HOST],
-                        username: properties[SFSessionProperty.USER],
-                        role: ""
-                    ));
-                    _mfaToken = SecureStringHelper.Encode(SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(mfaKey));
+                    _mfaToken = SecureStringHelper.Encode(
+                        SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(BuildTokenCacheKey(TokenType.MFAToken)));
                 }
             }
             catch (SnowflakeDbException e)
@@ -843,5 +819,13 @@ namespace Snowflake.Data.Core
         internal virtual bool IsInvalidatedForPooling() => _invalidatedForPooling;
 
         internal virtual bool IsClientTelemetryEnabled() => !string.IsNullOrEmpty(sessionId) && _isClientTelemetryEnabled;
+
+        private string BuildTokenCacheKey(TokenType tokenType) =>
+            SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                TokenType: tokenType.ToCacheKeyPrefix(),
+                Idp: "",
+                SnowflakeUrl: properties[SFSessionProperty.HOST],
+                Username: properties[SFSessionProperty.USER],
+                Role: ""));
     }
 }

--- a/doc/Client/Cache.md
+++ b/doc/Client/Cache.md
@@ -59,6 +59,36 @@ SnowflakeCredentialManagerFactory.UseFileCredentialManager();
 SnowflakeCredentialManagerFactory.SetCredentialManager(CustomCredentialManagerImplementation);
 ```
 
+A custom implementation receives the cache key as an opaque string. The key format is the same for every backend.
+
+### Cache Keys
+
+Cached tokens are stored under a versioned key, used by the Windows Credential Manager, file-based, in-memory, and custom backends:
+
+```
+SnowflakeTokenCache.v2.<TokenType>.<sha256>
+```
+
+`<TokenType>` is a readable PascalCase label so you can tell token classes apart without decoding the hash:
+
+| Token type | Used for |
+|------------|----------|
+| `IdToken` | SSO (`externalbrowser`) |
+| `MfaToken` | MFA (`username_password_mfa`) |
+| `OauthAccessToken` | OAuth authorization code access token |
+| `OauthRefreshToken` | OAuth authorization code refresh token |
+
+The hash is SHA-256 of a canonical JSON object (`keyData`). Which fields go into `keyData` depends on the flow:
+
+- **OAuth:** `idp`, `role`, `snowflake`, `username`
+- **SSO and MFA:** `snowflake`, `username` (`idp` and `role` are not used)
+
+`snowflake` is the Snowflake host from the connection. For OAuth, `idp` is the token request URL of the Identity Provider.
+
+User and role values are lowercased unless they contain a double quote (`"`), in which case they are stored exactly as provided (including SQL `""` escaped quotes). Host and IdP URLs have the scheme and any userinfo stripped, then are lowercased.
+
+Tokens written with the previous key format are not migrated. After upgrading the driver, the first authentication for each identity prompts again and writes a new cache entry.
+
 ## Certificate Revocation List (CRL) Caching
 
 Starting with version 5.0.0, Snowflake .NET driver uses by default a new algorithm for Certificate Revocation List-driven revocation checks.

--- a/doc/Client/Connecting.md
+++ b/doc/Client/Connecting.md
@@ -108,6 +108,7 @@ var connectionString = "account=testaccount;db=\"\"\"test\"\"db\"\"\";";
   A browser is opened for the authorization endpoint; after the user authenticates, the driver exchanges the authorization code for an access token.
 
   Tokens are cached when `CLIENT_STORE_TEMPORARY_CREDENTIAL=true` (default on Windows, `false` on Mac/Linux), reducing repeated browser interactions.
+  Cached access and refresh tokens are scoped to the Identity Provider, Snowflake host, user, and role, so switching any of those uses a separate cache entry.
 
   ```csharp
   using var conn = new SnowflakeDbConnection();
@@ -196,6 +197,8 @@ var connectionString = "account=testaccount;db=\"\"\"test\"\"db\"\"\";";
   ```
 
   Override the default browser timeout with `BROWSER_RESPONSE_TIMEOUT` (in seconds).
+
+  SSO ID tokens are cached when `CLIENT_STORE_TEMPORARY_CREDENTIAL=true` (default on Windows, `false` on Mac/Linux). Cache entries are scoped to the Snowflake host and user.
 
   Note: On Mac/Linux the browser is started via `open`/`xdg-open`. Ensure the command is on your `PATH`.
 
@@ -318,7 +321,7 @@ Special characters in TOML values:
 | EXPIRATIONTIMEOUT                 | 🟢 Optional | Maximum lifetime of a pooled connection. Supports units: `360000ms`, `3600s`, `60m` (default unit: seconds). Default: 1 hour. Set to `0` for immediate expiration. |
 | POOLINGENABLED                    | 🟢 Optional | Enable or disable connection pooling. Default: `true`. |
 | DISABLE_SAML_URL_CHECK            | 🟢 Optional | Skip SAML postback URL validation against the connection string host. Default: `false`. |
-| CLIENT_STORE_TEMPORARY_CREDENTIAL | 🟢 Optional | Cache tokens for external browser or OAuth authorization code flow. Default: `true`. |
+| CLIENT_STORE_TEMPORARY_CREDENTIAL | 🟢 Optional | Cache tokens for external browser or OAuth authorization code flow. Default: `true` on Windows, `false` on Linux and Mac. MFA (`username_password_mfa`) caching is always enabled. See [Cache](Cache.md). |
 | PASSCODE                          | 🟢 Optional | Passcode from a 2FA application for Multi-Factor Authentication. |
 | PASSCODEINPASSWORD                | 🟢 Optional | Whether the MFA passcode is appended to the password. |
 | OAUTHCLIENTID                     | 🔶 Depends | Client ID for OAuth flows. Required for OAuth Authorization Code Flow and OAuth Client Credentials Flow. Auto-filled with `LOCAL_APPLICATION` for Snowflake-provided OAuth when neither OAUTHCLIENTID nor OAUTHCLIENTSECRET are set. |


### PR DESCRIPTION
Introduce a versioned v2 token cache key format to fix two classes of collision:

1. **Multi-account / multi-role collisions** — OAuth flows now include `idp`, `role`, `snowflake`, and `username` in a flow-specific `keyData` map; MFA/ID flows include only `snowflake` and `username`.
2. **Case-sensitivity normalization** — all identifiers are lowercased (unquoted) or returned verbatim (any `"` present, including SQL `""` escaped quotes). URLs are lowercased after scheme and userinfo stripping.

### Key format

```
SnowflakeTokenCache.v2.<PascalCaseType>.<sha256hex(canonical_json(keyData))>
```

- `PascalCaseType`: `MfaToken`, `IdToken`, `OauthAccessToken`, `OauthRefreshToken`, `DpopBundledAccessToken`
- `keyData` fields sorted alphabetically; serialised as compact JSON before hashing.
- Applied uniformly across Windows Credential Manager and file backends.

### Golden test vectors (must not change)

- **A** (OAuth/DPoP): `SnowflakeTokenCache.v2.DpopBundledAccessToken.741b6d66d252666d6821bfd19e0151511cf4efdaaeba2b3c87673aa4de6d2c0b`
- **B** (MFA): `SnowflakeTokenCache.v2.MfaToken.10c5dde84bb8f584c0df06ea826d418c4f580e08f9db10187c0cb5e2a732a0d6`

### Changes

- `SnowflakeCredentialManagerFactory`: `CacheKeyInput` positional record, `BuildCacheKey`, `NormalizeUrl`, `NormalizeIdentifier`, `ToSha256HashLower`; removed obsolete `GetSecureCredentialKey`.
- `SFSession`: `BuildTokenCacheKey(TokenType)` helper replaces four inline `CacheKeyInput` constructions.
- `ExternalBrowserAuthenticator`: `BuildIdTokenCacheKey()` helper.
- `OAuthCacheKeys`: uses full `idp` + `role` for OAuth flows.
- `IsExternalInit.cs` shim for `readonly record struct` on net481/netstandard2.0.
- Unit tests: golden vectors A & B, dimension-isolation tests, `NormalizeUrl`/`NormalizeIdentifier` edge cases.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name