### PR TITLE
SNOW-3913764 Don't reflect over enum members and their attributes every time query status needs to be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Changelog
 - v6.1.0
+  - Performance improvements in parsing query status for given result set.
   - NuGet package now publishes `.snupkg` symbol packages, enabling source-link debugging for consumers.
   - Bug fix: Token cache file on Linux/macOS is now written as UTF-8 without a BOM for cross-driver compatibility.
 - v6.0.0

--- a/Snowflake.Data/Core/SFStatement.cs
+++ b/Snowflake.Data/Core/SFStatement.cs
@@ -52,12 +52,15 @@ namespace Snowflake.Data.Core
 
     internal static class QueryStatusExtensions
     {
+        private static readonly Dictionary<string, QueryStatus> s_queryStatusMap = Enum.GetValues(typeof(QueryStatus))
+            .Cast<QueryStatus>()
+            .ToDictionary(v => v.GetAttribute<StringAttr>().value, v => v, StringComparer.OrdinalIgnoreCase);
+
         internal static QueryStatus GetQueryStatusByStringValue(string stringValue)
         {
-            var statuses = Enum.GetValues(typeof(QueryStatus))
-                .Cast<QueryStatus>()
-                .Where(v => v.GetAttribute<StringAttr>().value.Equals(stringValue, StringComparison.OrdinalIgnoreCase));
-            return statuses.Any() ? statuses.First() : throw new Exception("The query status returned by the server is not recognized");
+            return s_queryStatusMap.TryGetValue(stringValue, out var status)
+                ? status
+                : throw new Exception("The query status returned by the server is not recognized");
         }
 
         internal static bool IsStillRunning(QueryStatus status)


### PR DESCRIPTION
Problem

  QueryStatusExtensions.GetQueryStatusByStringValue was called on every status poll during async query execution. Each
   call invoked Enum.GetValues, allocated a cast/LINQ pipeline, and linearly searched through all enum members by
  reading their [StringAttr] attributes via reflection. That work was repeated unconditionally, even though the enum
  and its attributes are immutable.

  Solution

  Build the string-to-QueryStatus lookup once at class initialization as a static Dictionary<string, QueryStatus> and
  replace the LINQ search with a single TryGetValue call.

  Changes

  - Snowflake.Data/Core/SFStatement.cs – added static s_queryStatusMap populated from Enum.GetValues at startup;
  replaced per-call LINQ + reflection in GetQueryStatusByStringValue with a O(1) dictionary lookup

  Test plan

  - Existing unit tests for QueryStatusExtensions.GetQueryStatusByStringValue continue to pass
  - Async query polling integration tests pass

  🤖 Pull Request description generated with https://claude.com/claude-code

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`)
- [x] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
