### PR TITLE
Bump dependencies for 6.0.0 release

### DIFF
--- a/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFBindTestIT.cs
@@ -929,7 +929,7 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 await conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
                 conn.ExecuteNonQuery($"alter session set DOTNET_QUERY_RESULT_FORMAT = {resultFormat}");
-                if (!timeZone.IsNullOrEmpty()) // Driver ignores this setting and relies on local environment timezone
+                if (!string.IsNullOrEmpty(timeZone)) // Driver ignores this setting and relies on local environment timezone
                     conn.ExecuteNonQuery($"alter session set TIMEZONE = '{timeZone}'");
 
                 // prepare initial column

--- a/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
+++ b/Snowflake.Data.Tests/IntegrationTests/SFConnectionWithTomlIT.cs
@@ -120,7 +120,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
             {
                 using (var writer = File.CreateText(filePath))
                 {
-                    writer.Write(Toml.FromModel(tomlModel));
+                    var fromModel = TomlSerializer.Serialize(tomlModel);
+                    writer.Write(fromModel);
                 }
             }
             else
@@ -132,7 +133,8 @@ namespace Snowflake.Data.Tests.IntegrationTests
                 Syscall.chmod(filePath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
                 using (var writer = File.CreateText(filePath))
                 {
-                    writer.Write(Toml.FromModel(tomlModel));
+                    var fromModel = TomlSerializer.Serialize(tomlModel);
+                    writer.Write(fromModel);
                 }
                 Syscall.chmod(filePath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
             }

--- a/Snowflake.Data.Tests/Mock/MockLoginMFATokenCacheRestRequester.cs
+++ b/Snowflake.Data.Tests/Mock/MockLoginMFATokenCacheRestRequester.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Snowflake.Data.Tests.Mock
             if (sfRequest.jsonBody is LoginRequest)
             {
                 LoginRequests.Enqueue((LoginRequest)sfRequest.jsonBody);
-                var responseData = this.LoginResponses.IsNullOrEmpty() ? new LoginResponseData()
+                var responseData = this.LoginResponses?.Any() != true ? new LoginResponseData()
                 {
                     token = "session_token",
                     masterToken = "master_token",

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -40,8 +40,6 @@
         <PackageReference Include="Serilog.Settings.Xml" Version="1.1.0"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageReference Include="Tomlyn.Signed" Version="0.17.0"/>
         <ProjectReference Include="..\Snowflake.Data\Snowflake.Data.csproj"/>
     </ItemGroup>
     <ItemGroup Condition="'$(OldXunit)' == 'True'">

--- a/Snowflake.Data/Core/TomlConnectionBuilder.cs
+++ b/Snowflake.Data/Core/TomlConnectionBuilder.cs
@@ -131,7 +131,7 @@ namespace Snowflake.Data.Core
             }
 
             var tomlContent = _fileOperations.ReadAllText(tomlPath, ValidateFilePermissions) ?? string.Empty;
-            var toml = Toml.ToModel(tomlContent);
+            var toml = TomlSerializer.Deserialize<TomlTable>(tomlContent);
             if (string.IsNullOrEmpty(connectionName))
             {
                 connectionName = _environmentFacade.GetString(EnvVars.DefaultConnectionName);

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -27,18 +27,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Arrow" Version="14.0.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.100.3" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Azure.Storage.Common" Version="12.12.0" />
+    <PackageReference Include="Apache.Arrow" Version="23.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.101.4" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.15.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
-    <PackageReference Include="Tomlyn.Signed" Version="0.17.0" />
+    <PackageReference Include="Tomlyn.Signed" Version="2.10.1" />
   </ItemGroup>
 
   <!-- Mono.Unix dependency ONLY for Unix/Linux platforms (netstandard2.0, net8.0 and net10.0) -->


### PR DESCRIPTION
### Description
Risk Assessment: Google.Cloud.Storage.V1 4.14.0 → 4.15.0:
Safe to upgrade. The change is purely additive (a new optional property on an existing options class). No dependency
   version floor jumps that would conflict with typical .NET projects.

Risk Analysis: Tomlyn.Signed 0.17.0 → 2.10.1
Complete API redesign: Toml.ToModel() → TomlSerializer.Deserialize<T>() ; removed legacy Toml facade; removed UTF-8 byte[] APIs; namespace changes = handled by - Toml.ToModel(tomlContent) → TomlSerializer.Deserialize<TomlTable>(tomlContent) change. Transparent to driver clients

Removed duplicate TomlPropertyNameAttribute (two definitions existed — one in root, one in Serialization namespace) - Not used in driver.

New transitive dep: System.Text.Json ≥ 10.0.2:
The new serializer may handle edge cases differently (e.g., integer overflow, date formats). For
  simple string/bool key-value parsing as used in TomlConnectionBuilder, this is low risk.

Risk Assessment: Azure.Storage.Blobs 12.13.0 → 12.29.1
Safe to upgrade. APIs being used (Upload, DownloadTo, GetProperties, BlobUploadOptions with metadata,
  AzureSasCredential) have no breaking changes across these 16 minor versions. 

Risk Assessment: System.IdentityModel.Tokens.Jwt 6.34.0 → 8.21.0
The driver's usage pattern (create JWT with RSA credentials, read JWT to extract issuer/subject) is
   the most basic and stable part of the API surface. No code changes needed. The main consideration is the expanded
  transitive dependency graph (System.Text.Json 8.0.5, Microsoft.Bcl.Cryptography) which slightly increases the
  package footprint.

Risk Assessment: AWSSDK.S3 upgrade from 4.0.100.3 →  4.0.101.4
Safe to upgrade. Breaking change in GetPreSignedURL which is not used by the driver. Only additive and bug fixing changes besides that.

Risk Assessmbent: Apache.Arrow 14.0.2 → 23.0.0
Changed affecting driver codebase:
new dependency: Apache.Arrow.Scalars:
Adds ~1 new DLL to output. Provides Parquet variant scalar types we don't use.

.net standard 1.3; netcoreapp 3.1; net6.0 tfms removes:
Our TFMs resolve to netstandard2.0 or net8.0 fine.

StringArray.GetString fix (GH-37861)  Fixed: returns "" instead of null for empty strings.  :
Our code already does string.IsNullOrEmpty(str) ? null : str so behavior is unchanged.

Decimal128 negation carry fix (GH-38481):
Fixed 2's complement carry for negative decimals. Our ExtractDecimal128CellAsString reads raw bytes via ValueBuffer.Span independently. The GetValue() path benefits from the fix.

This is a clean upgrade. Zero source changes required, zero behavioral regressions in unit tests. The library has
  been careful to keep additive-only changes for the APIs we consume. The main "cost" is an additional transitive
  dependency (Apache.Arrow.Scalars) that adds some package weight but nothing else.

### Checklist
- [ ] Code compiles correctly
- [ ] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`dotnet test`)
- [ ] Extended the README / documentation, if necessary
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in PR name
