### PR TITLE
SNOW-3977560 Fix TIMESTAMP_TZ sub-hour offset truncation in JSON result format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - NuGet package now publishes `.snupkg` symbol packages, enabling source-link debugging for consumers.
   - Added configurable timeouts for chunk download stream reads. `SF_CHUNK_DOWNLOAD_IDLE_TIMEOUT` (default 180s) detects stalled connections between reads; `SF_CHUNK_DOWNLOAD_READ_TIMEOUT` (default disabled) sets a per-read deadline. Both are configured in seconds; set to `0` to disable.
   - Bug fix: Token cache file on Linux/macOS is now written as UTF-8 without a BOM for cross-driver compatibility.
+  - Bug fix: Fixed TIMESTAMP_TZ sub-hour timezone offsets (e.g. +05:30) being truncated to whole hours in JSON result format.
 - v6.0.0
   -  Added `CancellationToken` support to chunk download and parsing pipeline. Query result fetching now respects cancellation during both JSON and Arrow chunk parsing.
   -  Upgraded `AWSSDK.S3` dependency. Now getting object header invokes HEAD s3 call instead of GET.

--- a/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/ArrowResultChunkTest.cs
@@ -537,6 +537,8 @@ namespace Snowflake.Data.Tests.UnitTests
                 DateTimeOffset.Parse("2019-01-01 12:12:12.1234567 -0500"),
                 DateTimeOffset.Parse("2019-01-01 12:12:12.1234567 +1400"),
                 DateTimeOffset.Parse("2019-01-01 12:12:12.1234567 -1400"),
+                DateTimeOffset.Parse("2019-01-01 12:12:12.1234567 +0530"), // SNOW-3977560 sub-hour offset
+                DateTimeOffset.Parse("2019-01-01 12:12:12.1234567 -0330"),
                 DateTimeOffset.Parse("0001-01-01 00:00:00.0000000 +0000"),
                 DateTimeOffset.Parse("9999-12-31 23:59:59.9999999 +0000"),
             };

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -334,6 +334,13 @@ namespace Snowflake.Data.Tests.UnitTests
             return (tickDiff / 10000000.0m).ToString(CultureInfo.InvariantCulture);
         }
 
+        private string DateTimeToTzWireFormat(DateTime utcDateTime, int offsetMinutes)
+        {
+            // TIMESTAMP_TZ wire format: "<seconds since epoch, in UTC> <offsetMinutes + 1440>"
+            var seconds = DateTimeToLtzWireFormat(utcDateTime);
+            return $"{seconds} {offsetMinutes + 1440}";
+        }
+
         [SFFact]
         public void TestConvertTimestampLtzToDateTimeOffsetWithLocalTimezone()
         {
@@ -400,6 +407,28 @@ namespace Snowflake.Data.Tests.UnitTests
 
             Assert.Equal(TimeSpan.Zero, result.Offset);
             Assert.Equal(utcDateTime, result.UtcDateTime);
+        }
+
+        [SFTheory]
+        [InlineData(330)]   // +05:30 India / Sri Lanka
+        [InlineData(-210)]  // -03:30 Newfoundland
+        [InlineData(345)]   // +05:45 Nepal
+        [InlineData(765)]   // +12:45 Chatham
+        [InlineData(60)]    // +01:00 whole-hour sanity
+        [InlineData(0)]     // UTC
+        public void TestConvertTimestampTzToDateTimeOffsetPreservesSubHourOffset(int offsetMinutes)
+        {
+            // SNOW-3977560: sub-hour offsets must not be truncated to whole hours.
+            var utcDateTime = new DateTime(2028, 2, 29, 6, 30, 0, DateTimeKind.Utc);
+            var wireValue = DateTimeToTzWireFormat(utcDateTime, offsetMinutes);
+
+            var result = (DateTimeOffset)SFDataConverter.ConvertToCSharpVal(
+                ConvertToUTF8Buffer(wireValue), GetCtx(SFDataType.TIMESTAMP_TZ, typeof(DateTimeOffset)));
+
+            var expectedOffset = TimeSpan.FromMinutes(offsetMinutes);
+            Assert.Equal(expectedOffset, result.Offset);
+            Assert.Equal(utcDateTime, result.UtcDateTime);
+            Assert.Equal(utcDateTime + expectedOffset, result.DateTime);
         }
 
         [SFTheory]

--- a/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
+++ b/Snowflake.Data.Tests/UnitTests/SFDataConverterTest.cs
@@ -334,13 +334,6 @@ namespace Snowflake.Data.Tests.UnitTests
             return (tickDiff / 10000000.0m).ToString(CultureInfo.InvariantCulture);
         }
 
