### PR TITLE
SNOW-3784414: token cache key v2 fixup — type in prefix, flow-specifi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 # Changelog
 - v5.9.0
     - Fixed token cache key collisions for multi-account (shared IdP) and multi-role
-      scenarios by switching to a versioned, SHA256-hashed canonical-JSON key applied
-      uniformly across Windows Credential Manager and file backends.
+      scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the
+      token type in the key prefix, applied uniformly across Windows Credential Manager
+      and file backends.
 - v5.8.0
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
       scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the
       token type in the key prefix, applied uniformly across Windows Credential Manager
       and file backends.
+    - Fixed token cache key normalization to use lowercase for consistency with
+      case-insensitive Snowflake identifiers; token type in the key prefix now uses
+      PascalCase (`MfaToken`, `OauthAccessToken`) instead of `SCREAMING_SNAKE_CASE`.
 - v5.8.0
   -  Added `AllowNumberOverflowAsString` connection property. When set to `true`, numeric values that exceed the range of `System.Decimal` (or a narrower integer type) are returned as strings from `GetValue()` instead of throwing `OverflowException`.
   -  Reduced synchronization context capture in library, minimizing the risk of deadlock occurrence across different code path executions.

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -10,31 +10,48 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
     public class SnowflakeCredentialManagerFactoryTest : IDisposable
     {
         [SFFact]
-        public void TestBuildCacheKeyGoldenHash()
+        public void TestBuildCacheKeyGoldenHashA_OAuth()
         {
-            // quoted segments are preserved verbatim by NormalizeIdentifier — pre-uppercase them to match the expected hash
+            // Vector A: OAuth flow — 4-field keyData, mixed-case quoted segments preserved verbatim.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                 tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
                 idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
-                username: "\"FIRST LAST\"@long-corporate-domain.example.com",
-                role: "\"ANALYST ROLE WITH SPACES\":north_america:prod:readonly"
+                username: "\"First Last\"@long-corporate-domain.example.com",
+                role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.75ff2ad65a68afb402f125f62894697673c5ef3d863aba466d16b7a81053d1f4", key);
+            Assert.Equal("SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f", key);
+        }
+
+        [SFFact]
+        public void TestBuildCacheKeyGoldenHashB_Mfa()
+        {
+            // Vector B: MFA flow — 2-field keyData (snowflake + username only), mixed-case quoted segment preserved.
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                tokenType: "MFA_TOKEN",
+                idp: "",
+                snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+                username: "\"First Last\"@long-corporate-domain.example.com",
+                role: ""
+            ));
+            Assert.Equal("SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHasCorrectPrefix()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            Assert.StartsWith("SnowflakeTokenCache.v2.", key);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            Assert.StartsWith("SnowflakeTokenCache.v2.MFA_TOKEN.", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHashIsLowercaseHex()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            var hash = key.Substring("SnowflakeTokenCache.v2.".Length);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var segments = key.Split('.');
+            // Format: SnowflakeTokenCache.v2.<TOKEN_TYPE>.<hash>
+            Assert.Equal(4, segments.Length);
+            var hash = segments[3];
             Assert.Equal(64, hash.Length);
             Assert.Equal(hash, hash.ToLowerInvariant());
         }
@@ -42,19 +59,24 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenSnowflakeEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "", "user", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "", "user", "")));
         }
 
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenUsernameEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "idp", "snowflake", "", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "", "")));
         }
 
         [SFFact]
-        public void TestBuildCacheKeyThrowsWhenIdpEmpty()
+        public void TestDimensionIsolationMfaVsOAuth()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "user", "")));
+            // MFA and OAuth for the same user/host must produce different keys (different prefix + field set).
+            var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                "MFA_TOKEN", "", "acct.snowflakecomputing.com", "user", ""));
+            var oauthKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
+                "OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
+            Assert.NotEqual(mfaKey, oauthKey);
         }
 
         [SFFact]
@@ -85,8 +107,8 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyIsDeterministic()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "host.snowflake.com", "host.snowflake.com", "user", ""));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
             Assert.Equal(key1, key2);
         }
 

