### PR TITLE
SNOW-3857631 Write token cache as UTF-8 without BOM on Unix/macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   -  Bug fix: Fixed incorrect DateTime conversion for timestamps preceding Unix epoch (1970-01-01) when fractional seconds are
     present.
   -  Bug fix: Fixed an unnecessary second PUT (stage re-resolution) per file during GCS uploads when the server scopes upload credentials with an access token.
+  -  Bug fix: Token cache file on Linux/macOS is now written as UTF-8 without a BOM for cross-driver compatibility.
 - v5.7.0
     - Improved input handling in `ChangeDatabase` by using parameterized queries.
     - Improved input validation in `QueryResultsAwaiter` with stricter UUID format checks.

--- a/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
@@ -320,6 +320,22 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
         }
 
         [SFFact(SkipCondition.SkipOnWindows)]
+        public void TestWriteAllTextDoesNotEmitUtf8Bom()
+        {
+            // arrange
+            var content = "{\"token\":\"abc\"}";
+            var filePath = Path.Combine(_fixture.WorkingDirectory, $"no_bom_{Path.GetRandomFileName()}");
+
+            // act
+            _fixture.UnixOperations.WriteAllText(filePath, content, _ => { });
+
+            // assert
+            var bytes = File.ReadAllBytes(filePath);
+            Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+            Assert.Equal(content, _fixture.UnixOperations.ReadAllText(filePath, _ => { }));
+        }
+
+        [SFFact(SkipCondition.SkipOnWindows)]
         public void TestReadBytesFromEmptyFile()
         {
             // arrange

--- a/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/Tools/UnixOperationsTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security;
+using System.Text;
 using Mono.Unix;
 using Mono.Unix.Native;
 using Xunit;
@@ -331,7 +332,8 @@ namespace Snowflake.Data.Tests.UnitTests.Tools
 
             // assert
             var bytes = File.ReadAllBytes(filePath);
-            Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+            var bom = Encoding.UTF8.GetPreamble();
+            Assert.False(bytes.Take(bom.Length).SequenceEqual(bom), "File should not contain BOM for cross-driver interoperability");
             Assert.Equal(content, _fixture.UnixOperations.ReadAllText(filePath, _ => { }));
         }
 

--- a/Snowflake.Data/Core/Tools/UnixOperations.cs
+++ b/Snowflake.Data/Core/Tools/UnixOperations.cs
@@ -14,6 +14,7 @@ namespace Snowflake.Data.Core.Tools
     {
         public static readonly UnixOperations Instance = new UnixOperations();
         private static readonly SFLogger s_logger = SFLoggerFactory.GetLogger<UnixOperations>();
+        private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         public virtual void CreateDirectoryWithPermissions(string path, FileAccessPermissions permissions, bool logEnabled = true)
         {
@@ -167,7 +168,7 @@ namespace Snowflake.Data.Core.Tools
             using (var handle = fileInfo.Open(FileMode.Create, FileAccess.ReadWrite, FilePermissions.S_IWUSR | FilePermissions.S_IRUSR))
             {
                 validator?.Invoke(handle);
-                using (var streamWriter = new StreamWriter(handle, Encoding.UTF8))
+                using (var streamWriter = new StreamWriter(handle, Utf8NoBom))
                 {
                     streamWriter.Write(content);
                 }
@@ -195,7 +196,7 @@ namespace Snowflake.Data.Core.Tools
             using (var handle = fileInfo.Open(FileMode.Append, FileAccess.ReadWrite, (FilePermissions)permissions))
             {
                 validator?.Invoke(handle);
-                using (var streamWriter = new StreamWriter(handle, Encoding.UTF8))
+                using (var streamWriter = new StreamWriter(handle, Utf8NoBom))
                 {
                     streamWriter.Write(mainContent);
                     if (additionalContent != null)


### PR DESCRIPTION
## Summary
- Stop writing a UTF-8 BOM when persisting the token cache (and log append path) on Linux/macOS, matching Windows and other drivers so shared cache JSON stays parseable.

## Test plan
- [x] Unit test `TestWriteAllTextDoesNotEmitUtf8Bom` asserts raw bytes have no `EF BB BF` and round-trips via `ReadAllText`
- [ ] Verify on Linux/macOS that a freshly written credential cache file starts with `{`, not a BOM


Made with [Cursor](https://cursor.com)