-        private string DateTimeToTzWireFormat(DateTime utcDateTime, int offsetMinutes)
-        {
-            // TIMESTAMP_TZ wire format: "<seconds since epoch, in UTC> <offsetMinutes + 1440>"
-            var seconds = DateTimeToLtzWireFormat(utcDateTime);
-            return $"{seconds} {offsetMinutes + 1440}";
-        }
-
         [SFFact]
         public void TestConvertTimestampLtzToDateTimeOffsetWithLocalTimezone()
         {
@@ -420,7 +413,8 @@ namespace Snowflake.Data.Tests.UnitTests
         {
             // SNOW-3977560: sub-hour offsets must not be truncated to whole hours.
             var utcDateTime = new DateTime(2028, 2, 29, 6, 30, 0, DateTimeKind.Utc);
-            var wireValue = DateTimeToTzWireFormat(utcDateTime, offsetMinutes);
+            // TIMESTAMP_TZ wire format: "<seconds since epoch, in UTC> <offsetMinutes + 1440>"
+            var wireValue = $"{DateTimeToLtzWireFormat(utcDateTime)} {offsetMinutes + 1440}";
 
             var result = (DateTimeOffset)SFDataConverter.ConvertToCSharpVal(
                 ConvertToUTF8Buffer(wireValue), GetCtx(SFDataType.TIMESTAMP_TZ, typeof(DateTimeOffset)));

--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -217,7 +217,8 @@ namespace Snowflake.Data.Core
                         spaceIndex -= srcVal.offset;
                         UTF8Buffer timeVal = new UTF8Buffer(srcVal.Buffer, srcVal.offset, spaceIndex);
                         int offset = FastParser.FastParseInt32(srcVal.Buffer, srcVal.offset + spaceIndex + 1, srcVal.length - spaceIndex - 1);
-                        TimeSpan offSetTimespan = new TimeSpan((offset - 1440) / 60, 0, 0);
+                        // offset is minutes biased by +1440; FromMinutes keeps sub-hour offsets (e.g. +05:30). SNOW-3977560
+                        TimeSpan offSetTimespan = TimeSpan.FromMinutes(offset - 1440);
                         return new DateTimeOffset(UnixEpoch.Ticks + GetTicksFromSecondAndNanosecond(timeVal), TimeSpan.Zero).ToOffset(offSetTimespan);
                     }
                 case SFDataType.TIMESTAMP_LTZ:


### PR DESCRIPTION
This is for https://github.com/snowflakedb/snowflake-connector-net/issues/1428

### Description

**Problem:** In the JSON result format, `ConvertToDateTimeOffset` in `SFDataConverter.cs` built the TIMESTAMP_TZ timezone offset with integer whole-hour division (`new TimeSpan((offset - 1440) / 60, 0, 0)`), discarding the sub-hour minutes, so offsets that are not a whole number of hours — `+05:30`, `-03:30`, `+05:45`, `+12:45` — were truncated to the whole hour.

**Impact:** The returned `DateTimeOffset` kept the correct UTC instant (`.UtcDateTime`) but had a wrong `.Offset`, `.DateTime`, and `.LocalDateTime`; for example a value that should be `2028-02-29 12:00:00 +05:30` came back as `2028-02-29 11:30:00 +05:00`. Only the JSON path was affected — Arrow was already correct — so the corruption showed up intermittently depending on which result format the server returned.

**Fix:** Use `TimeSpan.FromMinutes(offset - 1440)`, which preserves the full-minute offset and matches the Arrow decode, array-bind decode, and C#-to-wire encode paths in this same driver that were already correct.

**Test:** Added the JSON-path theory `TestConvertTimestampTzToDateTimeOffsetPreservesSubHourOffset` covering `+05:30`, `-03:30`, `+05:45`, `+12:45`, `+01:00`, and UTC and asserting `.Offset`, `.UtcDateTime`, and `.DateTime` — it fails on the four sub-hour cases with the old code and passes after the fix; also extended the existing Arrow test with `+05:30`/`-03:30` for symmetry. Full unit-test suite: 1287 passed, 6 skipped, 0 failed.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted according to [Coding Conventions](../blob/master/CodingConventions.md)
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`dotnet test`) — full unit-test suite green (integration tests require a live account)
- [ ] Extended the README / documentation, if necessary
- [x] Provide JIRA issue id (if possible) or GitHub issue id in PR name