--- a/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/CredentialManager/SnowflakeCredentialManagerFactoryTest.cs
@@ -12,44 +12,45 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyGoldenHashA_OAuth()
         {
-            // Vector A: OAuth flow — 4-field keyData, mixed-case quoted segments preserved verbatim.
+            // Vector A: OAuth flow — 4-field keyData, lowercase normalization, quoted values verbatim.
+            // "DpopBundledAccessToken" passed directly — no named constant for this type.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
+                tokenType: "DpopBundledAccessToken",
                 idp: "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
                 username: "\"First Last\"@long-corporate-domain.example.com",
                 role: "\"Analyst Role With Spaces\":north_america:prod:readonly"
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f", key);
+            Assert.Equal("SnowflakeTokenCache.v2.DpopBundledAccessToken.741b6d66d252666d6821bfd19e0151511cf4efdaaeba2b3c87673aa4de6d2c0b", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyGoldenHashB_Mfa()
         {
-            // Vector B: MFA flow — 2-field keyData (snowflake + username only), mixed-case quoted segment preserved.
+            // Vector B: MFA flow — 2-field keyData, lowercase normalization, quoted username verbatim.
             var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                tokenType: "MFA_TOKEN",
+                tokenType: "MfaToken",
                 idp: "",
                 snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
                 username: "\"First Last\"@long-corporate-domain.example.com",
                 role: ""
             ));
-            Assert.Equal("SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8", key);
+            Assert.Equal("SnowflakeTokenCache.v2.MfaToken.10c5dde84bb8f584c0df06ea826d418c4f580e08f9db10187c0cb5e2a732a0d6", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHasCorrectPrefix()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
-            Assert.StartsWith("SnowflakeTokenCache.v2.MFA_TOKEN.", key);
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            Assert.StartsWith("SnowflakeTokenCache.v2.MfaToken.", key);
         }
 
         [SFFact]
         public void TestBuildCacheKeyHashIsLowercaseHex()
         {
-            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
             var segments = key.Split('.');
-            // Format: SnowflakeTokenCache.v2.<TOKEN_TYPE>.<hash>
+            // Format: SnowflakeTokenCache.v2.<TokenType>.<hash>
             Assert.Equal(4, segments.Length);
             var hash = segments[3];
             Assert.Equal(64, hash.Length);
@@ -59,13 +60,13 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenSnowflakeEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "", "user", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "", "user", "")));
         }
 
         [SFFact]
         public void TestBuildCacheKeyThrowsWhenUsernameEmpty()
         {
-            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "snowflake", "", "")));
+            Assert.Throws<ArgumentException>(() => SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "snowflake", "", "")));
         }
 
         [SFFact]
@@ -73,25 +74,25 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         {
             // MFA and OAuth for the same user/host must produce different keys (different prefix + field set).
             var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                "MFA_TOKEN", "", "acct.snowflakecomputing.com", "user", ""));
+                "MfaToken", "", "acct.snowflakecomputing.com", "user", ""));
             var oauthKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                "OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
+                "OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", ""));
             Assert.NotEqual(mfaKey, oauthKey);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentSnowflakeHost()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct2.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct1.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct2.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentRole()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ANALYST"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "ENGINEER"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "analyst"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "engineer"));
             Assert.NotEqual(key1, key2);
         }
 
@@ -99,88 +100,99 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         public void TestDimensionIsolationDifferentIdp()
         {
             // Same Snowflake account and user, different IdP — the multi-account/shared-IdP collision case.
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantA", "acct.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "login.microsoftonline.com/tenantB", "acct.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "login.microsoftonline.com/tenantA", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "login.microsoftonline.com/tenantB", "acct.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestBuildCacheKeyIsDeterministic()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MFA_TOKEN", "", "host.snowflake.com", "user", ""));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("MfaToken", "", "host.snowflake.com", "user", ""));
             Assert.Equal(key1, key2);
         }
 
         [SFFact]
         public void TestDimensionIsolationDifferentTokenType()
         {
-            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_ACCESS_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
-            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OAUTH_REFRESH_TOKEN", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            var key1 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthAccessToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
+            var key2 = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput("OauthRefreshToken", "idp.example.com", "acct.snowflakecomputing.com", "user", "role"));
             Assert.NotEqual(key1, key2);
         }
 
         [SFFact]
         public void TestNormalizeUrlStripsScheme()
         {
-            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://example.com/path"));
-            Assert.Equal("EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("http://example.com/path"));
+            Assert.Equal("example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://example.com/path"));
+            Assert.Equal("example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("http://example.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlStripsUserinfo()
         {
-            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
-            Assert.Equal("HOST.EXAMPLE.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.example.com/path"));
+            Assert.Equal("host.com", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.com"));
+            Assert.Equal("host.example.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://user:pass@host.example.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlPreservesAtSignInPath()
         {
             // An '@' after the authority is part of the path and must survive; only userinfo is stripped.
-            Assert.Equal("HOST.EXAMPLE.COM/OAUTH/@HANDLE/TOKEN",
+            Assert.Equal("host.example.com/oauth/@handle/token",
                 SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.example.com/oauth/@handle/token"));
         }
 
         [SFFact]
         public void TestNormalizeUrlDropsQueryAndFragment()
         {
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?q=1#frag"));
             // An '@' inside the dropped query string must not be mistaken for userinfo.
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?email=user@domain.com"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path?email=user@domain.com"));
         }
 
         [SFFact]
         public void TestNormalizeUrlTrimsRootOnlyTrailingSlash()
         {
-            Assert.Equal("HOST.COM", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/"));
-            Assert.Equal("HOST.COM/PATH", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path"));
+            Assert.Equal("host.com", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/"));
+            Assert.Equal("host.com/path", SnowflakeCredentialManagerFactory.NormalizeUrl("https://host.com/path"));
         }
 
         [SFFact]
         public void TestNormalizeUrlPreservesPortAndPath()
         {
-            Assert.Equal("LOGIN.MICROSOFTONLINE.COM:443/TENANT-ID/OAUTH2/V2.0",
+            Assert.Equal("login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
                 SnowflakeCredentialManagerFactory.NormalizeUrl("https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierUnquotedIsUppercased()
+        public void TestNormalizeIdentifierUnquotedIsLowercased()
         {
-            Assert.Equal("USER@DOMAIN.COM", SnowflakeCredentialManagerFactory.NormalizeIdentifier("user@domain.com"));
+            Assert.Equal("user@domain.com", SnowflakeCredentialManagerFactory.NormalizeIdentifier("USER@DOMAIN.COM"));
+            Assert.Equal("analyst_role", SnowflakeCredentialManagerFactory.NormalizeIdentifier("ANALYST_ROLE"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierQuotedSegmentPreservedVerbatim()
+        public void TestNormalizeIdentifierQuotedValueIsVerbatim()
         {
-            Assert.Equal("\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM",
+            // Any double-quote anywhere in the value → return verbatim, unchanged.
+            Assert.Equal("\"First Last\"@long-corporate-domain.example.com",
                 SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"First Last\"@long-corporate-domain.example.com"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierMixedQuotedAndUnquoted()
+        public void TestNormalizeIdentifierQuotedValueNotAtStart()
         {
-            Assert.Equal("\"Analyst Role With Spaces\":NORTH_AMERICA:PROD:READONLY",
+            // A quote that is NOT at position 0 still triggers the verbatim path.
+            Assert.Equal("prefix-\"seg\"",
+                SnowflakeCredentialManagerFactory.NormalizeIdentifier("prefix-\"seg\""));
+        }
+
+        [SFFact]
+        public void TestNormalizeIdentifierMixedQuotedAndUnquotedIsVerbatim()
+        {
+            // Contains quotes → entire value returned verbatim (mixed case preserved).
+            Assert.Equal("\"Analyst Role With Spaces\":north_america:prod:readonly",
                 SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Analyst Role With Spaces\":north_america:prod:readonly"));
         }
 
@@ -191,18 +203,18 @@ namespace Snowflake.Data.Tests.UnitTests.CredentialManager
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierUppercasesAsciiOnly()
+        public void TestNormalizeIdentifierLowercasesNonAscii()
         {
-            // Matches the reference's ASCII-only case-folding: non-ASCII letters are left unchanged
-            // so keys stay byte-identical across drivers.
-            Assert.Equal("CAF\u00e9", SnowflakeCredentialManagerFactory.NormalizeIdentifier("caf\u00e9"));
-            Assert.Equal("STRA\u00dfE", SnowflakeCredentialManagerFactory.NormalizeIdentifier("stra\u00dfe"));
+            // No quotes → ToLowerInvariant applied to all characters.
+            Assert.Equal("caf\u00e9", SnowflakeCredentialManagerFactory.NormalizeIdentifier("caf\u00e9"));
+            Assert.Equal("stra\u00dfe", SnowflakeCredentialManagerFactory.NormalizeIdentifier("stra\u00dfe"));
         }
 
         [SFFact]
-        public void TestNormalizeIdentifierPreservesSqlEscapedQuotes()
+        public void TestNormalizeIdentifierSqlEscapedQuotesAreVerbatim()
         {
-            Assert.Equal("\"Foo\"\"Bar\":BAZ", SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Foo\"\"Bar\":baz"));
+            // SQL-escaped double-quote inside the value still triggers verbatim path.
+            Assert.Equal("\"Foo\"\"Bar\":baz", SnowflakeCredentialManagerFactory.NormalizeIdentifier("\"Foo\"\"Bar\":baz"));
         }
 
 

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -41,8 +41,14 @@ namespace Snowflake.Data.Client
         private static ISnowflakeCredentialManager s_credentialManager = s_defaultCredentialManager;
 
         /// <summary>
-        /// Builds a v2 token cache key: <c>SnowflakeTokenCache.v2.&lt;sha256hex(canonical_json)&gt;</c>.
-        /// All inputs are normalized before hashing.
+        /// Builds a v2 token cache key:
+        /// <c>SnowflakeTokenCache.v2.&lt;TOKEN_TYPE&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
+        /// The token type appears in the readable prefix so keystore tooling can identify token
+        /// classes without decoding the opaque hash. <c>keyData</c> is flow-specific and never
+        /// contains <c>token_type</c>: OAuth flows include <c>idp</c>, <c>role</c>,
+        /// <c>snowflake</c>, and <c>username</c>; MFA and ID token flows include only
+        /// <c>snowflake</c> and <c>username</c> (role is not embedded in those auth calls and
+        /// authentication always targets the Snowflake host directly).
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
@@ -50,23 +56,34 @@ namespace Snowflake.Data.Client
                 throw new ArgumentException("snowflake URL must not be empty");
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
-            // An empty idp would silently collapse the cross-IdP dimension of the key and
-            // reintroduce the collision class this format guards against, so it is rejected.
-            if (string.IsNullOrEmpty(input.Idp))
-                throw new ArgumentException("idp must not be empty");
 
-            var keyData = new SortedDictionary<string, string>
+            bool isOAuth = input.TokenType is "OAUTH_ACCESS_TOKEN"
+                            or "OAUTH_REFRESH_TOKEN"
+                            or "DPOP_BUNDLED_ACCESS_TOKEN";
+
+            SortedDictionary<string, string> keyData;
+            if (isOAuth)
             {
-                ["idp"]        = NormalizeUrl(input.Idp),
-                ["role"]       = NormalizeIdentifier(input.Role),
-                ["snowflake"]  = NormalizeUrl(input.SnowflakeUrl),
-                ["token_type"] = input.TokenType,
-                ["username"]   = NormalizeIdentifier(input.Username),
-            };
+                keyData = new SortedDictionary<string, string>
+                {
+                    ["idp"]       = NormalizeUrl(input.Idp),
+                    ["role"]      = NormalizeIdentifier(input.Role),
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"]  = NormalizeIdentifier(input.Username),
+                };
+            }
+            else  // MFA_TOKEN, ID_TOKEN
+            {
+                keyData = new SortedDictionary<string, string>
+                {
+                    ["snowflake"] = NormalizeUrl(input.SnowflakeUrl),
+                    ["username"]  = NormalizeIdentifier(input.Username),
+                };
+            }
 
             string json = JsonConvert.SerializeObject(keyData, Formatting.None);
             string hash = ToSha256HashLower(json);
-            return $"SnowflakeTokenCache.v2.{hash}";
+            return $"SnowflakeTokenCache.v2.{input.TokenType}.{hash}";
         }
 
         /// <summary>

--- a/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
+++ b/Snowflake.Data/Client/SnowflakeCredentialManagerFactory.cs
@@ -42,13 +42,12 @@ namespace Snowflake.Data.Client
 
         /// <summary>
         /// Builds a v2 token cache key:
-        /// <c>SnowflakeTokenCache.v2.&lt;TOKEN_TYPE&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
-        /// The token type appears in the readable prefix so keystore tooling can identify token
-        /// classes without decoding the opaque hash. <c>keyData</c> is flow-specific and never
-        /// contains <c>token_type</c>: OAuth flows include <c>idp</c>, <c>role</c>,
-        /// <c>snowflake</c>, and <c>username</c>; MFA and ID token flows include only
-        /// <c>snowflake</c> and <c>username</c> (role is not embedded in those auth calls and
-        /// authentication always targets the Snowflake host directly).
+        /// <c>SnowflakeTokenCache.v2.&lt;TokenType&gt;.&lt;sha256hex(canonical_json(keyData))&gt;</c>.
+        /// The PascalCase token type appears in the readable prefix so keystore tooling can
+        /// identify token classes without decoding the opaque hash. <c>keyData</c> is
+        /// flow-specific and never contains the token type: OAuth flows include <c>idp</c>,
+        /// <c>role</c>, <c>snowflake</c>, and <c>username</c> (all lowercased); MFA and ID
+        /// token flows include only <c>snowflake</c> and <c>username</c>.
         /// </summary>
         internal static string BuildCacheKey(CacheKeyInput input)
         {
@@ -57,9 +56,9 @@ namespace Snowflake.Data.Client
             if (string.IsNullOrEmpty(input.Username))
                 throw new ArgumentException("username must not be empty");
 
-            bool isOAuth = input.TokenType is "OAUTH_ACCESS_TOKEN"
-                            or "OAUTH_REFRESH_TOKEN"
-                            or "DPOP_BUNDLED_ACCESS_TOKEN";
+            bool isOAuth = input.TokenType is "OauthAccessToken"
+                            or "OauthRefreshToken"
+                            or "DpopBundledAccessToken";
 
             SortedDictionary<string, string> keyData;
             if (isOAuth)
@@ -87,7 +86,7 @@ namespace Snowflake.Data.Client
         }
 
         /// <summary>
-        /// Strips the scheme and any userinfo prefix, drops query and fragment, then uppercases the
+        /// Strips the scheme and any userinfo prefix, drops query and fragment, then lowercases the
         /// remaining authority (host and any explicitly-stated port) and path, trimming trailing slashes.
         /// The raw string is used (not a parsed URL) so an explicit default port such as <c>:443</c> is preserved.
         /// </summary>
@@ -113,26 +112,21 @@ namespace Snowflake.Data.Client
             if (atIdx >= 0)
                 authority = authority.Substring(atIdx + 1);
 
-            return (authority + path).TrimEnd('/').ToUpperInvariant();
+            return (authority + path).TrimEnd('/').ToLowerInvariant();
         }
 
         /// <summary>
-        /// Uppercases unquoted segments (ASCII only, matching Snowflake identifier case-folding);
-        /// preserves the content of double-quoted segments verbatim (including surrounding quotes).
+        /// Normalizes a Snowflake identifier for use as a cache key field.
+        /// If the value contains any double-quote character (<c>"</c>), it is returned
+        /// verbatim — the quotes signal case-sensitive SQL semantics that must not be altered.
+        /// Otherwise the entire value is lowercased: unquoted identifiers are case-insensitive
+        /// in Snowflake so lowercasing produces a stable canonical form.
         /// </summary>
         internal static string NormalizeIdentifier(string identifier)
         {
             if (string.IsNullOrEmpty(identifier))
                 return string.Empty;
-            var sb = new StringBuilder(identifier.Length);
-            bool inQuotes = false;
-            foreach (char c in identifier)
-            {
-                if (c == '"') { inQuotes = !inQuotes; sb.Append(c); }
-                else if (inQuotes) sb.Append(c);
-                else sb.Append(c >= 'a' && c <= 'z' ? (char)(c - ('a' - 'A')) : c);
-            }
-            return sb.ToString();
+            return identifier.Contains("\"") ? identifier : identifier.ToLowerInvariant();
         }
 
         private static string ToSha256HashLower(string text)

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -58,7 +58,7 @@ namespace Snowflake.Data.Core.Authenticator
             {
                 var host = session.properties[SFSessionProperty.HOST];
                 _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
                     idp: "",
                     snowflake: host,
                     username: user,

--- a/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
+++ b/Snowflake.Data/Core/Authenticator/ExternalBrowserAuthenticator.cs
@@ -57,14 +57,12 @@ namespace Snowflake.Data.Core.Authenticator
             if (!string.IsNullOrEmpty(user) && clientStoreTemporaryCredential)
             {
                 var host = session.properties[SFSessionProperty.HOST];
-                session.properties.TryGetValue(SFSessionProperty.ROLE, out var role);
-                // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                 _idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                     tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
-                    idp: host,
+                    idp: "",
                     snowflake: host,
                     username: user,
-                    role: role ?? string.Empty
+                    role: ""
                 ));
             }
         }

--- a/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
+++ b/Snowflake.Data/Core/Authenticator/OAuthCacheKeys.cs
@@ -20,14 +20,14 @@ namespace Snowflake.Data.Core.Authenticator
             if (IsCacheAvailableForAuthorizationCodeFlow(user, clientStoreTemporaryCredentials, true))
             {
                 accessTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthAccessToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.OAuthAccessToken.ToCacheKeyPrefix(),
                     idp: idpUrl,
                     snowflake: snowflakeHost,
                     username: user,
                     role: role ?? string.Empty
                 ));
                 refreshTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                    tokenType: TokenType.OAuthRefreshToken.GetAttribute<StringAttr>().value,
+                    tokenType: TokenType.OAuthRefreshToken.ToCacheKeyPrefix(),
                     idp: idpUrl,
                     snowflake: snowflakeHost,
                     username: user,

--- a/Snowflake.Data/Core/CredentialManager/TokenType.cs
+++ b/Snowflake.Data/Core/CredentialManager/TokenType.cs
@@ -11,4 +11,22 @@ namespace Snowflake.Data.Core.CredentialManager
         [StringAttr(value = "OAUTH_REFRESH_TOKEN")]
         OAuthRefreshToken
     }
+
+    internal static class TokenTypeExtensions
+    {
+        /// <summary>
+        /// Returns the PascalCase token-type string used as the third segment of the
+        /// cache key prefix (<c>SnowflakeTokenCache.v2.&lt;TokenType&gt;.&lt;hash&gt;</c>).
+        /// This is distinct from <c>GetAttribute&lt;StringAttr&gt;().value</c>, which returns
+        /// the REST-protocol wire value and must not be used to build cache keys.
+        /// </summary>
+        internal static string ToCacheKeyPrefix(this TokenType tokenType) => tokenType switch
+        {
+            TokenType.IdToken          => "IdToken",
+            TokenType.MFAToken         => "MfaToken",
+            TokenType.OAuthAccessToken => "OauthAccessToken",
+            TokenType.OAuthRefreshToken => "OauthRefreshToken",
+            _ => throw new System.ArgumentOutOfRangeException(nameof(tokenType), tokenType, "Unknown TokenType")
+        };
+    }
 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -131,26 +131,24 @@ namespace Snowflake.Data.Core
                 if (bool.Parse(properties[SFSessionProperty.CLIENT_STORE_TEMPORARY_CREDENTIAL]) &&
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
-                    // Native SSO: Snowflake acts as its own IdP, so idp and snowflake are both the server host.
                     var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: properties.TryGetValue(SFSessionProperty.ROLE, out var idTokenRole) ? idTokenRole : string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(idTokenKey, authnResponse.data.idToken);
                 }
                 if (!string.IsNullOrEmpty(authnResponse.data.mfaToken))
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().SaveCredentials(key, authnResponse.data.mfaToken);
                 }
@@ -173,13 +171,12 @@ namespace Snowflake.Data.Core
                 {
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     SnowflakeCredentialManagerFactory.GetCredentialManager().RemoveCredentials(mfaKey);
                 }
@@ -251,13 +248,12 @@ namespace Snowflake.Data.Core
                 if (properties.TryGetValue(SFSessionProperty.AUTHENTICATOR, out var _authenticatorType) &&
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
-                    // MFA: Snowflake is the IdP; role is not part of the MFA cache key.
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
                         tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
-                        idp: properties[SFSessionProperty.HOST],
+                        idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
-                        role: string.Empty
+                        role: ""
                     ));
                     _mfaToken = SecureStringHelper.Encode(SnowflakeCredentialManagerFactory.GetCredentialManager().GetCredentials(mfaKey));
                 }

--- a/Snowflake.Data/Core/Session/SFSession.cs
+++ b/Snowflake.Data/Core/Session/SFSession.cs
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Core
                     !string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(authnResponse.data.idToken))
                 {
                     var idTokenKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.IdToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.IdToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -144,7 +144,7 @@ namespace Snowflake.Data.Core
                 {
                     _mfaToken = SecureStringHelper.Encode(authnResponse.data.mfaToken);
                     var key = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -172,7 +172,7 @@ namespace Snowflake.Data.Core
                     logger.Info($"Unable to use cached MFA token is expired or invalid. Fails with the {e.Message}. ", e);
                     _mfaToken = null;
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],
@@ -249,7 +249,7 @@ namespace Snowflake.Data.Core
                     MFACacheAuthenticator.IsMfaCacheAuthenticator(_authenticatorType))
                 {
                     var mfaKey = SnowflakeCredentialManagerFactory.BuildCacheKey(new CacheKeyInput(
-                        tokenType: TokenType.MFAToken.GetAttribute<StringAttr>().value,
+                        tokenType: TokenType.MFAToken.ToCacheKeyPrefix(),
                         idp: "",
                         snowflake: properties[SFSessionProperty.HOST],
                         username: properties[SFSessionProperty.USER],


### PR DESCRIPTION
…c keyData

- Move token_type out of keyData JSON and into the readable key prefix (SnowflakeTokenCache.v2.<TOKEN_TYPE>.<hash>), allowing keystore tooling to identify and remove token classes without decoding the opaque hash.
- MFA_TOKEN and ID_TOKEN paths now include only snowflake + username in keyData; idp and role are absent because role is not embedded in those auth calls and the target is always the Snowflake host directly.
- OAuth paths continue to include idp, role, snowflake, username (4 fields).
- Remove the ArgumentException guard that rejected empty idp — MFA/ID flows intentionally pass idp="" and the new flow-dispatch handles it.
- Update all MFA and ID token call sites in SFSession.cs and ExternalBrowserAuthenticator.cs to pass idp="" and role="".
- Replace the old 5-field golden-hash test with Vector A (OAuth / DPOP_BUNDLED_ACCESS_TOKEN) and Vector B (MFA_TOKEN), both using mixed-case quoted identifiers to exercise the quote-preservation branch of NormalizeIdentifier.
- Add TestDimensionIsolationMfaVsOAuth to confirm MFA and OAuth keys for the same user/host differ (different prefix + field set).
- Update CHANGELOG.md bug-fix entry to mention the token type prefix.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
